### PR TITLE
Working horizontal and vertical regridder.

### DIFF
--- a/backend/regrid.py
+++ b/backend/regrid.py
@@ -1,16 +1,31 @@
-import numpy as np
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+import six
+
+from glob import glob
+import os
 
 import iris
 import iris.coords
 import iris.coord_systems
 import iris.cube
 import iris.fileformats.pp
+import numpy as np
+import stratify
 
 
-def _create_1x1():
-    cs = iris.coord_systems.GeogCS(iris.fileformats.pp.EARTH_RADIUS) 
+# Supported horizontal regridding schemes.
+_schemes = dict(linear=iris.analysis.Linear(),
+                nearest=iris.analysis.Nearest(),
+                areaweighted=iris.analysis.AreaWeighted(),
+                unstructurednearest=iris.analysis.UnstructuredNearest())
 
-    ydata = np.linspace(-89.5, 89.5, 180) 
+
+def _stock_1x1():
+    """Generate a 1 degree by 1 degree global stock cube."""
+    cs = iris.coord_systems.GeogCS(iris.fileformats.pp.EARTH_RADIUS)
+
+    ydata = np.linspace(-89.5, 89.5, 180)
     lats = iris.coords.DimCoord(ydata,
                                 standard_name='latitude',
                                 units='degrees_north',
@@ -24,42 +39,111 @@ def _create_1x1():
 
     shape = (ydata.size, xdata.size)
     coords = [(lats, 0), (lons, 1)]
-    target_1x1 = iris.cube.Cube(np.zeros(shape),
-                                dim_coords_and_dims=coords)
+    cube = iris.cube.Cube(np.zeros(shape),
+                          dim_coords_and_dims=coords)
+    return cube
 
 
-def regrid(source_cube, target_grid, scheme):
+# Cache a stock of standard horizontal target grids.
+# XXX: This is only for horizontal grids at the moment
+#      we need to extend this concept to include standard
+#      vertical pressure levels (perhaps).
+_cache = {'1x1': _stock_1x1()}
 
+
+def _vinterp(src_cube, tgt_grid):
+    # Default to no interpolation and pass-thru the original source cube.
+    result = src_cube
+
+    # Get the target grid pressure coordinate, if available.
+    tgt_plev = tgt_grid.coords('air_pressure')
+
+    if tgt_plev:
+        # Unpack the target pressure coordinate.
+        tgt_plev, = tgt_plev
+        tgt_plev_shape = tgt_plev.shape
+        tgt_plev_units = tgt_plev.units
+
+        # Get the source cube pressure coordinate, if available.
+        src_plev = src_cube.coords('air_pressure')
+
+        if src_plev:
+            # Unpack the source pressure coordinate.
+            src_plev, = src_plev
+            # Get the source cube pressure coordinate points.
+            src_plev_points = src_plev.points
+
+            # Perform unit conversion if necessary, but CMOR checking
+            # should have caught this hopefully!
+            if src_plev.units != tgt_plev_units:
+                src_plev_points = src_plev.units.convert(src_plev_points,
+                                                         tgt_plev_units)
+
+            if src_plev.shape == tgt_plev_shape and \
+               np.allclose(src_plev_points, tgt_plev.points):
+                # Don't perform vertical interpolation if the target and
+                # source pressure coordinates are "similar" enough.
+                return result
+
+            # Determine the source axis for vertical interpolation.
+            z_axis, = src_cube.coord_dims(src_plev)
+            x_axis, = src_cube.coord_dims(src_cube.coord(axis='x'))
+            y_axis, = src_cube.coord_dims(src_cube.coord(axis='y'))
+
+            # Broadcast the 1d source pressure coordinate to fully describe
+            # the spatial extent that will be interpolated.
+            axes = (z_axis, y_axis, x_axis)
+            min_axis, max_axis = min(axes), max(axes)
+            reshape = [1] * (max_axis - min_axis + 1)
+            broadcast_shape = [None] * len(reshape)
+            for i in range(min_axis, max_axis+1):
+                offset, N = i - min_axis, src_cube.shape[i]
+                if i == z_axis:
+                    reshape[offset] = N
+                broadcast_shape[offset] = N
+
+            src_plev_reshape = src_plev_points.reshape(reshape)
+            src_plev_broadcast = np.broadcast_to(src_plev_reshape,
+                                                 broadcast_shape)
+
+            # Now perform the actual vertical interpolation.
+            new_data = stratify.interpolate(tgt_plev.points,
+                                            src_plev_broadcast,
+                                            src_cube.data,
+                                            axis=z_axis)
+
+            result = tgt_grid.copy(data=new_data)
+
+    return result
+
+
+def regrid(src_cube, tgt_grid, scheme):
     if scheme is None:
-        if target_grid is not None:
-            raise Exception('target grid must be none if no scheme is given')
-        return source_cube
+        if tgt_grid is not None:
+            emsg = 'Target grid must be None if no scheme is given.'
+            raise ValueError(emsg)
+        return src_cube
 
-    if target_grid is None:
-        raise Exception('target grid must not be none')
-    elif target_grid == '1x1':
-        # XXX: Ideally, it would be better to create and cache this once,
-        # and re-use it multiple times, rather than re-create it everytime.
-        target_grid = _create_1x1()
-    elif not isinstance(target_cube, iris.cube.Cube):
+    if isinstance(scheme, six.string_types):
+        scheme = scheme.lower()
+
+    if _scheme.get(scheme) is None:
+        emsg = 'Unknown regridding scheme, got {!r}.'
+        raise ValueError(emsg.format(scheme))
+
+    if tgt_grid is None:
+        raise ValueError('Target grid must not be None.')
+    elif tgt_grid == '1x1':
+        tgt_grid = _cache[tgt_grid]
+    elif not isinstance(tgt_grid, iris.cube.Cube):
         emsg = 'Expecting a {!r} instance or "1x1", got {!r}.'
         raise ValueError(emsg.format(iris.cube.Cube.__name__,
-                                     type(target_cube)))
-        
-    schemes = dict(Linear=iris.analysis.Linear(),
-                    Nearest=iris.analysis.Nearest(),
-                    AreaWeighted=iris.analysis.AreaWeighted()
-                   )
+                                     type(tgt_grid)))
 
-    #horizontal regridding
-    result_cube = source_cube.regrid(target_grid, schemes[scheme])
+    # Perform horizontal regridding.
+    cube = src_cube.regrid(tgt_grid, _schemes[scheme])
 
-    #vertical regridding (if needed)
-
-    print 'source', source_cube
-    print 'target',target_grid_cube
-    print 'scheme',scheme
-    print 'result',result_cube
-    print 'done!'
+    # Perform vertical regridding.
+    result_cube = _vinterp(cube, tgt_cube)
 
     return result_cube


### PR DESCRIPTION
This is a working horizontal and vertical regridder. I need to push some tests, but that'll come later.

Its worth banking this change for all to see.

Note that, we need python-stratify to be pushed to the conda-forge or scitools channels and added to the ESMValTool environment.

I've added the `UnstructuredNearest` horizontal regridding scheme and that means we require to depend on `iris>=1.12`

We may want to separate the vertical interpolation from the horizontal regridding. But that will come out of future discussions regarding the structure and design of the backend preprocessing - which at the moment is in a state of flux.