### PR TITLE
Refactoring regrid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.py[co]
+
+# Created by editiors
+*~
+\#*
+\.\#*
+*.swp

--- a/backend/regrid.py
+++ b/backend/regrid.py
@@ -92,16 +92,13 @@ def _stock_cube(spec):
 
     mid_dx, mid_dy = dx / 2, dy / 2
 
-    cs = iris.coord_systems.GeogCS(iris.fileformats.pp.EARTH_RADIUS)
-
     # Construct the latitude coordinate, with bounds.
     ydata = np.linspace(_LAT_MIN + mid_dy,
                         _LAT_MAX - mid_dy,
                         _LAT_RANGE / dy)
     lats = iris.coords.DimCoord(ydata,
                                 standard_name='latitude',
-                                units='degrees_north',
-                                coord_system=cs)
+                                units='degrees_north')
     lats.guess_bounds()
 
     # Construct the longitude coordinate, with bounds.
@@ -110,8 +107,7 @@ def _stock_cube(spec):
                         _LON_RANGE / dx)
     lons = iris.coords.DimCoord(xdata,
                                 standard_name='longitude',
-                                units='degrees_east',
-                                coord_system=cs)
+                                units='degrees_east')
     lons.guess_bounds()
 
     # Construct the resultant stock cube, with dummy data.
@@ -168,6 +164,13 @@ def regrid(src_cube, tgt_grid, scheme):
         # Generate a target grid from the provided cell-specification,
         # and cache the resulting stock cube for later use.
         tgt_grid = _cache.setdefault(tgt_grid, _stock_cube(tgt_grid))
+        # Align the target grid coordinate system to the source
+        # coordinate system.
+        src_cs = src_cube.coord_system()
+        xcoord = tgt_grid.coord(axis='x', dim_coords=True)
+        ycoord = tgt_grid.coord(axis='y', dim_coords=True)
+        xcoord.coord_system = src_cs
+        ycoord.coord_system = src_cs
     elif not isinstance(tgt_grid, iris.cube.Cube):
         emsg = 'Expecting a cube or cell-specification, got {}.'
         raise ValueError(emsg.format(type(tgt_grid)))

--- a/backend/regrid.py
+++ b/backend/regrid.py
@@ -6,7 +6,7 @@ or vertical level interpolation.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
-import six
+import six  # noqa
 
 from copy import deepcopy
 from glob import glob

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -6,3 +6,76 @@ Provides testing capabilities for :mod:`esmvaltool.backend` package.
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 import six
+
+from functools import wraps
+
+import mock
+import numpy as np
+import unittest
+
+
+class Test(unittest.TestCase):
+    """
+    Provides esmvaltool specific testing functionality.
+
+    """
+    def _remove_testcase_patches(self):
+        """
+        Helper method to remove per-testcase patches installed by
+        :meth:`patch`.
+
+        """
+        # Remove all patches made, ignoring errors.
+        for patch in self.testcase_patches:
+            patch.stop()
+
+        # Reset per-test patch control variable.
+        self.testcase_patches.clear()
+
+    def patch(self, *args, **kwargs):
+        """
+        Install a patch to be removed automatically after the current test.
+
+        The patch is created with :func:`mock.patch`.
+
+        Parameters
+        ----------
+        args : list
+            The parameters to be passed to :func:`mock.patch`.
+        kwargs : dict
+            The keyword parameters to be passed to :func:`mock.patch`.
+
+        Returns
+        -------
+            The substitute mock instance returned by :func:`patch.start`.
+
+        """
+        # Make the new patch and start it.
+        patch = mock.patch(*args, **kwargs)
+        start_result = patch.start()
+
+        # Create the per-testcases control variable if it does not exist.
+        # NOTE: this mimics a setUp method, but continues to work when a
+        # subclass defines its own setUp.
+        if not hasattr(self, 'testcase_patches'):
+            self.testcase_patches = {}
+
+        # When installing the first patch, schedule remove-all at cleanup.
+        if not self.testcase_patches:
+            self.addCleanup(self._remove_testcase_patches)
+
+        # Record the new patch and start object for reference.
+        self.testcase_patches[patch] = start_result
+
+        # Return patch replacement object.
+        return start_result
+
+    @wraps(np.testing.assert_array_equal)
+    def assertArrayEqual(self, a, b, err_msg='', verbose=True):
+        np.testing.assert_array_equal(a, b, err_msg=err_msg, verbose=verbose)
+
+    @wraps(np.testing.assert_array_almost_equal)
+    def assertArrayAlmostEqual(self, a, b, decimal=6, err_msg='',
+                               verbose=True):
+        np.testing.assert_array_almost_equal(a, b, decimal=decimal,
+                                             err_msg=err_msg, verbose=verbose)

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -5,7 +5,7 @@ Provides testing capabilities for :mod:`esmvaltool.backend` package.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
-import six
+import six  # noqa
 
 from functools import wraps
 

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,8 @@
+"""
+Provides testing capabilities for :mod:`esmvaltool.backend` package.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+import six

--- a/backend/tests/integration/__init__.py
+++ b/backend/tests/integration/__init__.py
@@ -5,4 +5,4 @@ Integration tests for the :mod:`esmvaltool.backend` package.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
-import six
+import six  # noqa

--- a/backend/tests/integration/__init__.py
+++ b/backend/tests/integration/__init__.py
@@ -1,0 +1,8 @@
+"""
+Integration tests for the :mod:`esmvaltool.backend` package.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+import six

--- a/backend/tests/integration/regrid/__init__.py
+++ b/backend/tests/integration/regrid/__init__.py
@@ -1,0 +1,8 @@
+"""
+Integration tests for the :mod:`esmvaltool.backend.regrid` package.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+import six

--- a/backend/tests/integration/regrid/__init__.py
+++ b/backend/tests/integration/regrid/__init__.py
@@ -5,4 +5,4 @@ Integration tests for the :mod:`esmvaltool.backend.regrid` package.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
-import six
+import six  # noqa

--- a/backend/tests/integration/regrid/test_vinterp.py
+++ b/backend/tests/integration/regrid/test_vinterp.py
@@ -1,0 +1,106 @@
+"""
+Integration tests for the :func:`esmvaltool.backend.regrid.vinterp` function.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+import six
+
+import iris
+import numpy as np
+import unittest
+
+import backend.tests as tests
+from backend.tests.unit.regrid import _make_vcoord, _make_cube
+from backend.regrid import _MDI, vinterp
+
+
+class Test(tests.Test):
+    def setUp(self):
+        shape = (3, 2, 2)
+        self.z = shape[0]
+        data = np.arange(np.prod(shape)).reshape(shape)
+        cubes = iris.cube.CubeList()
+        # Create first realization cube.
+        cube = _make_cube(data)
+        coord = iris.coords.DimCoord(0, standard_name='realization')
+        cube.add_aux_coord(coord)
+        cubes.append(cube)
+        # Create second realization cube.
+        cube = _make_cube(data + np.prod(shape))
+        coord = iris.coords.DimCoord(1, standard_name='realization')
+        cube.add_aux_coord(coord)
+        cubes.append(cube)
+        # Create a 4d synthetic test cube.
+        self.cube = cubes.merge_cube()
+        coord = self.cube.coord(axis='z', dim_coords=True)
+        self.shape = list(self.cube.shape)
+        [self.z_dim] = self.cube.coord_dims(coord)
+
+    def test_nop(self):
+        result = vinterp(self.cube, None, None)
+        self.assertEqual(result, self.cube)
+        self.assertEqual(id(result), id(self.cube))
+
+    def test_nop__levels_match(self):
+        vcoord = _make_vcoord(self.z)
+        self.assertEqual(self.cube.coord(axis='z', dim_coords=True), vcoord)
+        levels = vcoord.points
+        result = vinterp(self.cube, levels, 'linear')
+        self.assertEqual(result, self.cube)
+        self.assertEqual(id(result), id(self.cube))
+
+    def test_interpolation__linear(self):
+        levels = [0.5, 1.5]
+        scheme = 'linear'
+        result = vinterp(self.cube, levels, scheme)
+        expected = np.array([[[[2., 3.], [4., 5.]],
+                              [[6., 7.], [8., 9.]]],
+                             [[[14., 15.], [16., 17.]],
+                              [[18., 19.], [20., 21.]]]])
+        self.assertArrayEqual(result.data, expected)
+        self.shape[self.z_dim] = len(levels)
+        self.assertEqual(result.shape, tuple(self.shape))
+
+    def test_interpolation__nearest(self):
+        levels = [0.49, 1.51]
+        scheme = 'nearest'
+        result = vinterp(self.cube, levels, scheme)
+        expected = np.array([[[[0., 1.], [2., 3.]],
+                              [[8., 9.], [10., 11.]]],
+                             [[[12., 13.], [14., 15.]],
+                              [[20., 21.], [22., 23.]]]])
+        self.assertArrayEqual(result.data, expected)
+        self.shape[self.z_dim] = len(levels)
+        self.assertEqual(result.shape, tuple(self.shape))
+
+    def test_interpolation__extrapolated_NaN_filling(self):
+        levels = [-10, 1, 2, 10]
+        scheme = 'nearest'
+        result = vinterp(self.cube, levels, scheme)
+        expected = np.array([[[[_MDI, _MDI], [_MDI, _MDI]],
+                              [[4., 5.], [6., 7.]],
+                              [[8., 9.], [10., 11.]],
+                              [[_MDI, _MDI], [_MDI, _MDI]]],
+                             [[[_MDI, _MDI], [_MDI, _MDI]],
+                              [[16., 17.], [18., 19.]],
+                              [[20., 21.], [22., 23.]],
+                              [[_MDI, _MDI], [_MDI, _MDI]]]])
+        self.assertArrayEqual(result.data, expected)
+        self.shape[self.z_dim] = len(levels)
+        self.assertEqual(result.shape, tuple(self.shape))
+
+    def test_interpolation__scalar_collapse(self):
+        level = 1
+        scheme = 'nearest'
+        result = vinterp(self.cube, level, scheme)
+        expected = np.array([[[4., 5.], [6., 7.]],
+                             [[16., 17.], [18., 19.]]])
+        self.assertArrayEqual(result.data, expected)
+        del self.shape[self.z_dim]
+        self.assertEqual(result.shape, tuple(self.shape))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/integration/regrid/test_vinterp.py
+++ b/backend/tests/integration/regrid/test_vinterp.py
@@ -5,7 +5,7 @@ Integration tests for the :func:`esmvaltool.backend.regrid.vinterp` function.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
-import six
+import six  # noqa
 
 import iris
 import numpy as np

--- a/backend/tests/unit/__init__.py
+++ b/backend/tests/unit/__init__.py
@@ -1,0 +1,8 @@
+"""
+Unit tests for the :mod:`esmvaltool.backend` package.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+import six

--- a/backend/tests/unit/__init__.py
+++ b/backend/tests/unit/__init__.py
@@ -5,4 +5,4 @@ Unit tests for the :mod:`esmvaltool.backend` package.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
-import six
+import six  # noqa

--- a/backend/tests/unit/regrid/__init__.py
+++ b/backend/tests/unit/regrid/__init__.py
@@ -1,0 +1,8 @@
+"""
+Unit tests for the :mod:`esmvaltool.backend.regrid` package.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+import six

--- a/backend/tests/unit/regrid/__init__.py
+++ b/backend/tests/unit/regrid/__init__.py
@@ -6,3 +6,99 @@ Unit tests for the :mod:`esmvaltool.backend.regrid` package.
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 import six
+
+import iris
+from iris.coords import AuxCoord, CellMethod, DimCoord
+import mock
+import numpy as np
+
+
+def _make_vcoord(data, dtype=None):
+    """
+    Create a synthetic test vertical coordinate.
+
+    """
+    if dtype is None:
+        dtype = np.dtype('int8')
+
+    if isinstance(data, int):
+        data = np.arange(data, dtype=dtype)
+    elif not isinstance(data, np.ndarray):
+        data = np.asarray(data, dtype=dtype)
+
+    # Create a pressure vertical coordinate.
+    kwargs = dict(standard_name='air_pressure',
+                  long_name='Pressure',
+                  var_name='plev', units='hPa',
+                  attributes=dict(positive='down'),
+                  coord_system=None)
+
+    try:
+        zcoord = DimCoord(data, **kwargs)
+    except ValueError:
+        zcoord = AuxCoord(data, **kwargs)
+
+    return zcoord
+
+
+def _make_cube(data, aux_coord=True, dim_coord=True, dtype=None):
+    """
+    Create a 3d synthetic test cube.
+
+    """
+    if dtype is None:
+        dtype = np.dtype('int8')
+
+    if not isinstance(data, np.ndarray):
+        data = np.empty(data, dtype=dtype)
+
+    z, y, x = data.shape
+
+    # Create the cube.
+    cm = CellMethod(method='mean', coords='time', intervals='20 minutes',
+                    comments=None)
+    kwargs = dict(standard_name='air_temperature',
+                  long_name='Air Temperature',
+                  var_name='ta', units='K',
+                  attributes=dict(cube='attribute'),
+                  cell_methods=(cm,))
+    cube = iris.cube.Cube(data, **kwargs)
+
+    # Create a synthetic test vertical coordinate.
+    if dim_coord:
+        cube.add_dim_coord(_make_vcoord(z, dtype=dtype), 0)
+
+    # Create a synthetic test latitude coordinate.
+    data = np.arange(y, dtype=dtype)
+    cs = iris.coord_systems.GeogCS(123)
+    kwargs = dict(standard_name='latitude',
+                  long_name='Latitude',
+                  var_name='lat', units='degrees_north',
+                  attributes=dict(latitude='attribute'),
+                  coord_system=cs)
+    ycoord = DimCoord(data, **kwargs)
+    cube.add_dim_coord(ycoord, 1)
+
+    # Create a synthetic test longitude coordinate.
+    data = np.arange(x, dtype=dtype)
+    kwargs = dict(standard_name='longitude',
+                  long_name='Longitude',
+                  var_name='lon', units='degrees_east',
+                  attributes=dict(longitude='attribute'),
+                  coord_system=cs)
+    xcoord = DimCoord(data, **kwargs)
+    cube.add_dim_coord(xcoord, 2)
+
+    # Create a synthetic test 2d auxiliary coordinate
+    # that spans the vertical dimension.
+    if aux_coord:
+        data = np.arange(np.prod((z, y)), dtype=dtype).reshape(z, y)
+        kwargs = dict(standard_name=None,
+                      long_name='Pressure Slice',
+                      var_name='aplev', units='hPa',
+                      attributes=dict(positive='down'),
+                      coord_system=None)
+        zycoord = AuxCoord(data, **kwargs)
+        cube.add_aux_coord(zycoord, (0, 1))
+
+    return cube

--- a/backend/tests/unit/regrid/__init__.py
+++ b/backend/tests/unit/regrid/__init__.py
@@ -5,11 +5,10 @@ Unit tests for the :mod:`esmvaltool.backend.regrid` package.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
-import six
+import six  # noqa
 
 import iris
 from iris.coords import AuxCoord, CellMethod, DimCoord
-import mock
 import numpy as np
 
 

--- a/backend/tests/unit/regrid/test__create_cube.py
+++ b/backend/tests/unit/regrid/test__create_cube.py
@@ -6,3 +6,58 @@ Unit tests for the :func:`esmvaltool.backend.regrid._create_cube` function.
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 import six
+
+import iris
+import numpy as np
+import unittest
+
+import backend.tests as tests
+from backend.tests.unit.regrid import _make_vcoord, _make_cube
+from backend.regrid import _create_cube as create_cube
+
+
+class Test(tests.Test):
+    def setUp(self):
+        shape = (3, 2, 1)
+        self.dtype = np.dtype('int8')
+        self.cube = _make_cube(shape, dtype=self.dtype)
+
+    def test_invalid_shape__data_mismatch_with_levels(self):
+        levels = np.array([0, 1])
+        emsg = 'Mismatch between data and levels'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            create_cube(self.cube, self.cube.data, levels)
+
+    def test(self):
+        shape = (2, 2, 1)
+        data = np.empty(shape)
+        levels = np.array([10, 20])
+        result = create_cube(self.cube, data, levels)
+        expected = _make_cube(data, aux_coord=False, dim_coord=False)
+        vcoord = _make_vcoord(levels)
+        expected.add_dim_coord(vcoord, 0)
+        self.assertEqual(result, expected)
+
+    def test_non_monotonic(self):
+        shape = (2, 2, 1)
+        data = np.empty(shape)
+        levels = np.array([10, 10])
+        result = create_cube(self.cube, data, levels)
+        expected = _make_cube(data, aux_coord=False, dim_coord=False)
+        vcoord = _make_vcoord(levels)
+        expected.add_aux_coord(vcoord, 0)
+        self.assertEqual(result, expected)
+
+    def test_collapse(self):
+        shape = (1, 2, 1)
+        data = np.empty(shape)
+        levels = np.array([123])
+        result = create_cube(self.cube, data, levels)
+        expected = _make_cube(data, aux_coord=False, dim_coord=False)[0]
+        vcoord = _make_vcoord(levels)
+        expected.add_aux_coord(vcoord)
+        self.assertEqual(result, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/unit/regrid/test__create_cube.py
+++ b/backend/tests/unit/regrid/test__create_cube.py
@@ -5,9 +5,8 @@ Unit tests for the :func:`esmvaltool.backend.regrid._create_cube` function.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
-import six
+import six  # noqa
 
-import iris
 import numpy as np
 import unittest
 

--- a/backend/tests/unit/regrid/test__create_cube.py
+++ b/backend/tests/unit/regrid/test__create_cube.py
@@ -1,0 +1,8 @@
+"""
+Unit tests for the :func:`esmvaltool.backend.regrid._create_cube` function.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+import six

--- a/backend/tests/unit/regrid/test__stock_cube.py
+++ b/backend/tests/unit/regrid/test__stock_cube.py
@@ -30,10 +30,6 @@ class Test(tests.Test):
                                           _LON_MAX - mid_dx,
                                           _LON_RANGE / dx)
 
-        # Check the stock cube coordinate-system creation.
-        radius = iris.fileformats.pp.EARTH_RADIUS
-        self.mock_GeogCS.assert_called_once_with(radius)
-
         # Check the stock cube coordinates.
         self.assertEqual(self.mock_DimCoord.call_count, 2)
         call_lats, call_lons = self.mock_DimCoord.call_args_list
@@ -42,16 +38,14 @@ class Test(tests.Test):
         [args], kwargs = call_lats
         self.assertArrayEqual(args, expected_lat_points)
         expected_lat_kwargs = dict(standard_name='latitude',
-                                   units='degrees_north',
-                                   coord_system=self.GeogCS)
+                                   units='degrees_north')
         self.assertEqual(kwargs, expected_lat_kwargs)
 
         # Check the longitude coordinate creation.
         [args], kwargs = call_lons
         self.assertArrayEqual(args, expected_lon_points)
         expected_lon_kwargs = dict(standard_name='longitude',
-                                   units='degrees_east',
-                                   coord_system=self.GeogCS)
+                                   units='degrees_east')
         self.assertEqual(kwargs, expected_lon_kwargs)
 
         # Check that the coordinate guess_bounds method has been called.
@@ -76,11 +70,7 @@ class Test(tests.Test):
         self.mock_coord = mock.Mock(spec=iris.coords.DimCoord)
         self.mock_DimCoord = self.patch('iris.coords.DimCoord',
                                         return_value=self.mock_coord)
-        self.GeogCS = mock.sentinel.GeogCS
-        self.mock_GeogCS = self.patch('iris.coord_systems.GeogCS',
-                                      return_value=self.GeogCS)
-        self.mocks = [self.mock_Cube, self.mock_coord,
-                      self.mock_DimCoord, self.mock_GeogCS]
+        self.mocks = [self.mock_Cube, self.mock_coord, self.mock_DimCoord]
 
     def test_invalid_cell_spec__alpha(self):
         emsg = 'Invalid MxN cell specification'

--- a/backend/tests/unit/regrid/test__stock_cube.py
+++ b/backend/tests/unit/regrid/test__stock_cube.py
@@ -6,3 +6,109 @@ Unit tests for the :func:`esmvaltool.backend.regrid._stock_cube` function.
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 import six
+
+import iris
+import mock
+import numpy as np
+import unittest
+
+import backend.tests as tests
+from backend.regrid import (_LAT_MIN, _LAT_MAX, _LAT_RANGE,
+                            _LON_MIN, _LON_MAX, _LON_RANGE)
+from backend.regrid import _stock_cube as stock_cube
+
+
+class Test(tests.Test):
+    def _check(self, dx, dy):
+        # Generate the expected stock cube coordinate points.
+        dx, dy = float(dx), float(dy)
+        mid_dx, mid_dy = dx / 2, dy / 2
+        expected_lat_points = np.linspace(_LAT_MIN + mid_dy,
+                                          _LAT_MAX - mid_dy,
+                                          _LAT_RANGE / dy)
+        expected_lon_points = np.linspace(_LON_MIN + mid_dx,
+                                          _LON_MAX - mid_dx,
+                                          _LON_RANGE / dx)
+
+        # Check the stock cube coordinate-system creation.
+        radius = iris.fileformats.pp.EARTH_RADIUS
+        self.mock_GeogCS.assert_called_once_with(radius)
+
+        # Check the stock cube coordinates.
+        self.assertEqual(self.mock_DimCoord.call_count, 2)
+        call_lats, call_lons = self.mock_DimCoord.call_args_list
+
+        # Check the latitude coordinate creation.
+        [args], kwargs = call_lats
+        self.assertArrayEqual(args, expected_lat_points)
+        expected_lat_kwargs = dict(standard_name='latitude',
+                                   units='degrees_north',
+                                   coord_system=self.GeogCS)
+        self.assertEqual(kwargs, expected_lat_kwargs)
+
+        # Check the longitude coordinate creation.
+        [args], kwargs = call_lons
+        self.assertArrayEqual(args, expected_lon_points)
+        expected_lon_kwargs = dict(standard_name='longitude',
+                                   units='degrees_east',
+                                   coord_system=self.GeogCS)
+        self.assertEqual(kwargs, expected_lon_kwargs)
+
+        # Check that the coordinate guess_bounds method has been called.
+        expected_calls = [mock.call.guess_bounds()] * 2
+        self.assertEqual(self.mock_coord.mock_calls, expected_calls)
+
+        # Check the stock cube creation.
+        self.mock_Cube.assert_called_once()
+        _, kwargs = self.mock_Cube.call_args
+        spec = [(self.mock_coord, 0), (self.mock_coord, 1)]
+        expected_cube_kwargs = dict(dim_coords_and_dims=spec)
+        self.assertEqual(kwargs, expected_cube_kwargs)
+
+        # Reset the mocks to enable multiple calls per test-case.
+        for mocker in self.mocks:
+            mocker.reset_mock()
+
+    def setUp(self):
+        self.Cube = mock.sentinel.Cube
+        self.mock_Cube = self.patch('iris.cube.Cube',
+                                    return_value=self.Cube)
+        self.mock_coord = mock.Mock(spec=iris.coords.DimCoord)
+        self.mock_DimCoord = self.patch('iris.coords.DimCoord',
+                                        return_value=self.mock_coord)
+        self.GeogCS = mock.sentinel.GeogCS
+        self.mock_GeogCS = self.patch('iris.coord_systems.GeogCS',
+                                      return_value=self.GeogCS)
+        self.mocks = [self.mock_Cube, self.mock_coord,
+                      self.mock_DimCoord, self.mock_GeogCS]
+
+    def test_invalid_cell_spec__alpha(self):
+        emsg = 'Invalid MxN cell specification'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            stock_cube('Ax1')
+
+    def test_invalid_cell_spec__separator(self):
+        emsg = 'Invalid MxN cell specification'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            stock_cube('1y1')
+
+    def test_invalid_cell_spec__longitude(self):
+        emsg = 'Invalid longitude delta in MxN cell specification'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            stock_cube('1.2x1')
+
+    def test_invalid_cell_spec__latitude(self):
+        emsg = 'Invalid latitude delta in MxN cell specification'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            stock_cube('1x2.3')
+
+    def test_specs(self):
+        specs = ['0.5x0.5', '1x1', '2.5x2.5', '5x5', '10x10']
+        for spec in specs:
+            result = stock_cube(spec)
+            self.assertEqual(result, self.Cube)
+            self._check(*map(float, spec.split('x')))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/unit/regrid/test__stock_cube.py
+++ b/backend/tests/unit/regrid/test__stock_cube.py
@@ -5,7 +5,7 @@ Unit tests for the :func:`esmvaltool.backend.regrid._stock_cube` function.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
-import six
+import six  # noqa
 
 import iris
 import mock

--- a/backend/tests/unit/regrid/test__stock_cube.py
+++ b/backend/tests/unit/regrid/test__stock_cube.py
@@ -1,0 +1,8 @@
+"""
+Unit tests for the :func:`esmvaltool.backend.regrid._stock_cube` function.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+import six

--- a/backend/tests/unit/regrid/test_regrid.py
+++ b/backend/tests/unit/regrid/test_regrid.py
@@ -6,3 +6,89 @@ Unit tests for the :func:`esmvaltool.backend.regrid.regrid` function.
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 import six
+
+import iris
+import mock
+import unittest
+
+import backend.tests as tests
+from backend.regrid import _cache, horizontal_schemes, regrid
+
+
+class Test(tests.Test):
+    def _check(self, tgt_grid, scheme, spec=False):
+        if spec:
+            self.assertIn(tgt_grid, _cache)
+            self.assertEqual(_cache[tgt_grid], tgt_grid)
+
+        self.mock_regrid.assert_called_once_with(tgt_grid,
+                                                 horizontal_schemes[scheme])
+
+        # Reset the mocks to enable multiple calls per test-case.
+        for mocker in self.mocks:
+            mocker.reset_mock()
+
+    def setUp(self):
+        self.cube = iris.cube.Cube(0)
+        self.regrid_schemes = ['linear', 'nearest', 'area_weighted',
+                               'unstructured_nearest']
+        self.regridded_cube = mock.sentinel.regridded_cube
+        self.mock_regrid = self.patch('iris.cube.Cube.regrid',
+                                      return_value=self.regridded_cube)
+        self.mock_stock = self.patch('backend.regrid._stock_cube',
+                                     side_effect=lambda arg: arg)
+        self.mocks = [self.mock_regrid, self.mock_stock]
+
+    def test_nop(self):
+        cube = mock.sentinel.cube
+        result = regrid(cube, None, None)
+        self.assertEqual(result, cube)
+
+    def test_invalid_tgt_grid__None(self):
+        dummy = mock.sentinel.dummy
+        emsg = 'A target grid must be specified'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            regrid(dummy, None, dummy)
+
+    def test_invalid_tgt_grid__unknown(self):
+        dummy = mock.sentinel.dummy
+        scheme = 'linear'
+        emsg = 'Expecting a cube or cell-specification'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            regrid(self.cube, dummy, scheme)
+
+    def test_invalid_scheme__None(self):
+        dummy = mock.sentinel.dummy
+        emsg = 'A scheme must be specified'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            regrid(dummy, dummy, None)
+
+    def test_invalid_scheme__unknown(self):
+        dummy = mock.sentinel.dummy
+        emsg = 'Unknown regridding scheme'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            regrid(dummy, dummy, 'wibble')
+
+    def test_horizontal_schemes(self):
+        self.assertEqual(horizontal_schemes.viewkeys(),
+                         set(self.regrid_schemes))
+
+    def test_regrid__horizontal_schemes(self):
+        tgt_grid = mock.Mock(spec=iris.cube.Cube)
+        for scheme in self.regrid_schemes:
+            result = regrid(self.cube, tgt_grid, scheme)
+            self.assertEqual(result, self.regridded_cube)
+            self._check(tgt_grid, scheme)
+
+    def test_regrid__cell_specification(self):
+        specs = ['one', 'two', 'three', 'four', 'five']
+        scheme = 'linear'
+        for spec in specs:
+            result = regrid(self.cube, spec, scheme)
+            self.assertEqual(result, self.regridded_cube)
+            self._check(spec, scheme, spec=True)
+        self.assertEqual(_cache.viewkeys(), set(specs))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/unit/regrid/test_regrid.py
+++ b/backend/tests/unit/regrid/test_regrid.py
@@ -1,0 +1,8 @@
+"""
+Unit tests for the :func:`esmvaltool.backend.regrid.regrid` function.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+import six

--- a/backend/tests/unit/regrid/test_regrid.py
+++ b/backend/tests/unit/regrid/test_regrid.py
@@ -17,27 +17,39 @@ from backend.regrid import _cache, horizontal_schemes, regrid
 
 class Test(tests.Test):
     def _check(self, tgt_grid, scheme, spec=False):
-        if spec:
-            self.assertIn(tgt_grid, _cache)
-            self.assertEqual(_cache[tgt_grid], tgt_grid)
+        expected_scheme = horizontal_schemes[scheme]
 
-        self.mock_regrid.assert_called_once_with(tgt_grid,
-                                                 horizontal_schemes[scheme])
+        if spec:
+            spec = tgt_grid
+            self.assertIn(spec, _cache)
+            self.assertEqual(_cache[spec], self.tgt_grid)
+            expected_calls = [mock.call(axis='x', dim_coords=True),
+                              mock.call(axis='y', dim_coords=True)]
+            self.assertEqual(self.tgt_grid_coord.mock_calls, expected_calls)
+            self.mock_regrid.assert_called_once_with(self.tgt_grid,
+                                                     expected_scheme)
+        else:
+            self.mock_regrid.assert_called_once_with(tgt_grid,
+                                                     expected_scheme)
 
         # Reset the mocks to enable multiple calls per test-case.
         for mocker in self.mocks:
             mocker.reset_mock()
 
     def setUp(self):
-        self.cube = iris.cube.Cube(0)
+        self.src_cube = iris.cube.Cube(0)
+        self.tgt_grid_coord = mock.Mock()
+        self.tgt_grid = mock.Mock(spec=iris.cube.Cube,
+                                  coord=self.tgt_grid_coord)
         self.regrid_schemes = ['linear', 'nearest', 'area_weighted',
                                'unstructured_nearest']
         self.regridded_cube = mock.sentinel.regridded_cube
         self.mock_regrid = self.patch('iris.cube.Cube.regrid',
                                       return_value=self.regridded_cube)
         self.mock_stock = self.patch('backend.regrid._stock_cube',
-                                     side_effect=lambda arg: arg)
-        self.mocks = [self.mock_regrid, self.mock_stock]
+                                     side_effect=lambda arg: self.tgt_grid)
+        self.mocks = [self.mock_regrid, self.mock_stock,
+                      self.tgt_grid_coord, self.tgt_grid]
 
     def test_nop(self):
         cube = mock.sentinel.cube
@@ -55,7 +67,7 @@ class Test(tests.Test):
         scheme = 'linear'
         emsg = 'Expecting a cube or cell-specification'
         with self.assertRaisesRegexp(ValueError, emsg):
-            regrid(self.cube, dummy, scheme)
+            regrid(self.src_cube, dummy, scheme)
 
     def test_invalid_scheme__None(self):
         dummy = mock.sentinel.dummy
@@ -74,17 +86,16 @@ class Test(tests.Test):
                          set(self.regrid_schemes))
 
     def test_regrid__horizontal_schemes(self):
-        tgt_grid = mock.Mock(spec=iris.cube.Cube)
         for scheme in self.regrid_schemes:
-            result = regrid(self.cube, tgt_grid, scheme)
+            result = regrid(self.src_cube, self.tgt_grid, scheme)
             self.assertEqual(result, self.regridded_cube)
-            self._check(tgt_grid, scheme)
+            self._check(self.tgt_grid, scheme)
 
     def test_regrid__cell_specification(self):
-        specs = ['one', 'two', 'three', 'four', 'five']
+        specs = ['1x1', '2x2', '3x3', '4x4', '5x5']
         scheme = 'linear'
         for spec in specs:
-            result = regrid(self.cube, spec, scheme)
+            result = regrid(self.src_cube, spec, scheme)
             self.assertEqual(result, self.regridded_cube)
             self._check(spec, scheme, spec=True)
         self.assertEqual(_cache.viewkeys(), set(specs))

--- a/backend/tests/unit/regrid/test_regrid.py
+++ b/backend/tests/unit/regrid/test_regrid.py
@@ -5,7 +5,7 @@ Unit tests for the :func:`esmvaltool.backend.regrid.regrid` function.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
-import six
+import six  # noqa
 
 import iris
 import mock

--- a/backend/tests/unit/regrid/test_vinterp.py
+++ b/backend/tests/unit/regrid/test_vinterp.py
@@ -5,7 +5,7 @@ Unit tests for the :func:`esmvaltool.backend.regrid.vinterp` function.
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
-import six
+import six  # noqa
 
 import mock
 import numpy as np

--- a/backend/tests/unit/regrid/test_vinterp.py
+++ b/backend/tests/unit/regrid/test_vinterp.py
@@ -1,0 +1,8 @@
+"""
+Unit tests for the :func:`esmvaltool.backend.regrid.vinterp` function.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+import six

--- a/backend/tests/unit/regrid/test_vinterp.py
+++ b/backend/tests/unit/regrid/test_vinterp.py
@@ -6,3 +6,143 @@ Unit tests for the :func:`esmvaltool.backend.regrid.vinterp` function.
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 import six
+
+import mock
+import numpy as np
+import unittest
+
+import backend.tests as tests
+from backend.tests.unit.regrid import _make_vcoord, _make_cube
+from backend.regrid import _MDI, vertical_schemes, vinterp
+
+
+class Test(tests.Test):
+    def setUp(self):
+        shape = (3, 2, 1)
+        self.z = shape[0]
+        self.dtype = np.dtype('int8')
+        data = np.arange(np.prod(shape), dtype=self.dtype).reshape(shape)
+        self.cube = _make_cube(data, dtype=self.dtype)
+        self.created_cube = mock.sentinel.created_cube
+        self.mock_create_cube = self.patch('backend.regrid._create_cube',
+                                           return_value=self.created_cube)
+        self.vinterp_schemes = ['linear', 'nearest']
+
+    def test_nop(self):
+        cube = mock.sentinel.cube
+        result = vinterp(cube, None, None)
+        self.assertEqual(result, cube)
+
+    def test_invalid_levels__None(self):
+        emsg = 'Target levels must be specified'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            vinterp(self.cube, None, 'linear')
+
+    def test_invalid_scheme__None(self):
+        levels = mock.sentinel.levels
+        emsg = 'A scheme must be specified'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            vinterp(self.cube, levels, None)
+
+    def test_invalid_scheme__unknown(self):
+        levels = mock.sentinel.levels
+        scheme = mock.sentinel.scheme
+        emsg = 'Unknown vertical interpolation scheme'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            vinterp(self.cube, levels, scheme)
+
+    def test_vertical_schemes(self):
+        self.assertEqual(set(vertical_schemes),
+                         set(self.vinterp_schemes))
+
+    def test_nop__levels_match(self):
+        vcoord = _make_vcoord(self.z, dtype=self.dtype)
+        self.assertEqual(self.cube.coord(axis='z', dim_coords=True), vcoord)
+        levels = vcoord.points
+        result = vinterp(self.cube, levels, 'linear')
+        self.assertEqual(id(result), id(self.cube))
+        self.assertEqual(result, self.cube)
+
+    def test_extraction(self):
+        levels = [0, 2]
+        result = vinterp(self.cube, levels, 'linear')
+        data = np.array([0, 1, 4, 5], dtype=self.dtype).reshape(2, 2, 1)
+        expected = _make_cube(data, aux_coord=False, dim_coord=False,
+                              dtype=self.dtype)
+        coord = self.cube.coord('Pressure Slice').copy()
+        expected.add_aux_coord(coord[levels], (0, 1))
+        coord = self.cube.coord('air_pressure').copy()
+        expected.add_dim_coord(coord[levels], 0)
+        self.assertEqual(result, expected)
+
+    def test_extraction__failure(self):
+        levels = [0, 2]
+        with mock.patch('iris.cube.Cube.extract', return_value=None):
+            emsg = 'Failed to extract levels'
+            with self.assertRaisesRegexp(ValueError, emsg):
+                vinterp(self.cube, levels, 'linear')
+
+    def test_interpolation(self):
+        new_data = np.array(True)
+        levels = np.array([0.5, 1.5])
+        scheme = 'linear'
+        with mock.patch('stratify.interpolate',
+                        return_value=new_data) as mocker:
+            result = vinterp(self.cube, levels, scheme)
+            self.assertEqual(result, self.created_cube)
+            args, kwargs = mocker.call_args
+            # Check the stratify.interpolate args ...
+            self.assertEqual(len(args), 3)
+            self.assertArrayEqual(args[0], levels)
+            pts = self.cube.coord(axis='z', dim_coords=True).points
+            src_levels_broadcast = np.broadcast_to(pts.reshape(self.z, 1, 1),
+                                                   self.cube.shape)
+            self.assertArrayEqual(args[1], src_levels_broadcast)
+            self.assertArrayEqual(args[2], self.cube.data)
+            # Check the stratify.interpolate kwargs ...
+            self.assertEqual(kwargs, dict(axis=0,
+                                          interpolation=scheme,
+                                          extrapolation='nan'))
+        args, kwargs = self.mock_create_cube.call_args
+        # Check the _create_cube args ...
+        self.assertEqual(len(args), 3)
+        self.assertArrayEqual(args[0], self.cube)
+        self.assertArrayEqual(args[1], new_data)
+        self.assertArrayEqual(args[2], levels)
+        # Check the _create_cube kwargs ...
+        self.assertEqual(kwargs, dict())
+
+    def test_interpolation__with_extrapolated_NaN_filling(self):
+        new_data = np.array([0, np.nan])
+        levels = [0.5, 1.5]
+        scheme = 'nearest'
+        with mock.patch('stratify.interpolate',
+                        return_value=new_data) as mocker:
+            result = vinterp(self.cube, levels, scheme)
+            self.assertEqual(result, self.created_cube)
+            args, kwargs = mocker.call_args
+            # Check the stratify.interpolate args ...
+            self.assertEqual(len(args), 3)
+            self.assertArrayEqual(args[0], levels)
+            pts = self.cube.coord(axis='z', dim_coords=True).points
+            src_levels_broadcast = np.broadcast_to(pts.reshape(self.z, 1, 1),
+                                                   self.cube.shape)
+            self.assertArrayEqual(args[1], src_levels_broadcast)
+            self.assertArrayEqual(args[2], self.cube.data)
+            # Check the stratify.interpolate kwargs ...
+            self.assertEqual(kwargs, dict(axis=0,
+                                          interpolation=scheme,
+                                          extrapolation='nan'))
+        args, kwargs = self.mock_create_cube.call_args
+        # Check the _create_cube args ...
+        self.assertEqual(len(args), 3)
+        self.assertArrayEqual(args[0], self.cube)
+        new_data[np.isnan(new_data)] = _MDI
+        self.assertArrayEqual(args[1], new_data)
+        self.assertArrayEqual(args[2], levels)
+        # Check the _create_cube kwargs ...
+        self.assertEqual(kwargs, dict())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/unit/regrid/test_vinterp.py
+++ b/backend/tests/unit/regrid/test_vinterp.py
@@ -112,7 +112,7 @@ class Test(tests.Test):
         # Check the _create_cube kwargs ...
         self.assertEqual(kwargs, dict())
 
-    def test_interpolation__with_extrapolated_NaN_filling(self):
+    def test_interpolation__extrapolated_NaN_filling(self):
         new_data = np.array([0, np.nan])
         levels = [0.5, 1.5]
         scheme = 'nearest'


### PR DESCRIPTION
This PR is the result of a major TLC refactor of the `backend.regrid` module, with added `unit` test and `integration` test goodness ...

The `backend.regrid` module API has been split to allow horizontal regridding and vertical interpolation to be performed separately via `backend.regrid.regrid` and `backend.regrid.vinterp`.