### PR TITLE
Fixed error in rank check when using aux_coords instead of dim_coords

### DIFF
--- a/esmvaltool/interface_scripts/cmor_check.py
+++ b/esmvaltool/interface_scripts/cmor_check.py
@@ -202,10 +202,8 @@ class CMORCheck(object):
         for coordinate in self._cmor_var.coordinates.values():
             if coordinate.generic_level or not coordinate.value:
                 rank += 1
-        # Extract dimension coordinates from cube
-        dim_coords = self._cube.coords(dim_coords=True)
         # Check number of dimension coords matches rank
-        if len(dim_coords) != rank:
+        if self._cube.ndim != rank:
             self.report_error(self._does_msg, self._cube.var_name,
                               'match coordinate rank')
 

--- a/tests/unit/interface_scripts/test_cmor_check.py
+++ b/tests/unit/interface_scripts/test_cmor_check.py
@@ -151,6 +151,10 @@ class TestCMORCheck(unittest.TestCase):
         self.cube.remove_coord('latitude')
         self._check_fails_in_metadata()
 
+    def test_rank_with_aux_coords(self):
+        iris.util.demote_dim_coord_to_aux_coord(self.cube, 'latitude')
+        self._check_cube()
+
     def _check_fails_in_metadata(self, automatic_fixes=False, frequency=None):
         checker = CMORCheck(
             self.cube,


### PR DESCRIPTION
Rank check was failing for irregular grids because lat and lon coordinates were aux_coords instead of dim_coords. I changed it to check the number of dimensions of the cube.

By the way, I am not really sure this check is needed: we are checking each coordinate separately later and it would fail for irregular grids that use only one dimension to identify the cell instead of a 2d matrix

Any of you see a reason to keep it?

