### PR TITLE
Add system resource usage logger

### DIFF
--- a/esmvaltool/main.py
+++ b/esmvaltool/main.py
@@ -56,6 +56,7 @@ if __name__ == '__main__':  # noqa
                         os.path.dirname(os.path.abspath(__file__))))  # noqa
 
 from esmvaltool.namelist import read_namelist_file
+from esmvaltool.task import resource_usage_logger
 from esmvaltool.version import __version__
 
 # set up logging
@@ -202,7 +203,9 @@ def main(args):
 
     cfg['synda_download'] = args.synda_download
 
-    process_namelist(namelist_file=namelist_file, config_user=cfg)
+    resource_log = os.path.join(cfg['run_dir'], 'resource_usage.txt')
+    with resource_usage_logger(pid=os.getpid(), filename=resource_log):
+        process_namelist(namelist_file=namelist_file, config_user=cfg)
 
 
 def process_namelist(namelist_file, config_user):

--- a/esmvaltool/task.py
+++ b/esmvaltool/task.py
@@ -74,8 +74,7 @@ def resource_usage_logger(pid, filename, interval=1):
             while not halt.is_set():
                 try:
                     txt = _get_resource_usage(process, start_time)
-                except (PermissionError, psutil.AccessDenied,
-                        psutil.NoSuchProcess):
+                except (OSError, psutil.AccessDenied, psutil.NoSuchProcess):
                     break
                 file.write(txt)
                 time.sleep(interval)

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ REQUIREMENTS = {
         'numba',
         'numpy',
         'pillow',
+        'psutil',
         'pyyaml',
         'shapely',
         'six',


### PR DESCRIPTION
This adds a logger that logs the usage of cpu/memory/disk to a file called `run/resource_usage.txt` for `esmvaltool` in general and also for all diagnostic scripts in particular in `run/diagnostic_name/script_name/resource_usage.txt`.

Having this kind of information available by default will hopefully help us and diagnostic developers to develop more computer friendly diagnostics.