### PR TITLE
Adding DOI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ESMValTool
+[![DOIBadge](https://img.shields.io/badge/DOI-10.17874%2Fac8548f0315-blue.svg)](http://dx.doi.org/10.17874/ac8548f0315)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/70c69582d71d417fa342a6f54e0eb0c5)](https://www.codacy.com/app/bjoernbroetz/ESMValTool?utm_source=github.com&utm_medium=referral&utm_content=ESMValGroup/ESMValTool&utm_campaign=badger)
  [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ESMValGroup?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![CircleCI](https://circleci.com/gh/ESMValGroup/ESMValTool.svg?style=svg)](https://circleci.com/gh/ESMValGroup/ESMValTool)


### PR DESCRIPTION
As discussed at the workshop with @axel-lauer, @bjlittle and @nielsdrost the ESMValTool DOI should be on the README. 