### PR TITLE
Refactoring support cmor levels

### DIFF
--- a/esmvaltool/interface_scripts/variable_info.py
+++ b/esmvaltool/interface_scripts/variable_info.py
@@ -301,6 +301,7 @@ class CMIP5Info(object):
                           self._cmor_folder)
 
         self.tables = {}
+        self.coords = {}
 
         for table_file in glob.glob(os.path.join(self._cmor_folder, '*')):
             if '_grids' in table_file:
@@ -315,7 +316,7 @@ class CMIP5Info(object):
         return cmor_tables_path
 
     def _load_table(self, table_file):
-        coords = {}
+
         table_name = ''
         frequency = ''
 
@@ -333,15 +334,15 @@ class CMIP5Info(object):
                         coord = CoordinateInfo(dim)
                         coord.generic_level = True
                         coord.axis = 'Z'
-                        coords[dim] = coord
+                        self.coords[dim] = coord
                 elif key == 'axis_entry':
-                    coords[value] = self._read_coordinate(value)
+                    self.coords[value] = self._read_coordinate(value)
                     continue
                 elif key == 'variable_entry':
                     variable = self._read_variable(value)
                     variable.frequency = frequency
                     for dim in variable.dimensions:
-                        variable.coordinates[dim] = coords[dim]
+                        variable.coordinates[dim] = self.coords[dim]
                     self.tables[table_name][value] = variable
                     continue
                 if not self._read_line():

--- a/esmvaltool/namelists/namelist_MyVar.yml
+++ b/esmvaltool/namelists/namelist_MyVar.yml
@@ -9,7 +9,7 @@ models:
 preprocessors:
   preprocessor_1:
     extract_levels:
-      levels: 85000
+      levels: CMIP6_alt40
       scheme: nearest
     regrid: false
     mask_landocean: false

--- a/esmvaltool/preprocessor/_regrid.py
+++ b/esmvaltool/preprocessor/_regrid.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 
 import re
 from copy import deepcopy
-from  ..preprocessor._reformat import CMOR_TABLES
+from ..preprocessor._reformat import CMOR_TABLES
 
 import iris
 import numpy as np

--- a/esmvaltool/preprocessor/_regrid.py
+++ b/esmvaltool/preprocessor/_regrid.py
@@ -393,13 +393,22 @@ def get_cmor_levels(levels):
     if cmor_type not in CMOR_TABLES:
         raise ValueError('Level definition {} not available'
                          .format(levels))
-    if len(level_definition) == 2:
-        coord = level_definition[1]
-        cmor = CMOR_TABLES[cmor_type].coords[coord]
-    else:
-        table = level_definition[1]
-        var = level_definition[2]
-        cmor = CMOR_TABLES[cmor_type].get_variable(table, var)
 
-    levels = [float(level) for level in cmor.requested]
-    return levels
+    if len(level_definition) != 2:
+        raise ValueError('Bad level definition {}. Correct format: '
+                         '$(CMOR_TABLE)_$(COORDINATE_NAME)')
+
+    coord = level_definition[1]
+    if coord not in CMOR_TABLES[cmor_type].coords:
+        raise ValueError('Coordinate {} not availabale for {}'
+                         .format(coord, cmor_type))
+
+    cmor = CMOR_TABLES[cmor_type].coords[coord]
+
+    if len(cmor.requested) > 0:
+        return [float(level) for level in cmor.requested]
+    elif cmor.value:
+        return [float(cmor.value)]
+    else:
+        raise ValueError('Coordinate {} in {} does not have requested values'
+                         .format(coord, cmor_type))

--- a/tests/integration/preprocessor/_regrid/test_get_cmor_levels.py
+++ b/tests/integration/preprocessor/_regrid/test_get_cmor_levels.py
@@ -25,13 +25,35 @@ class TestGetCmorLevels(unittest.TestCase):
                               16080.0, 16560.0, 17040.0, 17520.0, 18000.0,
                               18480.0, 18960.0])
 
+    def test_cmip6_p200(self):
+        self.assertListEqual(_regrid.get_cmor_levels('CMIP6_p200'),
+                             [20000.])
+
     def test_cmip5_alt40(self):
-        self.assertListEqual(_regrid.get_cmor_levels('CMIP5_Amon_plevs'),
-                             [240.0, 720.0, 1200.0, 1680.0, 2160.0, 2640.0,
-                              3120.0, 3600.0, 4080.0, 4560.0, 5040.0, 5520.0,
-                              6000.0, 6480.0, 6960.0, 7440.0, 7920.0, 8400.0,
-                              8880.0, 9360.0, 9840.0, 10320.0, 10800.0,
-                              11280.0, 11760.0, 12240.0, 12720.0, 13200.0,
-                              13680.0, 14160.0, 14640.0, 15120.0, 15600.0,
-                              16080.0, 16560.0, 17040.0, 17520.0, 18000.0,
-                              18480.0, 18960.0])
+        self.assertListEqual(_regrid.get_cmor_levels('CMIP5_plevs'),
+                             [100000., 92500., 85000., 70000., 60000., 50000.,
+                              40000., 30000., 25000., 20000., 15000., 10000.,
+                              7000., 5000., 3000., 2000., 1000.])
+
+    def test_cmip5_p500(self):
+        self.assertListEqual(_regrid.get_cmor_levels('CMIP5_p500'),
+                             [50000])
+
+    def test_not_values_in_coordinate(self):
+        with self.assertRaises(ValueError):
+            _regrid.get_cmor_levels('CMIP6_time')
+
+    def test_bad_table(self):
+        with self.assertRaises(ValueError):
+            _regrid.get_cmor_levels('CMOCK_p500')
+
+    def test_bad_coordinate(self):
+        with self.assertRaises(ValueError):
+            _regrid.get_cmor_levels('CMIP5_uglycoord')
+
+    def test_bad_format(self):
+        with self.assertRaises(ValueError):
+            _regrid.get_cmor_levels('CMIP5plevs')
+
+        with self.assertRaises(ValueError):
+            _regrid.get_cmor_levels('CMIP5_Amon_plevs')

--- a/tests/integration/preprocessor/_regrid/test_get_cmor_levels.py
+++ b/tests/integration/preprocessor/_regrid/test_get_cmor_levels.py
@@ -1,0 +1,37 @@
+"""
+Integration tests for the :func:
+`esmvaltool.preprocessor.regrid.get_cmor_levels`
+function.
+
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import unittest
+
+from esmvaltool.preprocessor import _regrid
+
+
+class TestGetCmorLevels(unittest.TestCase):
+
+    def test_cmip6_alt40(self):
+        self.assertListEqual(_regrid.get_cmor_levels('CMIP6_alt40'),
+                             [240.0, 720.0, 1200.0, 1680.0, 2160.0, 2640.0,
+                              3120.0, 3600.0, 4080.0, 4560.0, 5040.0, 5520.0,
+                              6000.0, 6480.0, 6960.0, 7440.0, 7920.0, 8400.0,
+                              8880.0, 9360.0, 9840.0, 10320.0, 10800.0,
+                              11280.0, 11760.0, 12240.0, 12720.0, 13200.0,
+                              13680.0, 14160.0, 14640.0, 15120.0, 15600.0,
+                              16080.0, 16560.0, 17040.0, 17520.0, 18000.0,
+                              18480.0, 18960.0])
+
+    def test_cmip5_alt40(self):
+        self.assertListEqual(_regrid.get_cmor_levels('CMIP5_Amon_plevs'),
+                             [240.0, 720.0, 1200.0, 1680.0, 2160.0, 2640.0,
+                              3120.0, 3600.0, 4080.0, 4560.0, 5040.0, 5520.0,
+                              6000.0, 6480.0, 6960.0, 7440.0, 7920.0, 8400.0,
+                              8880.0, 9360.0, 9840.0, 10320.0, 10800.0,
+                              11280.0, 11760.0, 12240.0, 12720.0, 13200.0,
+                              13680.0, 14160.0, 14640.0, 15120.0, 15600.0,
+                              16080.0, 16560.0, 17040.0, 17520.0, 18000.0,
+                              18480.0, 18960.0])


### PR DESCRIPTION
Now you can specify the levels for vertical interpolation with a string in the format cmorversion_coordinatename.

For example, to get CMIP6 presure levels from plev7 coordinate:
```yaml
preprocessors:
  preprocessor_1:
    extract_levels:
      levels: 'CMIP6_plev7'
      scheme: nearest
```
This will give you the levels defined in the plev7 coordinate.

 