### PR TITLE
Fix on esgf data retrieval for right data version

### DIFF
--- a/interface_scripts/projects.py
+++ b/interface_scripts/projects.py
@@ -3542,6 +3542,7 @@ class ESGF:
         If version given in model line as 'lastest', try and find
         most up to date version directory on the disk
         """
+        import glob
         # Start with default value
         version = None
 
@@ -3596,7 +3597,6 @@ class ESGF:
                     if best_candidate:
                         version = best_candidate
                         directory = "{0}/{1}/{2}".format(version_path, version, msd['variable'])
-                        import glob
                         #check if variable dir exists and if there are nc-files inside
                         if os.path.isdir(directory):
                             if len(glob.glob("{0}/*.nc".format(directory))) != 0:
@@ -3624,7 +3624,15 @@ class ESGF:
 
                         if best_candidate:
                             version = best_candidate
-                        stillsearching = False
+                            directory = "{0}/{1}/{2}".format(version_path, version, msd['variable'])
+                            #check if variable dir exists and if there are nc-files inside
+                            if os.path.isdir(directory):
+                                if len(glob.glob("{0}/*.nc".format(directory))) != 0:
+                                    stillsearching = False
+                                else:
+                                    dir_contents.remove(version)
+                            else:
+                                dir_contents.remove(version)
 
                     if len(version_dirs) == 0:
                         stillsearching = False

--- a/interface_scripts/projects.py
+++ b/interface_scripts/projects.py
@@ -3542,7 +3542,6 @@ class ESGF:
         If version given in model line as 'lastest', try and find
         most up to date version directory on the disk
         """
-        import glob
         # Start with default value
         version = None
 


### PR DESCRIPTION
This patch fixes the problem occurring when there are not all available
variables in the more recent version folder, e.g.:

root
   |
   |_v20170101
   |       |_VAR1
   |       |_VAR2
   |
   |_v20170102
           |_VAR2

Before, VAR1 would have not been found due to the more recent version
folder. Now, the most recent version of the available variable is found.