### PR TITLE
Cmip6 dicad cl-wrapper for routine evaluation

### DIFF
--- a/util/nml-utils/generateNML/generateNML.py
+++ b/util/nml-utils/generateNML/generateNML.py
@@ -1,6 +1,6 @@
 """
 Call like:
-python util/nml-utils/generateNML/generateNML.py --project PROJECT --name NAME --product PRODUCT --institute INSTITUTE --model MODEL --experiment EXPERIMENT --mip MIP --ensemble ENSEMBLE --start_year START_YEAR --end_year END_YEAR --variable VARIABLE
+python util/nml-utils/generateNML/generateNML.py --project PROJECT --name NAME --product PRODUCT --institute INSTITUTE --model MODEL --experiment EXPERIMENT --mip MIP --ensemble ENSEMBLE --grid GRID --start_year START_YEAR --end_year END_YEAR --variable VARIABLE
 
 """
 from jinja2 import Template
@@ -103,6 +103,7 @@ def get_namelist(**kwargs):
     d = dict()
     d['tas'] = {'ft':'T2Ms'}
     d['ta'] =  {'ft':'T3M'}
+    d['uas'] =  {'ft':'T2Ms'}
 
     tt_nml = Template(t_nml)
     if 'variable' in kwargs.keys():
@@ -121,6 +122,7 @@ def main():
     parser.add_argument('--experiment', dest='experiment')
     parser.add_argument('--mip', dest='mip')
     parser.add_argument('--ensemble', dest='ensemble')
+    parser.add_argument('--grid', dest='grid')
     parser.add_argument('--start_year', dest='start_year')
     parser.add_argument('--end_year', dest='end_year')
     parser.add_argument('--variable', dest='variable')

--- a/util/nml-utils/generateNML/generateNML.py
+++ b/util/nml-utils/generateNML/generateNML.py
@@ -104,6 +104,7 @@ def get_namelist(**kwargs):
     d['tas'] = {'ft':'T2Ms'}
     d['ta'] =  {'ft':'T3M'}
     d['uas'] =  {'ft':'T2Ms'}
+    d['prw'] =  {'ft':'T2M'}
 
     tt_nml = Template(t_nml)
     if 'variable' in kwargs.keys():

--- a/util/wrapper/routineEval.py
+++ b/util/wrapper/routineEval.py
@@ -69,6 +69,7 @@ model: MODEL
 experiment: EXPERIMENT
 mip: Amon
 ensemble: ENSEMBLE
+grid: GRID
 start_year: START_YEAR
 end_year: END_YEAR
 variable: tas """

--- a/util/wrapper/routineEval.py
+++ b/util/wrapper/routineEval.py
@@ -1,0 +1,50 @@
+yfile="""
+--- !CMIP6Dataset
+project: PROJECT
+name: NAME
+product: PRODUCT
+institute: INSTITUTE
+model: MODEL
+experiment: EXPERIMENT
+mip: MIP
+ensemble: ENSEMBLE
+start_year: START_YEAR
+end_year: END_YEAR
+variable: VARIABLE
+"""
+import yaml
+class CMIP6Dataset(yaml.YAMLObject):
+    yaml_tag = u'!CMIP6Dataset'
+    def __init__(self, project, name, product, institute, model, experiment,
+            mip, ensemble, start_year, end_year, variable):
+            self.project = project
+            self.name = name
+            self.product = product
+            self.institute = institute
+            self.model = model
+            self.experiment = experiment
+            self.mip = mip
+            self.ensemble = ensemble
+            self.start_year = start_year
+            self.end_year = end_year
+            self.variable = variable
+    def __repr__(self):
+        return "%s( project=%r, name=%r, product=%r, institute=%r, model=%r, experiment=%r, mip=%r, ensemble=%r, start_year=%r, end_year=%r, variable=%r )" % (
+            self.__class__.__name__, self.project , self.name ,
+            self.product , self.institute , self.model , self.experiment ,
+            self.mip , self.ensemble , self.start_year , self.end_year ,
+            self.variable )
+
+
+h = yaml.load_all(yfile)
+for d in h:
+    print(d)
+import os
+import sys
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), '../nml-utils/generateNML'))
+
+from generateNML import get_namelist
+
+print(get_namelist())

--- a/util/wrapper/routineEval.py
+++ b/util/wrapper/routineEval.py
@@ -1,3 +1,13 @@
+import yaml
+import os
+import sys
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), '../nml-utils/generateNML'))
+
+from generateNML import get_namelist
+
+
 yfile="""
 --- !CMIP6Dataset
 project: PROJECT
@@ -6,28 +16,30 @@ product: PRODUCT
 institute: INSTITUTE
 model: MODEL
 experiment: EXPERIMENT
-mip: MIP
+mip: Amon
 ensemble: ENSEMBLE
 start_year: START_YEAR
 end_year: END_YEAR
-variable: VARIABLE
+variable: tas
 """
-import yaml
+
 class CMIP6Dataset(yaml.YAMLObject):
     yaml_tag = u'!CMIP6Dataset'
     def __init__(self, project, name, product, institute, model, experiment,
             mip, ensemble, start_year, end_year, variable):
-            self.project = project
-            self.name = name
-            self.product = product
-            self.institute = institute
-            self.model = model
-            self.experiment = experiment
-            self.mip = mip
-            self.ensemble = ensemble
-            self.start_year = start_year
-            self.end_year = end_year
-            self.variable = variable
+        self.project = project
+        self.name = name
+        self.product = product
+        self.institute = institute
+        self.model = model
+        self.experiment = experiment
+        self.mip = mip
+        self.ensemble = ensemble
+        self.start_year = start_year
+        self.end_year = end_year
+        self.variable = variable
+    def get_dict(self):
+        return self.__dict__
     def __repr__(self):
         return "%s( project=%r, name=%r, product=%r, institute=%r, model=%r, experiment=%r, mip=%r, ensemble=%r, start_year=%r, end_year=%r, variable=%r )" % (
             self.__class__.__name__, self.project , self.name ,
@@ -39,12 +51,5 @@ class CMIP6Dataset(yaml.YAMLObject):
 h = yaml.load_all(yfile)
 for d in h:
     print(d)
-import os
-import sys
-
-sys.path.insert(0, os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), '../nml-utils/generateNML'))
-
-from generateNML import get_namelist
-
-print(get_namelist())
+    print(d.get_dict())
+    print(get_namelist(**d.get_dict()))

--- a/util/wrapper/routineEval.py
+++ b/util/wrapper/routineEval.py
@@ -1,11 +1,15 @@
 import yaml
 import os
 import sys
+import tempfile
+import shutil
 
 sys.path.insert(0, os.path.join(
     os.path.dirname(os.path.abspath(__file__)), '../nml-utils/generateNML'))
 
 from generateNML import get_namelist
+
+evtRoot = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../..')
 
 
 yfile="""
@@ -50,6 +54,8 @@ class CMIP6Dataset(yaml.YAMLObject):
 
 h = yaml.load_all(yfile)
 for d in h:
-    print(d)
-    print(d.get_dict())
-    print(get_namelist(**d.get_dict()))
+    tmpbase = tempfile.mkdtemp()
+    tmpdir = os.path.join(tmpbase, 'ESMValTool')
+    shutil.copytree(evtRoot, tmpdir, symlinks=False, ignore=shutil.ignore_patterns('.git', '.git*'))
+    with open(os.path.join(tmpdir,'namelist.xml'), 'w') as f:
+        f.write(get_namelist(**d.get_dict()))

--- a/util/wrapper/routineEval.py
+++ b/util/wrapper/routineEval.py
@@ -8,13 +8,14 @@ import argparse
 
 from jinja2 import Template
 
-sys.path.insert(0, os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), '../nml-utils/generateNML'))
+sys.path.insert(0,
+                os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)),
+                    '../nml-utils/generateNML'))
 
 from generateNML import get_namelist
 
 evtRoot = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../..')
-
 
 runscript = """#!/bin/bash
 #SBATCH -J {{ jobid }}
@@ -35,10 +36,12 @@ python main.py namelist.xml
 
 t_runscript = Template(runscript)
 
+
 class CMIP6Dataset(yaml.YAMLObject):
     yaml_tag = u'!CMIP6Dataset'
+
     def __init__(self, project, name, product, institute, model, experiment,
-            mip, ensemble, start_year, end_year, variable):
+                 mip, ensemble, start_year, end_year, variable):
         self.project = project
         self.name = name
         self.product = product
@@ -50,14 +53,16 @@ class CMIP6Dataset(yaml.YAMLObject):
         self.start_year = start_year
         self.end_year = end_year
         self.variable = variable
+
     def get_dict(self):
         return self.__dict__
+
     def __repr__(self):
         return "%s( project=%r, name=%r, product=%r, institute=%r, model=%r, experiment=%r, mip=%r, ensemble=%r, start_year=%r, end_year=%r, variable=%r )" % (
-            self.__class__.__name__, self.project , self.name ,
-            self.product , self.institute , self.model , self.experiment ,
-            self.mip , self.ensemble , self.start_year , self.end_year ,
-            self.variable )
+            self.__class__.__name__, self.project, self.name, self.product,
+            self.institute, self.model, self.experiment, self.mip,
+            self.ensemble, self.start_year, self.end_year, self.variable)
+
 
 def examplefile():
     e = """--- !CMIP6Dataset
@@ -75,6 +80,7 @@ end_year: 1992
 variable: prw """
     return e
 
+
 def process(yfile=examplefile(), verbose=True):
     """According to input file yfile build the temprorary director(y/ies) and submit the jobs
     """
@@ -83,25 +89,41 @@ def process(yfile=examplefile(), verbose=True):
     user = os.getenv('USER')
     for d in h:
         lfd += 1
-        tmpbase = tempfile.mkdtemp(dir='/scratch/b/{0}/rEval'.format(user)) # Needs to be mounted on compute nodes
+        tmpbase = tempfile.mkdtemp(dir='/scratch/b/{0}/rEval'.format(
+            user))  # Needs to be mounted on compute nodes
         tmpdir = os.path.join(tmpbase, 'ESMValTool')
-        shutil.copytree(evtRoot, tmpdir, symlinks=False, ignore=shutil.ignore_patterns('.git', '.git*'))
+        shutil.copytree(
+            evtRoot,
+            tmpdir,
+            symlinks=False,
+            ignore=shutil.ignore_patterns('.git', '.git*'))
         #shutil.copytree(evtRoot, tmpdir, symlinks=False, ignore=shutil.ignore_patterns('.git', '.git*', '*'))
-        with open(os.path.join(tmpdir,'namelist.xml'), 'w') as f:
+        with open(os.path.join(tmpdir, 'namelist.xml'), 'w') as f:
             f.write(get_namelist(**d.get_dict()))
-        s_runscript = os.path.join(tmpdir,'runscript')
+        s_runscript = os.path.join(tmpdir, 'runscript')
         with open(s_runscript, 'w') as f:
-            f.write(t_runscript.render(jobid="rEval{0}".format(str(lfd).zfill(3))) )
+            f.write(
+                t_runscript.render(jobid="rEval{0}".format(str(lfd).zfill(3))))
         if verbose:
             print(tmpdir)
         subprocess.Popen('sbatch runscript', cwd=tmpdir, shell=True)
 
+
 def main():
     """Executes the ESMValTool for routine evaluation on CMIP6-Data described in the input file. The ESMValTool must be configured beforehand."""
-    parser = argparse.ArgumentParser(description=main.__doc__ )
-    parser.add_argument('-f', '--infile', dest='infile', help='Path to file in yaml-format describing the dataset.',
-            type=argparse.FileType('r'))
-    parser.add_argument('-e', '--example', dest='example', action='store_true', help='Output example input file.')
+    parser = argparse.ArgumentParser(description=main.__doc__)
+    parser.add_argument(
+        '-f',
+        '--infile',
+        dest='infile',
+        help='Path to file in yaml-format describing the dataset.',
+        type=argparse.FileType('r'))
+    parser.add_argument(
+        '-e',
+        '--example',
+        dest='example',
+        action='store_true',
+        help='Output example input file.')
 
     args = parser.parse_args()
 
@@ -111,6 +133,6 @@ def main():
 
     process(yfile=args.infile)
 
+
 if __name__ == "__main__":
     main()
-

--- a/util/wrapper/routineEval.py
+++ b/util/wrapper/routineEval.py
@@ -20,7 +20,7 @@ runscript = """#!/bin/bash
 #SBATCH -J {{ jobid }}
 #SBATCH -p prepost
 #SBATCH -N 1
-#SBATCH -n 1
+#SBATCH -n 8
 #SBATCH --mem-per-cpu 1280
 #SBATCH -t 100
 #SBATCH -A bd0854
@@ -61,18 +61,18 @@ class CMIP6Dataset(yaml.YAMLObject):
 
 def examplefile():
     e = """--- !CMIP6Dataset
-project: PROJECT
-name: NAME
-product: PRODUCT
-institute: INSTITUTE
-model: MODEL
-experiment: EXPERIMENT
+project: ESGF_CMIP6
+name: HadGEM3-GC31-LL
+product: ScenarioMIP
+institute: MOHC
+model: HadGEM3-GC31-LL
+experiment: ssp245
 mip: Amon
-ensemble: ENSEMBLE
-grid: GRID
-start_year: START_YEAR
-end_year: END_YEAR
-variable: tas """
+ensemble: r1i1p1f1
+grid: gn
+start_year: 1990
+end_year: 1992
+variable: prw """
     return e
 
 def process(yfile=examplefile(), verbose=True):


### PR DESCRIPTION
This patch adds/enhances basically two utility files for the use in routine evaluation. 
``` generateNML.py ``` a module for generating a namelist using a template
``` routineEval.py ``` takes in ESGF-facets of the target datasets. Then it:
- calls ``` generateNML.py``` to generate a namelist
- generates a runscript
- creates a temporary directory and places the ESMValTool there for independent execution
- submits the runscript  

Check usage with ```--help``` option on both scripts