### PR TITLE
More general selection of model names in python diagnostics script

### DIFF
--- a/diag_scripts/sst_ESACCI.py
+++ b/diag_scripts/sst_ESACCI.py
@@ -76,16 +76,16 @@ def main(project_info):
     
             # only models are read
             for inc in range(len(project_info['MODELS'])):
-                
                 model=project_info['MODELS'][inc]
-                currProject = getattr(vars()['projects'], model.split_entries()[0])()
+                currProject = getattr(vars()['projects'],\
+                                      model.split_entries()[0])()
                 model_name = currProject.get_model_name(model)
 
-                
                 # only for non-reference models
-                if not model_name == project_info['RUNTIME']['currDiag'].variables[v].ref_model:
+                refference_model = project_info['RUNTIME']['currDiag'].variables[v].ref_model
+                if not model_name == refference_model:
                 
-                    model_filename=model_filelist[model_name]
+                    model_filename = model_filelist[model_name]
                     reference_filename=model_filelist[project_info['RUNTIME']['currDiag'].variables[v].ref_model]
                 
                     # copy old data to provide data that is needed again                                                                                                                                                           # copy old data to provide data that is needed again

--- a/diag_scripts/sst_ESACCI.py
+++ b/diag_scripts/sst_ESACCI.py
@@ -82,10 +82,8 @@ def main(project_info):
                 model_name = currProject.get_model_name(model)
 
                 # only for non-reference models
-                refference_model = project_info['RUNTIME']\
-                                               ['currDiag'].\
-                                               variables[v].\
-                                               ref_model
+                current_diagnostic = project_info['RUNTIME']['currDiag']
+                refference_model = current_diagnostic.variables[v].ref_model
                 if not model_name == refference_model:
                 
                     model_filename = model_filelist[model_name]

--- a/diag_scripts/sst_ESACCI.py
+++ b/diag_scripts/sst_ESACCI.py
@@ -77,7 +77,7 @@ def main(project_info):
             # only models are read
             for inc in range(len(project_info['MODELS'])):
                 model=project_info['MODELS'][inc]
-                currProject = getattr(vars()['projects'],\
+                currProject = getattr(vars()['projects'],
                                       model.split_entries()[0])()
                 model_name = currProject.get_model_name(model)
 
@@ -86,7 +86,7 @@ def main(project_info):
                 if not model_name == refference_model:
                 
                     model_filename = model_filelist[model_name]
-                    reference_filename=model_filelist[project_info['RUNTIME']['currDiag'].variables[v].ref_model]
+                    reference_filename=model_filelist[refference_model]
                 
                     # copy old data to provide data that is needed again                                                                                                                                                           # copy old data to provide data that is needed again
                     D_old=copy(Diag)

--- a/diag_scripts/sst_ESACCI.py
+++ b/diag_scripts/sst_ESACCI.py
@@ -82,11 +82,14 @@ def main(project_info):
                 model_name = currProject.get_model_name(model)
 
                 # only for non-reference models
-                refference_model = project_info['RUNTIME']['currDiag'].variables[v].ref_model
+                refference_model = project_info['RUNTIME']\
+                                               ['currDiag'].\
+                                               variables[v].\
+                                               ref_model
                 if not model_name == refference_model:
                 
                     model_filename = model_filelist[model_name]
-                    reference_filename=model_filelist[refference_model]
+                    reference_filename = model_filelist[refference_model]
                 
                     # copy old data to provide data that is needed again                                                                                                                                                           # copy old data to provide data that is needed again
                     D_old=copy(Diag)

--- a/diag_scripts/sst_ESACCI.py
+++ b/diag_scripts/sst_ESACCI.py
@@ -42,6 +42,7 @@ from esmval_lib import ESMValProject
 from sst_diagnostic import SeaSurfaceTemperatureDiagnostic
 
 def main(project_info):
+    import projects
     print(">>>>>>>> sst_ESACCI.py is running! <<<<<<<<<<<<")
 
 # A_laue_ax+
@@ -77,11 +78,14 @@ def main(project_info):
             for inc in range(len(project_info['MODELS'])):
                 
                 model=project_info['MODELS'][inc]
+                currProject = getattr(vars()['projects'], model.split_entries()[0])()
+                model_name = currProject.get_model_name(model)
+
                 
                 # only for non-reference models
-                if not model.model_line.split()[1] == project_info['RUNTIME']['currDiag'].variables[v].ref_model:
+                if not model_name == project_info['RUNTIME']['currDiag'].variables[v].ref_model:
                 
-                    model_filename=model_filelist[model.model_line.split()[1]]
+                    model_filename=model_filelist[model_name]
                     reference_filename=model_filelist[project_info['RUNTIME']['currDiag'].variables[v].ref_model]
                 
                     # copy old data to provide data that is needed again                                                                                                                                                           # copy old data to provide data that is needed again


### PR DESCRIPTION
At present the model name is selected by simply splitting the `model` string and selecting the first element. This is a good assumption if we assume that the `argument 1` in the Project is always model name. It might not be the case, and it is better to get the model name taking in to account Project definition as, for example, is done in [main.py](https://github.com/ESMValGroup/ESMValTool/blob/799150e4784f334262755a39022c72b2d39585c9/main.py#L155)

Proposed change is basically copy-paste from the `main.py`. Several other python diagnostics can be changed in the same way if developers decide it's a good idea.

