### PR TITLE
Fix datafinder for drs with [latestversion] in template

### DIFF
--- a/esmvaltool/config-developer.yml
+++ b/esmvaltool/config-developer.yml
@@ -33,7 +33,7 @@ CMIP5:
   input_dir:
     default: '/'
     BADC: '[institute]/[model]/[exp]/[freq]/[realm]/[mip]/[ensemble]/latest/[var]'
-    DKRZ: '[institute]/[model]/[exp]/[realm]/[freq]/[mip]/[ensemble]/[latestversion]/[var]'
+    DKRZ: '[institute]/[model]/[exp]/[freq]/[realm]/[mip]/[ensemble]/[latestversion]/[var]'
     ETHZ: '[exp]/[mip]/[var]/[model]/[ensemble]/'
     SMHI: '[model]/[ensemble]/[exp]/[freq]'
   input_file: '[var]_[mip]_[model]_[exp]_[ensemble]_*'

--- a/esmvaltool/interface_scripts/data_finder.py
+++ b/esmvaltool/interface_scripts/data_finder.py
@@ -163,7 +163,6 @@ def get_input_filelist(variable, rootpath, drs):
         if not os.path.isdir(path):
             raise OSError('Directory not found: {}'.format(path))
 
-
     # Find latest version if required
     if '[latestversion]' in dirname_template:
         part1, part2 = dirname_template.split('[latestversion]')

--- a/esmvaltool/interface_scripts/data_finder.py
+++ b/esmvaltool/interface_scripts/data_finder.py
@@ -66,7 +66,7 @@ def replace_tags(path, variable):
                 elif tag == 'realm':
                     replacewith = cmip5_mip2realm_freq(variable['mip'])[0]
         elif tag == 'latestversion':  # handled separately later
-            pass
+            continue
         elif tag == 'tier':
             replacewith = ''.join(('Tier', str(variable['tier'])))
         elif tag == 'model':
@@ -163,11 +163,11 @@ def get_input_filelist(variable, rootpath, drs):
         if not os.path.isdir(path):
             raise OSError('Directory not found: {}'.format(path))
 
-    check_isdir(os.path.dirname(dirname_template))
 
     # Find latest version if required
     if '[latestversion]' in dirname_template:
         part1, part2 = dirname_template.split('[latestversion]')
+        part2 = part2.lstrip(os.sep)
         list_versions = os.listdir(part1)
         list_versions.sort()
         latest = os.path.basename(list_versions[-1])


### PR DESCRIPTION
Minor fix when drs template in config-developer.yml contains the [latestversion] tag. 