### PR TITLE
Fix installed version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -205,7 +205,6 @@ with open('README.md') as readme:
         packages=PACKAGES,
         # Include all version controlled files
         include_package_data=True,
-        use_scm_version=True,
         setup_requires=REQUIREMENTS['setup'],
         install_requires=REQUIREMENTS['install'],
         tests_require=REQUIREMENTS['test'],


### PR DESCRIPTION
The option `use_scm_version=True` overrides the version number in `version.py` with a version number from git. This leads to version 1.1.1 being reported instead of version 2.0.0.