### PR TITLE
Refactoring launch fix

### DIFF
--- a/esmvaltool/interface_scripts/data_finder.py
+++ b/esmvaltool/interface_scripts/data_finder.py
@@ -100,7 +100,7 @@ def cmip5_mip2realm_freq(mip):
         'aero': ['aerosol', 'mon'],
         #'3hr': ???
         'cfDay': ['atmos', 'day'],
-        'cfMon': ['atmos', 'mon'], 
+        'cfMon': ['atmos', 'mon'],
         'day': ['atmos', 'day'],
         'fx': ['*', 'fx']
     }
@@ -124,12 +124,16 @@ def replace_tags(path, model, var):
             replacewith = var['name']
         elif tag == 'field':
             replacewith = var['field']
-        elif tag == 'institute':
-            replacewith = cmip5_model2inst(model['name'])
-        elif tag == 'freq':
-            replacewith = cmip5_mip2realm_freq(model['mip'])[1]
-        elif tag == 'realm':
-            replacewith = cmip5_mip2realm_freq(model['mip'])[0]
+        elif tag in ('institute', 'freq', 'realm'):
+            if tag in model:
+                replacewith = str(model[tag])
+            else:
+                if tag == 'institute':
+                    replacewith = cmip5_model2inst(model['name'])
+                elif tag == 'freq':
+                    replacewith = cmip5_mip2realm_freq(model['mip'])[1]
+                elif tag == 'realm':
+                    replacewith = cmip5_mip2realm_freq(model['mip'])[0]
         elif tag == 'latestversion':  # handled separately later
             pass
         elif tag == 'tier':
@@ -143,7 +147,7 @@ def replace_tags(path, model, var):
                 raise KeyError('Model key %s must be specified for project %s, check your namelist entry' % (tag, model['project']))
 
         path = path.replace('[' + tag + ']', replacewith)
-       
+
     return path
 
 
@@ -167,8 +171,8 @@ def get_input_filelist(project_info, model, var):
     """ Returns the full path to input files
     """
 
-    project = model['project'] 
-   
+    project = model['project']
+
     dict = read_config_file(project)
 
     # Apply variable-dependent model keys
@@ -229,9 +233,9 @@ def get_output_file(project_info, model, var):
     """
 
     dict = read_config_file(model['project'])
-    
-    outfile = os.path.join(project_info['GLOBAL']['preproc_dir'], 
-                           model['project'], 
+
+    outfile = os.path.join(project_info['GLOBAL']['preproc_dir'],
+                           model['project'],
                            replace_tags(dict['output_file'], model, var))
     outfile = ''.join((outfile, '.nc'))
 
@@ -279,7 +283,7 @@ def veto_files(model, dirname, filename):
 
 def time_handling(year1, year1_model, year2, year2_model):
     """
-    This function is responsible for finding the correct 
+    This function is responsible for finding the correct
     files for the needed timespan:
 
     year1 - the start year in files

--- a/esmvaltool/interface_scripts/preprocess.py
+++ b/esmvaltool/interface_scripts/preprocess.py
@@ -61,7 +61,7 @@ def run_executable(string_to_execute,
         Check the type of script/binary from the executable string suffix and
         execute the script/binary properly.
     """
-    
+
     if write_di:
         write_data_interface(string_to_execute, project_info)
 
@@ -466,9 +466,9 @@ def preprocess(project_info, variable, model, current_diag, cmor_reformat_type):
                 raise exceptions.IOError(2, "Expected reformatted file isn't available: ",
                                          project_info['TEMPORARY']['outfile_fullpath'])
                 sys.exit(1)
-        
+
         # load cube now, if available
-        reft_cube = iris.load_cube(project_info['TEMPORARY']['outfile_fullpath']) 
+        reft_cube = iris.load_cube(project_info['TEMPORARY']['outfile_fullpath'])
 
     ################## 0. CMOR_REFORMAT (PY version) ##############
     # New code: cmor_check.py (by Javier Vegas)
@@ -483,7 +483,6 @@ def preprocess(project_info, variable, model, current_diag, cmor_reformat_type):
 
         var_name = variable.name
         table = model['mip']
-
 
         try:
             # Load cubes for requested variable in given files
@@ -683,7 +682,7 @@ def preprocess(project_info, variable, model, current_diag, cmor_reformat_type):
         else:
             logger.warning("Vertical levels must be int, float, string or list (of ints or floats) " + levels + " - no select level!")
             psl = 0
-            
+
 
         if psl > 0 and nsl > 0:
 
@@ -925,7 +924,7 @@ def multimodel_mean(cube_collection, path_collection):
     #print(smeans_cubes)
     #smeans = [np.mean(c.data) for c in smeans_cubes]
     #logger.info(" >>> preprocess.py >>> Multimodel seasonal global means: %s" % str(smeans))
-    
+
 
 
 

--- a/esmvaltool/main.py
+++ b/esmvaltool/main.py
@@ -170,14 +170,14 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('-n', '--namelist-file',
-                        help='Namelist file')
+                        help='Path to the namelist file', required=True)
     parser.add_argument('-c', '--config-file',
                         default=os.path.join(os.path.dirname(__file__), 'config-user.yml'),
                         help='Config file')
     args = parser.parse_args()
 
-    namelist_file = os.path.abspath(args.namelist_file)
-    config_file = os.path.abspath(args.config_file)
+    namelist_file = os.path.abspath(os.path.expandvars(os.path.expanduser(args.namelist_file)))
+    config_file = os.path.abspath(os.path.expandvars(os.path.expanduser(args.config_file)))
 
     ####################################################
     # Set up logging before anything else              #


### PR DESCRIPTION
Hi 

I have made some usability changes:

I have made the --namelist parameter required, so the launch will fail if it is not provided, telling the user what is happening

I have expanded tha 'os.path.abspath(args.namelist_file)' call to
`os.path.abspath(os.path.expandvars(os.path.expanduser(args.namelist_file)))` for the namelist and configuration file paths. This way we can use environment variables and the ~ character in both paths. 

Finally, I have changed the way we are getting the institute, frequency and realm tag values to allow the user to specify them at model level. 

 