### PR TITLE
Refactoring multi model mean

### DIFF
--- a/esmvaltool/interface_scripts/auxiliary.py
+++ b/esmvaltool/interface_scripts/auxiliary.py
@@ -9,12 +9,12 @@ def ncl_version_check():
     """ @brief Check the NCL version"""
     try:
         cmd = ['ncl', '-V']
-        version = subprocess.check_output(cmd)
+        version = subprocess.check_output(cmd, universal_newlines=True)
     except subprocess.CalledProcessError:
         logger.error("Failed to execute '%s'", ' '.join(cmd))
         raise
 
-    version = version.decode(sys.stdout.encoding)
+    #version = version.decode(sys.stdout.encoding)
 
     if version == "6.3.0":
         logger.error("NCL version " + version + " not supported due to a bug "

--- a/esmvaltool/interface_scripts/auxiliary.py
+++ b/esmvaltool/interface_scripts/auxiliary.py
@@ -14,8 +14,6 @@ def ncl_version_check():
         logger.error("Failed to execute '%s'", ' '.join(cmd))
         raise
 
-    #version = version.decode(sys.stdout.encoding)
-
     if version == "6.3.0":
         logger.error("NCL version " + version + " not supported due to a bug "
                      + "(see Known Issues in the ESMValTool user guide)")

--- a/esmvaltool/namelist.py
+++ b/esmvaltool/namelist.py
@@ -26,6 +26,23 @@ logger = logging.getLogger(__name__)
 
 TASKSEP = os.sep
 
+def run_once(f):
+    """
+    Decorator to call/execute a function f
+    only once if the output is identical
+    everytime; single output is only elem of m.
+    """
+    m = []
+    def wrapper(*args, **kwargs):
+        if not wrapper.has_run:
+            wrapper.has_run = True
+            y = f(*args, **kwargs)
+            m.append(y)
+            return m[0]
+        else:
+            return m[0]
+    wrapper.has_run = False
+    return wrapper
 
 class NamelistError(Exception):
     """Namelist contains an error."""
@@ -201,6 +218,7 @@ def _add_cmor_info(variable, keys):
                     variable[key] = value
 
 
+@run_once
 def _update_target_grid(variable, all_variables, settings, config_user):
     """Replace the target grid model name with a filename if needed.
 
@@ -224,8 +242,9 @@ def _update_target_grid(variable, all_variables, settings, config_user):
                 rootpath=config_user['rootpath'],
                 drs=config_user['drs'])
             target_file = files[0]
-            settings['regrid']['target_grid'] = target_file
-            return
+            #decorator needs file output
+            #settings['regrid']['target_grid'] = target_file
+            return target_file
 
 
 def _get_default_settings(variable, config_user):
@@ -360,11 +379,12 @@ def _get_preprocessor_settings(variables, preprocessors, config_user):
         settings = _get_default_settings(variable, config_user)
         _apply_preprocessor_settings(settings, profile_settings)
         # if the target grid is a model name, replace it with a file name
-        _update_target_grid(
-            variable=variable,
-            all_variables=variables,
-            settings=settings,
-            config_user=config_user)
+        tgt_file = _update_target_grid(
+                       variable=variable,
+                       all_variables=variables,
+                       settings=settings,
+                       config_user=config_user)
+        settings['regrid']['target_grid'] = tgt_file
         if 'derive' in settings:
             # create two pairs of settings?
             pass

--- a/esmvaltool/namelist.py
+++ b/esmvaltool/namelist.py
@@ -325,7 +325,9 @@ def _apply_preprocessor_settings(settings, profile_settings):
 
 def _update_multi_model_mean(variables, settings, config_user):
     """Configure multi model mean."""
-    if 'multi_model_mean' in settings:
+    if settings.get('multi_model_mean', False):
+        if settings['multi_model_mean'] is True:
+            settings['multi_model_mean'] = {}
         variable = variables[0]
         filename = os.path.join(
             os.path.dirname(variable['filename']), 'multi_model_statistics.nc')
@@ -334,13 +336,11 @@ def _update_multi_model_mean(variables, settings, config_user):
         for key in 'reference_model', 'alternative_model':
             if key in variable:
                 exclude_models.add(variable[key])
-        exclude = {
-            '_filename': [
-                get_output_file(v, config_user['preproc_dir'])
-                for v in variables if v['model'] in exclude_models
-            ]
+        exclude_files = {
+            v['filename']
+            for v in variables if v['model'] in exclude_models
         }
-        settings['multi_model_mean']['exclude'] = exclude
+        settings['multi_model_mean']['exclude'] = {'_filename': exclude_files}
 
 
 def _get_preprocessor_settings(variables, preprocessors, config_user):

--- a/esmvaltool/namelist.py
+++ b/esmvaltool/namelist.py
@@ -26,23 +26,6 @@ logger = logging.getLogger(__name__)
 
 TASKSEP = os.sep
 
-def run_once(f):
-    """
-    Decorator to call/execute a function f
-    only once if the output is identical
-    everytime; single output is only elem of m.
-    """
-    m = []
-    def wrapper(*args, **kwargs):
-        if not wrapper.has_run:
-            wrapper.has_run = True
-            y = f(*args, **kwargs)
-            m.append(y)
-            return m[0]
-        else:
-            return m[0]
-    wrapper.has_run = False
-    return wrapper
 
 class NamelistError(Exception):
     """Namelist contains an error."""
@@ -218,7 +201,6 @@ def _add_cmor_info(variable, keys):
                     variable[key] = value
 
 
-@run_once
 def _update_target_grid(variable, all_variables, settings, config_user):
     """Replace the target grid model name with a filename if needed.
 
@@ -242,9 +224,8 @@ def _update_target_grid(variable, all_variables, settings, config_user):
                 rootpath=config_user['rootpath'],
                 drs=config_user['drs'])
             target_file = files[0]
-            #decorator needs file output
-            #settings['regrid']['target_grid'] = target_file
-            return target_file
+            settings['regrid']['target_grid'] = target_file
+            return
 
 
 def _get_default_settings(variable, config_user):
@@ -379,12 +360,11 @@ def _get_preprocessor_settings(variables, preprocessors, config_user):
         settings = _get_default_settings(variable, config_user)
         _apply_preprocessor_settings(settings, profile_settings)
         # if the target grid is a model name, replace it with a file name
-        tgt_file = _update_target_grid(
-                       variable=variable,
-                       all_variables=variables,
-                       settings=settings,
-                       config_user=config_user)
-        settings['regrid']['target_grid'] = tgt_file
+        _update_target_grid(
+            variable=variable,
+            all_variables=variables,
+            settings=settings,
+            config_user=config_user)
         if 'derive' in settings:
             # create two pairs of settings?
             pass

--- a/esmvaltool/namelists/namelist_perfmetrics_CMIP5.yml
+++ b/esmvaltool/namelists/namelist_perfmetrics_CMIP5.yml
@@ -84,6 +84,8 @@ preprocessors:
       scheme: linear
     mask_fillvalues:
       threshold_fraction: 0.95
+    multi_model_mean:
+      span: overlap
 
 diagnostics:
   ta_850_global:

--- a/esmvaltool/namelists/namelist_perfmetrics_CMIP5_short.yml
+++ b/esmvaltool/namelists/namelist_perfmetrics_CMIP5_short.yml
@@ -38,6 +38,8 @@ preprocessors:
       scheme: linear
     mask_fillvalues:
       threshold_fraction: 0.95
+    multi_model_mean:
+      span: overlap
 
 diagnostics:
   ta_850_global:

--- a/esmvaltool/namelists/namelist_perfmetrics_CMIP5_short.yml
+++ b/esmvaltool/namelists/namelist_perfmetrics_CMIP5_short.yml
@@ -39,7 +39,8 @@ preprocessors:
     mask_fillvalues:
       threshold_fraction: 0.95
     multi_model_mean:
-      span: overlap
+      span: overlap #or full
+      exclude: {GFDL-ESM2G}
 
 diagnostics:
   ta_850_global:

--- a/esmvaltool/preprocessor/_multimodel.py
+++ b/esmvaltool/preprocessor/_multimodel.py
@@ -3,6 +3,7 @@ import logging
 from functools import reduce
 
 import os
+import datetime
 import iris
 import numpy as np
 
@@ -19,13 +20,31 @@ def _put_in_cube(stats, stats_name, ncfiles, fname):
     return stats_cube
 
 
+def _sdat(srl_no):
+    """convert to a datatime point"""
+    new_date = datetime.datetime(1950, 1, 1, 0) +\
+        datetime.timedelta(srl_no)
+    return new_date
+
+
 def _get_overlap(cubes):
     """Get discrete time overlaps."""
     all_times = [cube.coord('time').points for cube in cubes]
-    bounds = [range(int(np.min(b)), int(np.max(b)) + 1) for b in all_times]
+    bounds = [range(int(b[0]), int(b[-1]) + 1) for b in all_times]
     time_pts = reduce(np.intersect1d, (i for i in bounds))
     if len(time_pts) > 1:
-        return time_pts[0], time_pts[-1]
+        print(_sdat(time_pts[0]), _sdat(time_pts[-1]))
+        return _sdat(time_pts[0]), _sdat(time_pts[-1])
+
+
+def _slice_cube(cube, min_t, max_t):
+    """slice cube on time"""
+    irisConstr = 
+        iris.Constraint(time=lambda x:
+                        min_t <= datetime.datetime.strptime(x.point.strftime('%Y-%m-%d-%H'),
+                                                            '%Y-%m-%d-%H') <= max_t)
+    cube_slice = cube.extract(irisConstr)
+    return cube_slice
 
 
 def multi_model_mean(cubes, span, filename, exclude):
@@ -59,12 +78,13 @@ def multi_model_mean(cubes, span, filename, exclude):
         # look at overlap type
         if span == 'overlap':
             tx1, tx2 = _get_overlap(cubes)
+            print(tx1, tx2)
             for cube in selection:
                 logger.debug("Using common time overlap between "
                              "models to compute statistics.")
                 # slice cube on time
-                cube = cube.extract(iris.Constraint(
-                    time=lambda t: t.point > tx1 and t.point < tx2))
+                with iris.FUTURE.context(cell_datetime_objects=True):
+                    cube = _slice_cube(cube, tx1, tx2)
 
                 # store nr time points
                 data_size.append(len(list(cube.coord('time').points)))

--- a/esmvaltool/preprocessor/_multimodel.py
+++ b/esmvaltool/preprocessor/_multimodel.py
@@ -33,7 +33,6 @@ def _get_overlap(cubes):
     bounds = [range(int(b[0]), int(b[-1]) + 1) for b in all_times]
     time_pts = reduce(np.intersect1d, (i for i in bounds))
     if len(time_pts) > 1:
-        print(_sdat(time_pts[0]), _sdat(time_pts[-1]))
         return _sdat(time_pts[0]), _sdat(time_pts[-1])
 
 
@@ -78,10 +77,10 @@ def multi_model_mean(cubes, span, filename, exclude):
         # look at overlap type
         if span == 'overlap':
             tx1, tx2 = _get_overlap(cubes)
-            print(tx1, tx2)
             for cube in selection:
                 logger.debug("Using common time overlap between "
                              "models to compute statistics.")
+                logger.debug("Bounds: %s and %s", str(tx1), str(tx2))
                 # slice cube on time
                 with iris.FUTURE.context(cell_datetime_objects=True):
                     cube = _slice_cube(cube, tx1, tx2)

--- a/esmvaltool/preprocessor/_multimodel.py
+++ b/esmvaltool/preprocessor/_multimodel.py
@@ -25,7 +25,7 @@ def _get_overlap(cubes):
 def multi_model_mean(cubes, span, filename, exclude):
     """Compute multi-model mean and median."""
 
-    logger.debug('Multi model statistics: excluding: %s' % str(exclude))
+    logger.debug('Multi model statistics: excluding files: %s' % str(exclude))
     selection = [
         cube for cube in cubes
         if not all(cube.attributes.get(k) in exclude[k] for k in exclude)
@@ -38,6 +38,7 @@ def multi_model_mean(cubes, span, filename, exclude):
     means = []
     medians = []
     data_size = []
+    file_names = []
     tx1, tx2 = _get_overlap(cubes)
 
     # check if we have any time overlap
@@ -47,6 +48,8 @@ def multi_model_mean(cubes, span, filename, exclude):
         return cubes
 
     for cube in selection:
+        file_name = cube.attributes.get('_filename').split('/')[-1]
+        file_names.append(file_name)
         for coord in cube.coords():
             if coord.standard_name == 'time':
                 if span == 'overlap':
@@ -89,14 +92,17 @@ def multi_model_mean(cubes, span, filename, exclude):
     logger.debug("Global means: %s", means)
     means_cube = iris.cube.Cube(means, long_name='means')
     means_cube.attributes['_filename'] = filename
+    means_cube.attributes['NCfiles'] = str(file_names)
 
     logger.debug("Global medians: %s", medians)
     medians_cube = iris.cube.Cube(medians, long_name='medians')
     medians_cube.attributes['_filename'] = filename
+    medians_cube.attributes['NCfiles'] = str(file_names)
 
     logger.debug("Data sizes: %s", data_size)
     datasize_cube = iris.cube.Cube(data_size, long_name='data_size')
     datasize_cube.attributes['_filename'] = filename
+    datasize_cube.attributes['NCfiles'] = str(file_names)
 
     save_cubes([means_cube, medians_cube, datasize_cube])
 

--- a/esmvaltool/preprocessor/_multimodel.py
+++ b/esmvaltool/preprocessor/_multimodel.py
@@ -9,19 +9,23 @@ from ._io import save_cubes
 
 logger = logging.getLogger(__name__)
 
-
 def _get_overlap(cubes):
     """Get discrete time overlaps."""
     all_times = [cube.coord('time').points for cube in cubes]
     bounds = [range(int(np.min(b)), int(np.max(b)) + 1) for b in all_times]
     time_pts = reduce(np.intersect1d, (i for i in bounds))
-    t1 = time_pts[0]
-    t2 = time_pts[-1]
-    return t1, t2
+    if len(time_pts) > 1:
+        t1 = time_pts[0]
+        t2 = time_pts[-1]
+        return t1, t2
+    else:
+        return 0, 0
 
 
-def multi_model_mean(cubes, span, filename, exclude=None):
+def multi_model_mean(cubes, span, filename, exclude):
     """Compute multi-model mean and median."""
+
+    logger.debug('Multi model statistics: excluding: %s' % str(exclude))
     selection = [
         cube for cube in cubes
         if not all(cube.attributes.get(k) in exclude[k] for k in exclude)
@@ -33,35 +37,67 @@ def multi_model_mean(cubes, span, filename, exclude=None):
 
     means = []
     medians = []
+    data_size = []
     tx1, tx2 = _get_overlap(cubes)
+
+    # check if we have any time overlap
+    if tx1 == tx2:
+        logger.info("Time overlap between cubes is none or a single point.")
+        logger.info("check models: will not compute statistics.")
+        return cubes
 
     for cube in selection:
         for coord in cube.coords():
             if coord.standard_name == 'time':
                 if span == 'overlap':
+
+                    logger.debug("Using common time overlap between models to compute statistics.")
+                    # find the nearest points to the overlap region
                     all_times = list(cube.coord('time').points)
                     a1 = min(all_times, key=lambda x: abs(x - tx1))
                     a2 = min(all_times, key=lambda x: abs(x - tx2))
                     i1 = all_times.index(a1)
                     i2 = all_times.index(a2)
-                    cmean = np.mean(cube.data[i1:i2, :, :])
-                    cmedian = np.median(cube.data[i1:i2, :, :])
-                    means.append(cmean)
-                    medians.append(cmedian)
-                elif span == 'full':
-                    cmean = np.mean(cube.data)
-                    cmedian = np.median(cube.data)
+                    logger.debug("Indexing time axis for overlap on indices %i and %i of %i" % (i1,i2,len(all_times)-1))
+
+                    # index data on these points and
+                    # get rid of masked values
+                    flat_data = cube.data[i1:i2+1,:,:]
+                    cdata = flat_data[~flat_data.mask]
+                    data_size.append(cdata.shape[0])
+
+                    # compute stats and append to lists
+                    cmean = np.mean(cdata)
+                    cmedian = np.median(cdata)
                     means.append(cmean)
                     medians.append(cmedian)
 
-    logger.info("Global means: %s", means)
+                elif span == 'full':
+
+                    logger.debug("Using full time spans to compute statistics.")
+                    # get rid of masked
+                    flat_data = cube.data
+                    cdata = flat_data[~flat_data.mask]
+                    data_size.append(cdata.shape[0])
+
+                    # compute stats and append to lists
+                    cmean = np.mean(cdata)
+                    cmedian = np.median(cdata)
+                    means.append(cmean)
+                    medians.append(cmedian)
+
+    logger.debug("Global means: %s", means)
     means_cube = iris.cube.Cube(means, long_name='means')
     means_cube.attributes['_filename'] = filename
 
-    logger.info("Global medians: %s", medians)
+    logger.debug("Global medians: %s", medians)
     medians_cube = iris.cube.Cube(medians, long_name='medians')
     medians_cube.attributes['_filename'] = filename
 
-    save_cubes([means_cube, medians_cube])
+    logger.debug("Data sizes: %s", data_size)
+    datasize_cube = iris.cube.Cube(data_size, long_name='data_size')
+    datasize_cube.attributes['_filename'] = filename
+
+    save_cubes([means_cube, medians_cube, datasize_cube])
 
     return cubes

--- a/esmvaltool/preprocessor/_multimodel.py
+++ b/esmvaltool/preprocessor/_multimodel.py
@@ -1,6 +1,67 @@
 """Functions for multi-model operations"""
+import logging
+from functools import reduce
+
+import iris
+import numpy as np
+
+from ._io import save_cubes
+
+logger = logging.getLogger(__name__)
 
 
-def multi_model_mean(cubes):
-    """Compute multi-model mean"""
-    raise NotImplementedError
+def _get_overlap(cubes):
+    """Get discrete time overlaps."""
+    all_times = [cube.coord('time').points for cube in cubes]
+    bounds = [range(int(np.min(b)), int(np.max(b)) + 1) for b in all_times]
+    time_pts = reduce(np.intersect1d, (i for i in bounds))
+    t1 = time_pts[0]
+    t2 = time_pts[-1]
+    return t1, t2
+
+
+def multi_model_mean(cubes, span, filename, exclude=None):
+    """Compute multi-model mean and median."""
+    selection = [
+        cube for cube in cubes
+        if not all(cube.attributes.get(k) in exclude[k] for k in exclude)
+    ]
+
+    if len(selection) < 2:
+        logger.info("Single model in list: will not compute statistics.")
+        return cubes
+
+    means = []
+    medians = []
+    tx1, tx2 = _get_overlap(cubes)
+
+    for cube in selection:
+        for coord in cube.coords():
+            if coord.standard_name == 'time':
+                if span == 'overlap':
+                    all_times = list(cube.coord('time').points)
+                    a1 = min(all_times, key=lambda x: abs(x - tx1))
+                    a2 = min(all_times, key=lambda x: abs(x - tx2))
+                    i1 = all_times.index(a1)
+                    i2 = all_times.index(a2)
+                    cmean = np.mean(cube.data[i1:i2, :, :])
+                    cmedian = np.median(cube.data[i1:i2, :, :])
+                    means.append(cmean)
+                    medians.append(cmedian)
+                elif span == 'full':
+                    cmean = np.mean(cube.data)
+                    cmedian = np.median(cube.data)
+                    means.append(cmean)
+                    medians.append(cmedian)
+
+    logger.info("Global means: %s", means)
+    means_cube = iris.cube.Cube(means, long_name='means')
+    means_cube.attributes['_filename'] = filename
+
+    logger.info("Global medians: %s", medians)
+    medians_cube = iris.cube.Cube(medians, long_name='medians')
+    medians_cube.attributes['_filename'] = filename
+
+    save_cubes([means_cube, medians_cube])
+
+    return cubes

--- a/esmvaltool/preprocessor/_multimodel.py
+++ b/esmvaltool/preprocessor/_multimodel.py
@@ -3,7 +3,8 @@ import logging
 from functools import reduce
 
 import os
-import datetime
+from datetime import datetime as dd
+from datetime import timedelta as td
 import iris
 import numpy as np
 
@@ -22,8 +23,7 @@ def _put_in_cube(stats, stats_name, ncfiles, fname):
 
 def _sdat(srl_no):
     """convert to a datatime point"""
-    new_date = datetime.datetime(1950, 1, 1, 0) +\
-        datetime.timedelta(srl_no)
+    new_date = dd(1950, 1, 1, 0) + td(srl_no)
     return new_date
 
 
@@ -39,11 +39,11 @@ def _get_overlap(cubes):
 
 def _slice_cube(cube, min_t, max_t):
     """slice cube on time"""
-    irisConstr = 
-        iris.Constraint(time=lambda x:
-                        min_t <= datetime.datetime.strptime(x.point.strftime('%Y-%m-%d-%H'),
-                                                            '%Y-%m-%d-%H') <= max_t)
-    cube_slice = cube.extract(irisConstr)
+    fmt = '%Y-%m-%d-%H'
+    ctr = iris.Constraint(time=lambda x:
+                          min_t <= dd.strptime(x.point.strftime(fmt),
+                                               fmt) <= max_t)
+    cube_slice = cube.extract(ctr)
     return cube_slice
 
 

--- a/esmvaltool/preprocessor/_multimodel.py
+++ b/esmvaltool/preprocessor/_multimodel.py
@@ -2,6 +2,7 @@
 import logging
 from functools import reduce
 
+import os
 import iris
 import numpy as np
 
@@ -10,17 +11,28 @@ from ._io import save_cubes
 logger = logging.getLogger(__name__)
 
 
+def _find_index(flist, idm):
+    """Find nearest element to idm in flist"""
+    max_t = min(flist, key=lambda x: abs(x - idm))
+    id_min = flist.index(max_t)
+    return id_min
+
+
+def _put_in_cube(stats, stats_name, ncfiles, fname):
+    """quick cube building"""
+    stats_cube = iris.cube.Cube(stats, long_name=stats_name)
+    stats_cube.attributes['_filename'] = fname
+    stats_cube.attributes['NCfiles'] = str(ncfiles)
+    return stats_cube
+
+
 def _get_overlap(cubes):
     """Get discrete time overlaps."""
     all_times = [cube.coord('time').points for cube in cubes]
     bounds = [range(int(np.min(b)), int(np.max(b)) + 1) for b in all_times]
     time_pts = reduce(np.intersect1d, (i for i in bounds))
     if len(time_pts) > 1:
-        time1 = time_pts[0]
-        time2 = time_pts[-1]
-        return time1, time2
-    else:
-        return 0, 0
+        return time_pts[0], time_pts[-1]
 
 
 def multi_model_mean(cubes, span, filename, exclude):
@@ -35,80 +47,71 @@ def multi_model_mean(cubes, span, filename, exclude):
         logger.info("Single model in list: will not compute statistics.")
         return cubes
 
-    means = []
-    medians = []
-    data_size = []
-    file_names = []
-    tx1, tx2 = _get_overlap(cubes)
-
     # check if we have any time overlap
-    if tx1 == tx2:
+    if _get_overlap(cubes) is None:
         logger.info("Time overlap between cubes is none or a single point.")
         logger.info("check models: will not compute statistics.")
         return cubes
+    else:
+        # empty lists to hold data
+        means = []
+        medians = []
+        data_size = []
 
-    for cube in selection:
-        file_name = cube.attributes.get('_filename').split('/')[-1]
-        file_names.append(file_name)
-        for coord in cube.coords():
-            if coord.standard_name == 'time':
-                if span == 'overlap':
+        # add file name info
+        file_names = [
+            os.path.basename(cube.attributes.get('_filename'))
+            for cube in cubes
+        ]
 
-                    logger.debug("Using common time overlap between \
-                                 models to compute statistics.")
-                    # find the nearest points to the overlap region
-                    all_times = list(cube.coord('time').points)
-                    min_t = min(all_times, key=lambda x: abs(x - tx1))
-                    max_t = min(all_times, key=lambda x: abs(x - tx2))
-                    id_min = all_times.index(min_t)
-                    id_max = all_times.index(max_t)
-                    tot = len(all_times) - 1
-                    logger.debug("Indexing time axis for overlap on \
-                                 indices %i and %i \
-                                 of %i", id_min, id_max, tot)
+        # look at overlap type
+        if span == 'overlap':
+            tx1, tx2 = _get_overlap(cubes)
+            for cube in selection:
+                logger.debug("Using common time overlap between "
+                             "models to compute statistics.")
+                # find the nearest points to the overlap region
+                id_min = _find_index(list(cube.coord('time').points), tx1)
+                id_max = _find_index(list(cube.coord('time').points), tx2)
+                logger.debug("Indexing time axis for overlap on "
+                             "indices %i and %i "
+                             "of %i", id_min, id_max,
+                             len(list(cube.coord('time').points)) - 1)
 
-                    # index data on these points and
-                    # get rid of masked values
-                    flat_data = cube.data[id_min:id_max + 1, :, :]
-                    cdata = flat_data[~flat_data.mask]
-                    data_size.append(cdata.shape[0])
+                # index data on these points and
+                # get rid of masked values
+                flat_data = cube.data[id_min:id_max + 1, :, :]
+                data_size.append(flat_data[~flat_data.mask].shape[0])
 
-                    # compute stats and append to lists
-                    cmean = np.mean(cdata)
-                    cmedian = np.median(cdata)
-                    means.append(cmean)
-                    medians.append(cmedian)
+                # compute stats and append to lists
+                means.append(np.mean(flat_data[~flat_data.mask]))
+                medians.append(np.median(flat_data[~flat_data.mask]))
 
-                elif span == 'full':
+        elif span == 'full':
+            for cube in selection:
+                logger.debug("Using full time spans "
+                             "to compute statistics.")
+                # get rid of masked
+                data_size.append(cube.data[~cube.data.mask].shape[0])
 
-                    logger.debug("Using full time spans \
-                                 to compute statistics.")
-                    # get rid of masked
-                    flat_data = cube.data
-                    cdata = flat_data[~flat_data.mask]
-                    data_size.append(cdata.shape[0])
+                # compute stats and append to lists
+                means.append(np.mean(cube.data[~cube.data.mask]))
+                medians.append(np.median(cube.data[~cube.data.mask]))
 
-                    # compute stats and append to lists
-                    cmean = np.mean(cdata)
-                    cmedian = np.median(cdata)
-                    means.append(cmean)
-                    medians.append(cmedian)
+        else:
+            logger.debug("No type of time overlap specified "
+                         "- will not compute cubes statistics")
+            return cubes
 
     logger.debug("Global means: %s", means)
-    means_cube = iris.cube.Cube(means, long_name='means')
-    means_cube.attributes['_filename'] = filename
-    means_cube.attributes['NCfiles'] = str(file_names)
+    c_mean = _put_in_cube(means, 'means', file_names, filename)
 
     logger.debug("Global medians: %s", medians)
-    medians_cube = iris.cube.Cube(medians, long_name='medians')
-    medians_cube.attributes['_filename'] = filename
-    medians_cube.attributes['NCfiles'] = str(file_names)
+    c_med = _put_in_cube(medians, 'medians', file_names, filename)
 
     logger.debug("Data sizes: %s", data_size)
-    datasize_cube = iris.cube.Cube(data_size, long_name='data_size')
-    datasize_cube.attributes['_filename'] = filename
-    datasize_cube.attributes['NCfiles'] = str(file_names)
+    c_dat = _put_in_cube(data_size, 'data_size', file_names, filename)
 
-    save_cubes([means_cube, medians_cube, datasize_cube])
+    save_cubes([c_mean, c_med, c_dat])
 
     return cubes


### PR DESCRIPTION
Hey guys -- tested the following new stuffs:

- multimodel statistics (mean, median and data sizes written to multi_model_mean.nc file that has NCfiles as attributes as well; exclusion of ALL reference and additional models by default and exclusion of any other models specified with exclude: {MODEL1, MODEL2, ...} in the namelist; stats computed with span: overlap or full in time, per model); cheers to Bouwe for the help integrating this in the workflow;

- new way of checking for NCL version that doesn't break piping to file;

- introduced run_once() decorator function in namelist.py so we add it to any function that should be executed only once (eg _update_target_grid() that now gows and find the regrid files only once for the first model);

All these above have been tested by me with the namelist_perfmetrics_CMIP5_short.yml namelist included. Let me know what's up :)

Cheers,
V