### PR TITLE
More informative python error message

### DIFF
--- a/interface_scripts/launchers.py
+++ b/interface_scripts/launchers.py
@@ -7,6 +7,7 @@ import sys
 import string
 import StringIO
 import contextlib
+import traceback
 
 @contextlib.contextmanager
 def stdoutIO(std_outerr=None):
@@ -310,7 +311,8 @@ class py_launcher(launchers):
         try:
             exec cmd
         except:
-            print cmd
+            print(cmd)
+	    print(traceback.format_exc())
             raise ValueError('The script %s can not be imported!' % python_executable)
 
         # import was successfull. Now call the script with project_info

--- a/interface_scripts/launchers.py
+++ b/interface_scripts/launchers.py
@@ -312,7 +312,7 @@ class py_launcher(launchers):
             exec cmd
         except:
             print(cmd)
-	    print(traceback.format_exc())
+            print(traceback.format_exc())
             raise ValueError('The script %s can not be imported!' % python_executable)
 
         # import was successfull. Now call the script with project_info


### PR DESCRIPTION
The reasons for this PR described in #45 . In short - it is easier to debug when the stack trace is printed out.