### PR TITLE
vinterp masking + regrid unstructured spatial fix.

### DIFF
--- a/backend/tests/unit/regrid/test__stock_cube.py
+++ b/backend/tests/unit/regrid/test__stock_cube.py
@@ -85,7 +85,7 @@ class Test(tests.Test):
     def test_invalid_cell_spec__longitude(self):
         emsg = 'Invalid longitude delta in MxN cell specification'
         with self.assertRaisesRegexp(ValueError, emsg):
-            stock_cube('1.2x1')
+            stock_cube('1.3x1')
 
     def test_invalid_cell_spec__latitude(self):
         emsg = 'Invalid latitude delta in MxN cell specification'


### PR DESCRIPTION
Minor fixes to the regridding to address the following issues:
* Purge `src_cube` 1d spatial coords prior to performing an `unstructured_nearest` scheme `regrid`
* `vinterp` re-masks interpolated data when the `src_cube` contains a spatial mask e.g. a land/sea mask