### PR TITLE
Refactoring launchers, step 1: ncl interface

### DIFF
--- a/esmvaltool/__init__.py
+++ b/esmvaltool/__init__.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-from .main import __version__
+from .version import __version__
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/esmvaltool/config-logging.yml
+++ b/esmvaltool/config-logging.yml
@@ -3,9 +3,9 @@ version: 1
 disable_existing_loggers: False
 formatters:
   console:
-    format: '%(asctime)s %(levelname)-7s %(name)s: %(message)s'
+    format: '%(asctime)s %(levelname)-7s %(message)s'
   brief:
-    format: '%(levelname)-7s %(name)s: %(message)s'
+    format: '%(levelname)-7s %(message)s'
   debug:
     format: '%(asctime)s [%(process)d] %(levelname)-7s %(filename)s:%(lineno)s %(message)s'
 handlers:

--- a/esmvaltool/diag_scripts/MyDiag_test_pr.ncl
+++ b/esmvaltool/diag_scripts/MyDiag_test_pr.ncl
@@ -55,6 +55,7 @@
 load "$ESMValTool_interface_data/ncl.interface"
 
 ; Auxiliary NCL routines
+load "./interface_scripts/interface.ncl"
 load "./interface_scripts/auxiliary.ncl"
 load "./interface_scripts/data_handling.ncl"
 load "./interface_scripts/messaging.ncl"

--- a/esmvaltool/diag_scripts/MyDiag_test_ta.ncl
+++ b/esmvaltool/diag_scripts/MyDiag_test_ta.ncl
@@ -55,6 +55,7 @@
 load "$ESMValTool_interface_data/ncl.interface"
 
 ; Auxiliary NCL routines
+load "./interface_scripts/interface.ncl"
 load "./interface_scripts/auxiliary.ncl"
 load "./interface_scripts/data_handling.ncl"
 load "./interface_scripts/messaging.ncl"

--- a/esmvaltool/diag_scripts/MyDiag_test_ta_no2.ncl
+++ b/esmvaltool/diag_scripts/MyDiag_test_ta_no2.ncl
@@ -55,6 +55,7 @@
 load "$ESMValTool_interface_data/ncl.interface"
 
 ; Auxiliary NCL routines
+load "./interface_scripts/interface.ncl"
 load "./interface_scripts/auxiliary.ncl"
 load "./interface_scripts/data_handling.ncl"
 load "./interface_scripts/messaging.ncl"

--- a/esmvaltool/diag_scripts/perfmetrics_grading.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics_grading.ncl
@@ -43,6 +43,7 @@
 ;;#############################################################################
 
 load "$ESMValTool_interface_data/ncl.interface"
+load "./interface_scripts/interface.ncl"
 load "./interface_scripts/auxiliary.ncl"
 load "./interface_scripts/data_handling.ncl"
 load "./interface_scripts/messaging.ncl"

--- a/esmvaltool/diag_scripts/perfmetrics_grading_collect.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics_grading_collect.ncl
@@ -44,6 +44,7 @@
 
 
 load "$ESMValTool_interface_data/ncl.interface"
+load "./interface_scripts/interface.ncl"
 load "./interface_scripts/auxiliary.ncl"
 load "./interface_scripts/data_handling.ncl"
 load "./interface_scripts/messaging.ncl"

--- a/esmvaltool/diag_scripts/perfmetrics_main.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics_main.ncl
@@ -79,6 +79,7 @@
 ;;#############################################################################
 
 load "$ESMValTool_interface_data/ncl.interface"
+load "./interface_scripts/interface.ncl"
 load "./interface_scripts/auxiliary.ncl"
 load "./interface_scripts/data_handling.ncl"
 load "./interface_scripts/messaging.ncl"

--- a/esmvaltool/diag_scripts/perfmetrics_taylor.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics_taylor.ncl
@@ -42,6 +42,7 @@
 ;;#############################################################################
 
 load "$ESMValTool_interface_data/ncl.interface"
+load "./interface_scripts/interface.ncl"
 load "./interface_scripts/auxiliary.ncl"
 load "./interface_scripts/data_handling.ncl"
 load "./interface_scripts/messaging.ncl"

--- a/esmvaltool/diag_scripts/perfmetrics_taylor_collect.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics_taylor_collect.ncl
@@ -30,6 +30,7 @@
 
 
 load "$ESMValTool_interface_data/ncl.interface"
+load "./interface_scripts/interface.ncl"
 load "./interface_scripts/auxiliary.ncl"
 load "./interface_scripts/data_handling.ncl"
 load "./interface_scripts/messaging.ncl"

--- a/esmvaltool/interface_scripts/data_finder.py
+++ b/esmvaltool/interface_scripts/data_finder.py
@@ -191,7 +191,7 @@ def get_output_file(variable, preproc_dir):
     """Return the full path to the output (preprocessed) file"""
     cfg = read_config_file(variable['project'])
 
-    outfile = os.path.join(preproc_dir, variable['project'],
+    outfile = os.path.join(preproc_dir, variable['preprocessor'],
                            replace_tags(cfg['output_file'], variable))
     outfile = ''.join((outfile, '.nc'))
 

--- a/esmvaltool/interface_scripts/data_interface.py
+++ b/esmvaltool/interface_scripts/data_interface.py
@@ -186,16 +186,17 @@ def write_legacy_ncl_interface(variables, settings, config_user,
     ncl_interface['diag_script_info'] = settings
 
     # write ncl.interface
-    interface_file = os.path.join(interface_data_dir, 'interface.ncl')
-    write_settings(ncl_interface, interface_file)
-    os.rename(interface_file, os.path.join(interface_data_dir,
-                                           'ncl.interface'))
+    interface_file_tmp = os.path.join(interface_data_dir, 'interface.ncl')
+    write_settings(ncl_interface, interface_file_tmp)
+    interface_file = os.path.join(interface_data_dir, 'ncl.interface')
+    os.rename(interface_file_tmp, interface_file)
+    logger.info("with configuration file %s", interface_file)
 
     # variable info files
     for name, variable in variables.items():
-        info_file = os.path.join(interface_data_dir, name + '_info.ncl')
+        info_file_tmp = os.path.join(interface_data_dir, name + '_info.ncl')
         # write header
-        with open(info_file, 'wt') as file:
+        with open(info_file_tmp, 'wt') as file:
             header = ('if (isvar("variable_info")) then\n'
                       '    delete(variable_info)\n'
                       'end if\n')
@@ -207,8 +208,10 @@ def write_legacy_ncl_interface(variables, settings, config_user,
             if all(v == w.get(k) for w in variable)
         }
         variable_info = {'variable_info': common_items}
-        write_settings(variable_info, info_file, mode='at')
-        os.rename(info_file, os.path.splitext(info_file)[0] + '.tmp')
+        write_settings(variable_info, info_file_tmp, mode='at')
+        info_file = os.path.splitext(info_file_tmp)[0] + '.tmp'
+        logger.info("and configuration file %s", interface_file)
+        os.rename(info_file_tmp, info_file)
 
 
 def get_legacy_ncl_env(config_user, interface_data_dir, namelist_basename):

--- a/esmvaltool/interface_scripts/data_interface.py
+++ b/esmvaltool/interface_scripts/data_interface.py
@@ -242,10 +242,7 @@ def get_output_file_template(variable, preproc_dir):
 
 
 def get_figure_file_names(variable):
-    """ @brief Returns names for plots
-        @param project_info Current namelist in dictionary format
-        @param some model from namelist
-    """
+    """Get plot filename."""
     #     return "_".join([
     #         model['project'],
     #         model['name'],

--- a/esmvaltool/interface_scripts/interface.ncl
+++ b/esmvaltool/interface_scripts/interface.ncl
@@ -1,4 +1,4 @@
-; This is a temporary file updated by Python on the fly
+; TODO: add a description of the functions in this file
 ;------------------------------------------------------
 load "./interface_scripts/messaging.ncl"
 

--- a/esmvaltool/interface_scripts/interface.ncl
+++ b/esmvaltool/interface_scripts/interface.ncl
@@ -1,0 +1,339 @@
+; This is a temporary file updated by Python on the fly
+;------------------------------------------------------
+load "./interface_scripts/messaging.ncl"
+
+undef("interface_get_idx_var")
+function interface_get_idx_var(variable)
+local idx_var
+begin
+    if (derived_var .eq. "Undefined") then
+        idx_var = ind(variable .eq. variables)
+    else
+        idx_var = ind(derived_var .eq. variables)
+    end if
+    return idx_var
+end
+
+undef("interface_get_var_mip")
+function interface_get_var_mip(idx [1] : integer,
+                               variable [1] : string,
+                               array [*] : string)
+; Description:
+;    Fetches the current MIP table, either from the models@-data
+;    structure or, if specified, from the specific variable attribute
+local array_local, idx_var
+begin
+    array_local = array
+    ;; Default case (no variable attribute is specified)
+    if (variable .eq. "default") then
+        if (isatt(models, "mip")) then
+            array_local = str_sub_str(array_local, "${MIP}", models@mip(idx))
+        end if
+    else  ; Variable attribute specified and should replace the models@-entry
+        idx_var = interface_get_idx_var(variable)
+
+        if (var_attr_mip(idx_var) .ne. "None") then
+            array_local = str_sub_str(array_local, "${MIP}", var_attr_mip(idx_var))
+        else
+            if (isatt(models, "mip")) then
+                array_local = str_sub_str(array_local, "${MIP}", models@mip(idx))
+            end if
+        end if
+    end if
+    return array_local
+end
+
+undef("interface_get_var_exp")
+function interface_get_var_exp(idx [1] : integer,
+                               variable [1] : string,
+                               array [*] : string)
+; Description:
+;    Fetches the current experiment type, either from the models@-data
+;    structure or, if specified, from the specific variable attribute
+local array_local, idx_var
+begin
+    array_local = array
+    ;; Default case (no variable attribute is specified)
+    if (variable .eq. "default") then
+        if (isatt(models, "experiment")) then
+            array_local = str_sub_str(array_local, "${EXP}", models@experiment(idx))
+        end if
+    else  ; Variable attribute specified and should replace the models@-entry
+        idx_var = interface_get_idx_var(variable)
+
+        if (var_attr_exp(idx_var) .ne. "None") then
+            array_local = str_sub_str(array_local, "${EXP}", var_attr_exp(idx_var))
+        else
+            if (isatt(models, "experiment")) then
+                array_local = str_sub_str(array_local, "${EXP}", models@experiment(idx))
+            end if
+        end if
+    end if
+    return array_local
+end
+
+undef("interface_replace_place_holders")
+function interface_replace_place_holders(variable [1] : string,
+                                         field [1] : string,
+                                           idx [1] : integer,
+                      array_with_place_holders [*] : string)
+;                                   return val [1] : string
+; Arguments:
+;         @brief Reconstructs the current (idx) input path + filename
+;         @param variable  -  Current variable
+;         @param idx  -  The index to the current model
+;         @param field  -  Current field type
+;         @param array_with_place_holders  - array with place holder strings
+local verbosity, idx_var, array_local_copy
+begin
+    verbosity  = stringtointeger(getenv("ESMValTool_verbosity"))
+    info_output("<<<<<<<< Entering interface_replace_place_holders", verbosity, 6)
+
+    array_local_copy = str_sub_str(array_with_place_holders(idx), "${VARIABLE}", variable)
+    array_local_copy = str_sub_str(array_local_copy, "${FIELD}", field)
+
+    array_local_copy = interface_get_var_mip(idx, variable, array_local_copy)
+    array_local_copy = interface_get_var_exp(idx, variable, array_local_copy)
+
+    info_output(">>>>>>>> Leaving interface_replace_place_holders", verbosity, 6)
+    return array_local_copy
+end
+
+undef("interface_get_figure_filename")
+function interface_get_figure_filename(diag_script_base [1] : string,
+                                           variable [1] : string,
+                                         field_type [1] : string,
+                                           aux_info [1] : string,
+                                            idx_mod [1] : integer)
+;                                        return val [1] : string
+;   Arguments:
+;         @brief Construct a figure output file name
+;         @param diags_script_base  -  The current running diag script without
+;                                      it's suffix
+;         @param variable  -  Current variable
+;         @param field_type  -  Current field type
+;         @param aux_info  -  User supplied info to put in figure filename
+;         @param idx_mod  -  Current model number, set to -1 if not applicable
+local verbosity, aux_sep, figure_name, fig_file_local_copy, use_this_for_var
+begin
+    verbosity  = stringtointeger(getenv("ESMValTool_verbosity"))
+    info_output("<<<<<<<< Entering interface_get_figure_filename", verbosity, 4)
+    sep = "_"  ; Default separator
+    aux_sep = "_"  ; Auxiliary info separator
+    if (aux_info .eq. "") then
+        aux_sep = ""  ; Auxiliary info separator if no aux-info
+    else
+        aux_info = str_sub_str(aux_info, "_", "-")
+    end if
+
+    if (idx_mod .eq. -1) then
+        figure_name = diag_script_base + sep + variable \
+                                       + sep + field_type \
+                                       + aux_sep + aux_info
+    else
+        if (any(ismissing(ind(variable .eq. variables)))) then
+            use_this_for_var = "default"
+        else
+            use_this_for_var = variable
+        end if
+
+        fig_file_local_copy = interface_replace_place_holders(use_this_for_var,\
+                                                              field_type,\
+                                                              idx_mod,\
+                                                              figfiles_suffix)
+        figure_name = diag_script_base + sep + variable \
+                                       + sep + field_type \
+                                       + sep + aux_info + aux_sep \
+                                       + fig_file_local_copy
+    end if
+    info_output(">>>>>>>> Leaving interface_get_figure_filename", verbosity, 4)
+    return figure_name
+end
+
+undef("interface_get_fullpath")
+function interface_get_fullpath(variable [1] : string,
+                                   field [1] : string,
+                                     idx [1] : integer)
+;                             return val [1] : string
+; Arguments:
+;         @brief Reconstructs the current (idx) input path + filename
+;         @param variable  -  Current variable
+;         @param idx  -  The index to the current model
+;         @param field  -  Current field type
+local verbosity, idx_var, fullpaths_local_copy
+begin
+    verbosity  = stringtointeger(getenv("ESMValTool_verbosity"))
+    info_output("<<<<<<<< Entering interface_get_fullpath", verbosity, 4)
+    fullpaths_local_copy = interface_replace_place_holders(variable, field, idx, fullpaths)
+    info_output(">>>>>>>> Leaving interface_get_fullpath", verbosity, 4)
+    return fullpaths_local_copy
+end
+
+undef("interface_get_infile")
+function interface_get_infile(variable [1] : string,
+                                 field [1] : string,
+                                   idx [1] : integer)
+;                           return val [1] : string
+; Arguments:
+;         @brief Reconstructs the current (idx) input filename
+;         @param variable  -  Current variable
+;         @param idx  -  The index to the current model
+;         @param field  -  Current field type
+local verbosity, infiles_local_copy
+begin
+    verbosity  = stringtointeger(getenv("ESMValTool_verbosity"))
+    info_output("<<<<<<<< Entering interface_get_infile", verbosity, 4)
+    infiles_local_copy = interface_replace_place_holders(variable, field, idx, infiles)
+    info_output(">>>>>>>> Leaving interface_get_infile", verbosity, 4)
+    return infiles_local_copy
+end
+
+undef("interface_get_inpaths")
+function interface_get_inpaths(idx [1] : integer)
+;                       return val [1] : string
+; Arguments:
+;         @brief Returns the current (idx) path to the input filename
+;         @param idx  -  The index to the current model
+local verbosity
+begin
+    verbosity  = stringtointeger(getenv("ESMValTool_verbosity"))
+    info_output("<<<<<<<< Entering interface_get_inpaths", verbosity, 4)
+    info_output(">>>>>>>> Leaving interface_get_inpaths", verbosity, 4)
+    return infile_paths(idx)
+end
+
+undef("interface_get_dictkeys")
+function interface_get_dictkeys(variable [1] : string,
+                                     idx [1] : integer)
+;                             return val [1] : string
+; Arguments:
+;         @brief Reconstructs the current (idx) dictionary keys
+;         @param variable  -  Current variable
+;         @param idx  -  The index to the current model
+;         @param field  -  Current field type
+local verbosity, idx_var, dictkeys_local_copy
+begin
+    verbosity  = stringtointeger(getenv("ESMValTool_verbosity"))
+    info_output("<<<<<<<< Entering interface_get_dictkeys", verbosity, 4)
+    dictkeys_local_copy = interface_replace_place_holders(variable, "NO_FIELD", idx, dictkeys@dictkeys)
+    info_output(">>>>>>>> Leaving interface_get_dictkeys", verbosity, 4)
+    return dictkeys_local_copy
+end
+
+undef("interface_get_dictkeys_no_var")
+function interface_get_dictkeys_no_var(idx [1] : integer)
+;                             return val [1] : string
+; Arguments:
+;         @brief Reconstructs the current (idx) dictionary keys
+;         @param idx  -  The index to the current model
+;         @param field  -  Current field type
+local verbosity, idx_var, dictkeys_local_copy
+begin
+    verbosity  = stringtointeger(getenv("ESMValTool_verbosity"))
+    info_output("<<<<<<<< Entering interface_get_dictkeys", verbosity, 4)
+    dictkeys_local_copy = interface_replace_place_holders("default", "NO_FIELD", idx, dictkeys@dictkeys)
+    info_output(">>>>>>>> Leaving interface_get_dictkeys", verbosity, 4)
+    return dictkeys_local_copy
+end
+
+undef("noop")
+procedure noop()
+; no-operation
+begin
+end
+
+; == Wrapper definitions used extend/redefine existing NCL routines ==
+
+undef("addfile_wrapper")
+function addfile_wrapper(filename [1]: string, operation [1]:string)
+;                       return [file]: file_handle
+; Description:
+;         Logs any file access using the addfile function to a log file.
+;         To use the wrapper, run the following line to replace all
+;          addfile-occurances
+;
+; find . -type f -name '*ncl' ! -iregex '.*to_be_checked.*' -exec sed -i 's/addfile/addfile_wrapper/g' {} \;
+;
+local fhandle, logfile, datestamp, use_addfile_wrapper
+begin
+    verbosity  = stringtointeger(getenv("ESMValTool_verbosity"))
+    info_output("<<<<<<<< Entering addfile_wrapper", verbosity, 4)
+
+    logfile = "addfile_access.log"
+    datestamp = systemfunc("date -u")
+    operation = str_lower(operation)
+    if (operation .eq. "r") then
+        logfile_prefix = "'READ:   '"
+    else if (operation .eq. "w") then
+        logfile_prefix = "'WRITE:  '"
+    else if (operation .eq. "c") then
+        logfile_prefix = "'CREATE: '"
+    end if
+    end if
+    end if
+
+    system("echo " + datestamp + "  --  " + logfile_prefix + filename + " >> " + logfile)
+    fhandle = addfile(filename, operation)
+
+    info_output(">>>>>>>> Leaving addfile_wrapper", verbosity, 4)
+    return fhandle
+end
+
+undef("isfilepresent_esmval")
+function isfilepresent_esmval(file_path [1]: string)
+;                             return_val [dimsizes(file_path)] :  logical
+; Description
+;         Wrapper introduced to handle the backwards-incompatitable changes
+;         introduced in NCL v6.2.1, see the official announcement for details,
+;
+; http://www.ncl.ucar.edu/current_release.shtml#BackwardsIncompatibleChanges6.2.1
+;
+;         This wrapper checks the existance of any path for any NCL version,
+;         i.e., pre- and post- version 6.2.1).
+; Arguments:
+;         @brief isfilepresent(...) work-around for NCL v6.2.1 code changes
+;         @param file_path  -  single path as string to check for existence
+local ASCII_ZERO,   FILEEXISTS_MIN_VERSION,  file_is_present,\
+    ncl_version,  temp_char,               temp_int_1,\
+    temp_int_2,   temp_str,                use_fileexists
+begin
+    ASCII_ZERO = 48  ; Used for char to int single digit conversion
+    FILEEXISTS_MIN_VERSION = (/6, 2, 1/)  ;; 'fileexists' only available
+                                          ;; in 6.2.1+
+
+    ;; Get NCL version, to determine whether to use 'fileexists' or
+    ;; 'isFilePresent'
+
+    ncl_version = (/0, 0, 0/)  ; Start with an undefined value
+    temp_str = get_ncl_version()
+    temp_char = stringtochar(temp_str)
+    ncl_version(0) = chartointeger(temp_char(0))\
+                      - ASCII_ZERO  ; Convert ascii to 0-9
+    ncl_version(1) = chartointeger(temp_char(2))\
+                      - ASCII_ZERO  ; Convert ascii to 0-9
+    ncl_version(2) = chartointeger(temp_char(4))\
+                      - ASCII_ZERO  ; Convert ascii to 0-9
+
+    ;; Determine whether version is sufficient for use of 'fileexists'
+    temp_int_1 = ncl_version(0) * 100\
+                 + ncl_version(1) * 10\
+                 + ncl_version(2)
+    temp_int_2 = FILEEXISTS_MIN_VERSION(0) * 100\
+                 + FILEEXISTS_MIN_VERSION(1) * 10\
+                 + FILEEXISTS_MIN_VERSION(2)
+    use_fileexists = temp_int_1.ge.temp_int_2
+
+    ;; Set default return value
+    file_is_present = False
+
+    if (use_fileexists) then  ; Only for version >= 6.2.1
+        if (fileexists(file_path)) then
+            file_is_present = True
+        end if
+    else
+        if (isfilepresent(file_path)) then  ; Only for version < 6.2.1
+            file_is_present = True
+        end if
+    end if
+    return file_is_present
+end

--- a/esmvaltool/main.py
+++ b/esmvaltool/main.py
@@ -215,6 +215,7 @@ def process_namelist(namelist_file, global_config):
     namelist = read_namelist_file(namelist_file, global_config)
     # run (only preprocessors for now) # TODO: also run diagnostics from here
     logger.debug("Namelist summary:\n%s", namelist)
+    logger.info("Running preprocessor")
     namelist.run()
 
     os.environ['0_ESMValTool_version'] = __version__
@@ -332,8 +333,8 @@ def process_namelist(namelist_file, global_config):
             os.makedirs(interface_data)
             ext = 'ncl' if script.lower().endswith('.ncl') else 'yml'
             cfg_file = os.path.join(interface_data, 'settings.' + ext)
-            logger.info("with configuration file: %s", cfg_file)
             if ext != 'ncl':
+                logger.info("with configuration file: %s", cfg_file)
                 write_settings(script_cfg['settings'], cfg_file)
             else:
                 write_legacy_ncl_interface(

--- a/esmvaltool/namelist.py
+++ b/esmvaltool/namelist.py
@@ -193,9 +193,12 @@ def get_single_model_task(variable, settings, user_config):
     check_data_availability(input_files, variable['start_year'],
                             variable['end_year'])
 
+    logger.info("Using input files:\n%s", '\n'.join(input_files))
+
     # Configure saving to output files
     output_file = get_output_file(
         variable=variable, preproc_dir=user_config['preproc_dir'])
+    logger.info("Output will be written to:\n%s", output_file)
 
     cfg['save'] = {
         'target': output_file,
@@ -398,13 +401,13 @@ class Namelist(object):
 
     def initialize_tasks(self):
         """Define tasks in namelist"""
-        logger.debug("Creating tasks from namelist")
+        logger.info("Creating tasks from namelist")
 
         tasks = []
 
         all_preproc_tasks = {}
         for diagnostic_name, diagnostic in self.diagnostics.items():
-            logger.debug("Creating tasks for diagnostic %s", diagnostic_name)
+            logger.info("Creating tasks for diagnostic %s", diagnostic_name)
 
             # Create preprocessor tasks
             for variable_name in diagnostic['variables']:

--- a/esmvaltool/namelist.py
+++ b/esmvaltool/namelist.py
@@ -8,12 +8,13 @@ import os
 import yaml
 
 from .interface_scripts.data_finder import (
-    get_input_filelist, get_input_filename, get_output_file)
+    get_input_filelist, get_input_filename, get_output_file,
+    get_start_end_year)
 from .interface_scripts.preprocessing_tools import merge_callback
 from .preprocessor import (DEFAULT_ORDER, PreprocessingTask,
                            select_multi_model_settings,
                            select_single_model_settings)
-from .preprocessor._download import get_start_end_year, synda_search
+from .preprocessor._download import synda_search
 from .preprocessor._reformat import CMOR_TABLES
 from .task import DiagnosticTask
 

--- a/esmvaltool/namelist.py
+++ b/esmvaltool/namelist.py
@@ -103,7 +103,9 @@ def _add_cmor_info(variable, keys):
             variable['mip'], variable['short_name'])
         for key in keys:
             if key not in variable and hasattr(variable_info, key):
-                variable[key] = getattr(variable_info, key)
+                value = getattr(variable_info, key)
+                if value is not None:
+                    variable[key] = value
 
 
 def get_single_model_settings(variable):
@@ -313,7 +315,7 @@ class Namelist(object):
                 for key in ['mip'] + cmor_keys:
                     if key not in variable:
                         value = _get_value(key, variables[variable_name])
-                        if value:
+                        if value is not None:
                             variable[key] = value
 
         return variables

--- a/esmvaltool/namelists/namelist_perfmetrics_CMIP5.yml
+++ b/esmvaltool/namelists/namelist_perfmetrics_CMIP5.yml
@@ -91,7 +91,8 @@ diagnostics:
     variables:
       ta:
         preprocessor: pp850
-        reference_model: [ERA-Interim, NCEP]
+        reference_model: ERA-Interim
+        alternative_model: NCEP
         mip: Amon
         field: T3M
     additional_models:

--- a/esmvaltool/namelists/namelist_perfmetrics_CMIP5_short.yml
+++ b/esmvaltool/namelists/namelist_perfmetrics_CMIP5_short.yml
@@ -23,10 +23,10 @@
 ---
 
 models:
-  - {model: bcc-csm1-1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2002}
-  - {model: GFDL-ESM2G,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2002}
-  - {model: MPI-ESM-LR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2002}
-  - {model: MPI-ESM-MR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2002}
+  - {model: bcc-csm1-1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+  - {model: GFDL-ESM2G,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+  - {model: MPI-ESM-LR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+  - {model: MPI-ESM-MR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
 
 preprocessors:
   pp850:

--- a/esmvaltool/namelists/namelist_perfmetrics_CMIP5_short.yml
+++ b/esmvaltool/namelists/namelist_perfmetrics_CMIP5_short.yml
@@ -45,7 +45,8 @@ diagnostics:
     variables:
       ta:
         preprocessor: pp850
-        reference_model: [ERA-Interim, NCEP]
+        reference_model: ERA-Interim
+        alternative_model: NCEP
         mip: Amon
         field: T3M
     additional_models:

--- a/esmvaltool/namelists/namelist_perfmetrics_CMIP5_short.yml
+++ b/esmvaltool/namelists/namelist_perfmetrics_CMIP5_short.yml
@@ -73,3 +73,12 @@ diagnostics:
         MultiModelMedian: true         # Multi-model median
         metric: RMSD                   # Metric ("RMSD", "BIAS")
         normalization: centered_median # Normalization ("mean", "median", "centered_median")
+
+  grading_collect:
+    script: perfmetrics_grading_collect.ncl
+    ancestors: ['*/grading']
+    label_bounds: [-0.5, 0.5]
+    label_scale: 0.1
+    disp_values: false
+    cm_interval: [2, 241]
+    sort: true  # Sort model in alphabetic order (excluding MMM)

--- a/esmvaltool/preprocessor/__init__.py
+++ b/esmvaltool/preprocessor/__init__.py
@@ -60,8 +60,8 @@ def _save_cubes(cubes, **args):
 
     if (os.path.exists(filename)
             and all(cube.has_lazy_data() for cube in cubes)):
-        logger.info("Not saving cubes %s to %s to avoid data loss. "
-                    "The cube is probably unchanged.", cubes, filename)
+        logger.debug("Not saving cubes %s to %s to avoid data loss. "
+                     "The cube is probably unchanged.", cubes, filename)
     else:
         logger.debug("Saving cubes %s to %s", cubes, filename)
         iris.save(cubes, **args)

--- a/esmvaltool/preprocessor/__init__.py
+++ b/esmvaltool/preprocessor/__init__.py
@@ -265,7 +265,8 @@ class PreprocessingTask(AbstractTask):
         # specified in self.run(input_data), use default
         if not self.ancestors and not input_data:
             input_data = self._input_data
-        self.output_data = preprocess(input_data, settings, debug=self.debug)
+        output_data = preprocess(input_data, settings, debug=self.debug) 
+        return output_data
 
     def __str__(self):
         """Get human readable description."""

--- a/esmvaltool/preprocessor/__init__.py
+++ b/esmvaltool/preprocessor/__init__.py
@@ -265,7 +265,7 @@ class PreprocessingTask(AbstractTask):
         # specified in self.run(input_data), use default
         if not self.ancestors and not input_data:
             input_data = self._input_data
-        output_data = preprocess(input_data, settings, debug=self.debug) 
+        output_data = preprocess(input_data, settings, debug=self.debug)
         return output_data
 
     def __str__(self):

--- a/esmvaltool/task.py
+++ b/esmvaltool/task.py
@@ -20,7 +20,7 @@ class AbstractTask(object):
                 input_data = []
             for task in self.ancestors:
                 input_data.extend(task.run())
-            self._run(input_data)
+            self.output_data = self._run(input_data)
 
         return self.output_data
 
@@ -66,8 +66,8 @@ class DiagnosticTask(AbstractTask):
         """Run the diagnostic script."""
         # Run only preprocessor
         if self.script is None:
-            self.output_data = []
-            return
+            output_data = []
+            return output_data
 
         self.settings['input_files'] = input_data
 

--- a/esmvaltool/version.py
+++ b/esmvaltool/version.py
@@ -1,0 +1,2 @@
+"""ESMValTool version"""
+__version__ = '2.0.0'


### PR DESCRIPTION
I started to work on the simplified launchers. Some first improvements:

- Write ncl interface without template file
- Write variable info from namelist, closes #174 
- Create output from preprocessors in proproc/preprocessor_name directory to avoid collisions, closes #163
- Clean up data_finder.py

Note that while the grading_collect script is now in namelists/namelist_perfmetrics_CMIP5_short.yml, it does not yet work.
