### PR TITLE
Pycodestyle update

### DIFF
--- a/esmvaltool/diag_scripts/shared/esmval_lib.py
+++ b/esmvaltool/diag_scripts/shared/esmval_lib.py
@@ -21,8 +21,6 @@ class ESMValProject(object):
         self.project_info = project_info
         self.firstime = True
         self.oldvar = ""
-
-
 #        self.version = os.environ['0_ESMValTool_version']
 
     def _get_path_with_sep(self, p):


### PR DESCRIPTION
Due to an update to `pycodestyle`, these empty lines now make the PEP8 unit test fail. This PR fixes the unit test.