### PR TITLE
Make drs section optional in config file

### DIFF
--- a/esmvaltool/main.py
+++ b/esmvaltool/main.py
@@ -107,6 +107,7 @@ def read_config_file(config_file, namelist_name):
         'save_intermediary_cubes': False,
         'max_parallel_tasks': 1,
         'run_diagnostic': True,
+        'drs': {},
     }
 
     for key in defaults:


### PR DESCRIPTION
It is possible, specially when using custom projects, that drs specification is not needed in config file.

In the current you always have to provide a dictionary in the drs, I have updated the config file reader to add an empy dictionary if no drs section is present