### PR TITLE
Fix on 'deadlock' while using subprocess

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,43 @@ jobs:
   build:
     working_directory: /esmvaltool
     docker:
-      - image: nielsdrost/esmvaltool-deps:20170520
+      - image: continuumio/miniconda
     steps:
       - checkout
-      - run: ./run-tests
+      - run:
+          # Add some system packages (mostly since geoval needs them)
+          command : |
+            apt-get update -y && apt-get install -y build-essential
+      - run:
+          # Create Conda Environment
+          command : |
+            conda create -n esmvaltool -y
+      - restore_cache:
+          key: deps2-{{ .Branch }}-{{ checksum "environment.yml" }}
+      - run:
+          # Update Conda Environment (result is cached, only run again if environment.yml was changed)
+          command : |
+            conda env update --quiet --file environment.yml --name esmvaltool
+      - save_cache:
+          key: deps2-{{ .Branch }}-{{ checksum "environment.yml" }}
+          paths:
+            - "/opt/conda/envs/esmvaltool"
+      - run:
+          # Update Conda Environment (for any changes since cache was created)
+          command : |
+            conda env update --quiet --file environment.yml --name esmvaltool
+      - run:
+          # Activate Conda environment and run tests
+          command : |
+            source activate esmvaltool
+            ./run-tests
       - store_test_results:
           path: test-reports/
+      - store_artifacts:
+          path: test-reports/
+      - run:
+          # Upload test results to codacy, even when the actual running of the tests fails
+          when: always
+          command : |
+            pip install codacy-coverage
+            python-codacy-coverage -r test-reports/coverage.xml

--- a/environment.yml
+++ b/environment.yml
@@ -31,4 +31,6 @@ dependencies:
 # testing
 - nose
 - pytest
+- pytest-cov
+- pytest-html
 - easytest

--- a/interface_scripts/launchers.py
+++ b/interface_scripts/launchers.py
@@ -228,7 +228,6 @@ class r_launcher(launchers):
                                            stdin=open(os.devnull),
                                            stdout=subprocess.PIPE,
                                            stderr=subprocess.STDOUT)
-        run_application.wait()
         std_outerr = run_application.communicate()[0].split('\n')
         self.write_stdouterr(std_outerr, verbosity, exit_on_warning)
 
@@ -332,7 +331,6 @@ class py_launcher(launchers):
         run_application = subprocess.Popen("python " + python_executable, shell=True,
                                            stdin=open(os.devnull),
                                            stdout=subprocess.PIPE)
-        run_application.wait()
         std_outerr = run_application.communicate()[0].split('\n')
         self.write_stdouterr(std_outerr, verbosity, exit_on_warning)
 
@@ -366,7 +364,6 @@ class shell_launcher(launchers):
                                            stdin=open(os.devnull),                         
                                            stdout=subprocess.PIPE,                         
                                            stderr=subprocess.PIPE)                         
-              run_application.wait()                                                       
               output = run_application.communicate()                                       
               std_out = filter(None,output[0].split('\n'))                                 
               std_err = filter(None,output[1].split('\n'))                                 

--- a/run-tests
+++ b/run-tests
@@ -2,4 +2,5 @@
 
 # Test runner script for ESMValtool. This should eventually go into
 # setup.py once this is available. For now a oneliner using pytest
-pytest tests/*.py --junit-xml=test-reports/report.xml
+report_dir='test-reports'
+pytest tests --ignore=tests/test_diagnostics --ignore=tests/test_diagnostics_old --ignore=tests/test_esmval_testlib.py --cov=. --cov-report=term --cov-report=html:$report_dir/coverage_html --cov-report=xml:$report_dir/coverage.xml --junit-xml=$report_dir/report.xml --html=$report_dir/report.html


### PR DESCRIPTION
Removing Popen.wait() from the launchers, see discussion in https://github.com/ESMValGroup/ESMValTool-private/issues/40
