### PR TITLE
Fix conda environment.yml of development branch

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,15 +11,15 @@ dependencies:
   - esgf-pyclient
   - ncl
   # iris
-  - matplotlib=1.5.*
-  - cartopy=0.15.*
+  - matplotlib
+  - cartopy
 
   # ncl
-  - libnetcdf=4.4.1.1
-  - hdf5=1.8.18
-  - hdf4=4.2.12
-  - xorg-libsm=1.2.2
-  - icu=58.1
+  - libnetcdf
+  - hdf5
+  - hdf4
+  - xorg-libsm
+  - icu
   - xorg-libxrender
   - xorg-libxext
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -1,36 +1,33 @@
 name: root
 channels:
-- khallock
-- conda-forge
-- defaults
-- Clyde_Fare
+  - conda-forge
+  - defaults
 
 dependencies:
-# esmvaltool
-- cython
-- basemap
-- iris
-- esgf-pyclient
-- scientificpython
-- ncl
-# iris
-- matplotlib=1.5.*
-- cartopy=0.15.*
+  # esmvaltool
+  - cython
+  - basemap
+  - iris
+  - esgf-pyclient
+  - ncl
+  # iris
+  - matplotlib=1.5.*
+  - cartopy=0.15.*
 
-# ncl
-- libnetcdf=4.4.1.1
-- hdf5=1.8.17
-- hdf4=4.2.12
-- xorg-libsm=1.2.2
-- icu=58.1
-- xorg-libxrender
-- xorg-libxext
-- pip:
-  - geoval
+  # ncl
+  - libnetcdf=4.4.1.1
+  - hdf5=1.8.18
+  - hdf4=4.2.12
+  - xorg-libsm=1.2.2
+  - icu=58.1
+  - xorg-libxrender
+  - xorg-libxext
+  - pip:
+      - geoval
 
-# testing
-- nose
-- pytest
-- pytest-cov
-- pytest-html
-- easytest
+  # testing
+  - nose
+  - pytest
+  - pytest-cov
+  - pytest-html
+  - easytest


### PR DESCRIPTION
The environment in the development branch appears to be broken, from circleci:
```
conda env update --quiet --file environment.yml --name esmvaltool

UnsatisfiableError: The following specifications were found to be in conflict:
  - hdf5 1.8.17*
  - libnetcdf 4.4.1.1* -> hdf5 1.8.18|1.8.18.*
Use "conda info <package>" to see the dependencies for each package.

Exited with code 1
```

