### PR TITLE
Support for using two different time periods of the same experiment

### DIFF
--- a/esmvaltool/preprocessor/__init__.py
+++ b/esmvaltool/preprocessor/__init__.py
@@ -155,7 +155,9 @@ def _group_input(in_files, out_files):
             tmp = sum(c in out_chunks for c in in_chunks)
             if tmp > score:
                 score = tmp
-                fname = out_file
+                fname = [out_file]
+            elif tmp == score:
+                fname.append(out_file)
         if not fname:
             logger.warning(
                 "Unable to find matching output file for input file %s",
@@ -164,8 +166,7 @@ def _group_input(in_files, out_files):
 
     # Group input files by output file
     for in_file in in_files:
-        out_file = get_matching(in_file)
-        if out_file:
+        for out_file in get_matching(in_file):
             if out_file not in grouped_files:
                 grouped_files[out_file] = []
             grouped_files[out_file].append(in_file)

--- a/esmvaltool/preprocessor/__init__.py
+++ b/esmvaltool/preprocessor/__init__.py
@@ -149,7 +149,7 @@ def _group_input(in_files, out_files):
         """Find the output file which matches input file best."""
         in_chunks = os.path.basename(in_file).split('_')
         score = 0
-        fname = None
+        fname = []
         for out_file in out_files:
             out_chunks = os.path.basename(out_file).split('_')
             tmp = sum(c in out_chunks for c in in_chunks)


### PR DESCRIPTION
Sometimes it can be useful to have in the comparison different periods of the same experiment. For example, to check the impact of climate change in a long run or to test a multi model setup when you only have one dataset available

I have modified the score function that returns the out_files for each in_file to return a list of all the files with the highest score. Currently, it only returns the first one and fails when the same file should be added to two different entries