### PR TITLE
Regrid linear/nearest with mask extrapolation_mode

### DIFF
--- a/backend/regrid.py
+++ b/backend/regrid.py
@@ -43,8 +43,8 @@ _LON_RANGE = _LON_MAX - _LON_MIN
 _cache = dict()
 
 # Supported horizontal regridding schemes.
-horizontal_schemes = dict(linear=Linear(),
-                          nearest=Nearest(),
+horizontal_schemes = dict(linear=Linear(extrapolation_mode='mask'),
+                          nearest=Nearest(extrapolation_mode='mask'),
                           area_weighted=AreaWeighted(),
                           unstructured_nearest=UnstructuredNearest())
 

--- a/backend/tests/integration/regrid/test_regrid.py
+++ b/backend/tests/integration/regrid/test_regrid.py
@@ -1,0 +1,155 @@
+"""
+Integration tests for the :func:`esmvaltool.backend.regrid.regrid` function.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+import six  # noqa
+
+import iris
+from numpy import ma
+import numpy as np
+import unittest
+
+import backend.tests as tests
+from backend.tests.unit.regrid import _make_cube
+from backend.regrid import regrid
+
+
+class Test(tests.Test):
+    def setUp(self):
+        shape = (3, 2, 2)
+        data = np.arange(np.prod(shape)).reshape(shape)
+        self.cube = _make_cube(data)
+        self.cs = iris.coord_systems.GeogCS(iris.fileformats.pp.EARTH_RADIUS)
+
+    def test_nop(self):
+        result = regrid(self.cube, None, None)
+        self.assertEqual(result, self.cube)
+        self.assertEqual(id(result), id(self.cube))
+
+    def test_regrid__linear(self):
+        data = np.empty((1, 1))
+        grid = iris.cube.Cube(data)
+        lons = iris.coords.DimCoord([1.5], standard_name='longitude',
+                                    bounds=[[1, 2]],
+                                    units='degrees_east',
+                                    coord_system=self.cs)
+        lats = iris.coords.DimCoord([1.5], standard_name='latitude',
+                                    bounds=[[1, 2]],
+                                    units='degrees_north',
+                                    coord_system=self.cs)
+        coords_spec = [(lats, 0), (lons, 1)]
+        grid = iris.cube.Cube(data, dim_coords_and_dims=coords_spec)
+        result = regrid(self.cube, grid, 'linear')
+        expected = np.array([[[1.5]], [[5.5]], [[9.5]]])
+        self.assertArrayEqual(result.data, expected)
+
+    def test_regrid__linear_extrapolate_with_mask(self):
+        data = np.empty((3, 3))
+        grid = iris.cube.Cube(data)
+        lons = iris.coords.DimCoord([0, 1.5, 3],
+                                    standard_name='longitude',
+                                    bounds=[[0, 1], [1, 2], [2, 3]],
+                                    units='degrees_east',
+                                    coord_system=self.cs)
+        lats = iris.coords.DimCoord([0, 1.5, 3],
+                                    standard_name='latitude',
+                                    bounds=[[0, 1], [1, 2], [2, 3]],
+                                    units='degrees_north',
+                                    coord_system=self.cs)
+        coords_spec = [(lats, 0), (lons, 1)]
+        grid = iris.cube.Cube(data, dim_coords_and_dims=coords_spec)
+        result = regrid(self.cube, grid, 'linear')
+        expected = ma.empty((3, 3, 3))
+        expected.mask = ma.masked
+        expected[:, 1, 1] = np.array([1.5, 5.5, 9.5])
+        self.assertArrayEqual(result.data, expected)
+
+    def test_regrid__nearest(self):
+        data = np.empty((1, 1))
+        grid = iris.cube.Cube(data)
+        lons = iris.coords.DimCoord([1.6], standard_name='longitude',
+                                    bounds=[[1, 2]],
+                                    units='degrees_east',
+                                    coord_system=self.cs)
+        lats = iris.coords.DimCoord([1.6], standard_name='latitude',
+                                    bounds=[[1, 2]],
+                                    units='degrees_north',
+                                    coord_system=self.cs)
+        coords_spec = [(lats, 0), (lons, 1)]
+        grid = iris.cube.Cube(data, dim_coords_and_dims=coords_spec)
+        result = regrid(self.cube, grid, 'nearest')
+        expected = np.array([[[3]], [[7]], [[11]]])
+        self.assertArrayEqual(result.data, expected)
+
+    def test_regrid__nearest_extrapolate_with_mask(self):
+        data = np.empty((3, 3))
+        grid = iris.cube.Cube(data)
+        lons = iris.coords.DimCoord([0, 1.6, 3],
+                                    standard_name='longitude',
+                                    bounds=[[0, 1], [1, 2], [2, 3]],
+                                    units='degrees_east',
+                                    coord_system=self.cs)
+        lats = iris.coords.DimCoord([0, 1.6, 3],
+                                    standard_name='latitude',
+                                    bounds=[[0, 1], [1, 2], [2, 3]],
+                                    units='degrees_north',
+                                    coord_system=self.cs)
+        coords_spec = [(lats, 0), (lons, 1)]
+        grid = iris.cube.Cube(data, dim_coords_and_dims=coords_spec)
+        result = regrid(self.cube, grid, 'nearest')
+        expected = ma.empty((3, 3, 3))
+        expected.mask = ma.masked
+        expected[:, 1, 1] = np.array([3, 7, 11])
+        self.assertArrayEqual(result.data, expected)
+
+    def test_regrid__area_weighted(self):
+        data = np.empty((1, 1))
+        grid = iris.cube.Cube(data)
+        lons = iris.coords.DimCoord([1.6], standard_name='longitude',
+                                    bounds=[[1, 2]],
+                                    units='degrees_east',
+                                    coord_system=self.cs)
+        lats = iris.coords.DimCoord([1.6], standard_name='latitude',
+                                    bounds=[[1, 2]],
+                                    units='degrees_north',
+                                    coord_system=self.cs)
+        coords_spec = [(lats, 0), (lons, 1)]
+        grid = iris.cube.Cube(data, dim_coords_and_dims=coords_spec)
+        result = regrid(self.cube, grid, 'area_weighted')
+        expected = np.array([1.499886, 5.499886, 9.499886])
+        self.assertArrayAlmostEqual(result.data, expected)
+
+    def test_regrid__unstructured_nearest(self):
+        data = np.empty((1, 1))
+        grid = iris.cube.Cube(data)
+        lons = iris.coords.DimCoord([1.6], standard_name='longitude',
+                                    bounds=[[1, 2]],
+                                    units='degrees_east',
+                                    coord_system=self.cs)
+        lats = iris.coords.DimCoord([1.6], standard_name='latitude',
+                                    bounds=[[1, 2]],
+                                    units='degrees_north',
+                                    coord_system=self.cs)
+        coords_spec = [(lats, 0), (lons, 1)]
+        grid = iris.cube.Cube(data, dim_coords_and_dims=coords_spec)
+        # Replace 1d spatial coords with 2d spatial coords.
+        lons = self.cube.coord('longitude')
+        lats = self.cube.coord('latitude')
+        x, y = np.meshgrid(lons.points, lats.points)
+        lats = iris.coords.AuxCoord(x, **lats._as_defn()._asdict())
+        lons = iris.coords.AuxCoord(y, **lons._as_defn()._asdict())
+        self.cube.remove_coord('longitude')
+        self.cube.remove_coord('latitude')
+        self.cube.remove_coord('Pressure Slice')
+        self.cube.add_aux_coord(lons, (1, 2))
+        self.cube.add_aux_coord(lats, (1, 2))
+        result = regrid(self.cube, grid, 'unstructured_nearest')
+        expected = np.array([[[3]], [[7]], [[11]]])
+        self.assertArrayAlmostEqual(result.data, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/unit/regrid/__init__.py
+++ b/backend/tests/unit/regrid/__init__.py
@@ -68,24 +68,28 @@ def _make_cube(data, aux_coord=True, dim_coord=True, dtype=None):
         cube.add_dim_coord(_make_vcoord(z, dtype=dtype), 0)
 
     # Create a synthetic test latitude coordinate.
-    data = np.arange(y, dtype=dtype)
-    cs = iris.coord_systems.GeogCS(123)
+    data = np.arange(y, dtype=dtype) + 1
+    cs = iris.coord_systems.GeogCS(iris.fileformats.pp.EARTH_RADIUS)
     kwargs = dict(standard_name='latitude',
                   long_name='Latitude',
                   var_name='lat', units='degrees_north',
                   attributes=dict(latitude='attribute'),
                   coord_system=cs)
     ycoord = DimCoord(data, **kwargs)
+    if data.size > 1:
+        ycoord.guess_bounds()
     cube.add_dim_coord(ycoord, 1)
 
     # Create a synthetic test longitude coordinate.
-    data = np.arange(x, dtype=dtype)
+    data = np.arange(x, dtype=dtype) + 1
     kwargs = dict(standard_name='longitude',
                   long_name='Longitude',
                   var_name='lon', units='degrees_east',
                   attributes=dict(longitude='attribute'),
                   coord_system=cs)
     xcoord = DimCoord(data, **kwargs)
+    if data.size > 1:
+        xcoord.guess_bounds()
     cube.add_dim_coord(xcoord, 2)
 
     # Create a synthetic test 2d auxiliary coordinate


### PR DESCRIPTION
This PR sets the default `extrapolation_mode` for both the `linear` and `nearest` regridders to be `mask`, which means that all target grid points outside the source grid domain will be masked. See #63.

I've also added some elementary `integration` tests to cover each `scheme` of the `backend.regrid.regrid` function. 