### PR TITLE
Getting started for developres

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Go to the directory where the repository is cloned and run `./setup.py test`. Te
 First go to the directory where the repository is cloned, e.g. `cd ESMValTool`.
 - To review if your own code follows our coding standards, run `prospector esmvaltool/diag_scripts/your_diagnostic/your_script.py`.
 - Run `./setup.py lint` to see the warnings about the code style of the entire project.
+
 We use Codacy for monitoring (Python) code quality. However, running prospector locally will generally give you quicker and sometimes more accurate results. Note that Codacy does not install dependencies, so getting a warning "Unable to import 'external_library'" is probably not a real issue.   
 
 ### Building documentation

--- a/README.md
+++ b/README.md
@@ -7,3 +7,32 @@
 [![Docker Build Status](https://img.shields.io/docker/build/esmvalgroup/esmvaltool.svg)](https://hub.docker.com/r/esmvalgroup/esmvaltool/)
 
 ESMValTool: A community diagnostic and performance metrics tool for routine evaluation of Earth system models in CMIP
+
+## Developing
+This is the development branch for version 2 of ESMValTool. To get started developing esmvaltool or developing/porting diagnostics, follow the instructions below. More detailed instructions can be found in the [manual](http://esmvaltool.readthedocs.io/en/refactoring_backend/).
+
+### Getting started
+To install in development mode, follow these instructions.
+- [Download and install conda](https://conda.io/docs/user-guide/install/linux.html)
+- Update conda: `conda update -y conda`
+- Create a conda environment: `conda create -y -n esmvaltool python=3`
+- Activate the esmvaltool environment: `source activate esmvaltool`
+- Clone the ESMValTool github repository: `git clone git@github.com/ESMValGroup/ESMValTool`
+- Go to the esmvaltool directory: `cd ESMValTool`
+- Update the esmvaltool conda environment `conda env update`
+- Install in development mode: `pip install -e .[develop]`
+- Test that your installation was succesful by running `esmvaltool -h`.
+- Review `config-user.yml`. To customize for your system, create a copy, edit and use the command line option `-c` to instruct `esmvaltool` to use your custom configuration.
+- Available namelists are located in the directory `esmvaltool/namelists`.
+
+### Running tests
+Go to the directory where the repository is cloned and run `./setup.py test`. Tests will also be run automatically by CircleCI.
+
+### Code style
+First go to the directory where the repository is cloned, e.g. `cd ESMValTool`.
+- To review if your own code follows our coding standards, run `prospector esmvaltool/diag_scripts/your_diagnostic/your_script.py`.
+- Run `./setup.py lint` to see the warnings about the code style of the entire project.
+We use Codacy for monitoring (Python) code quality. However, running prospector locally will generally give you quicker and sometimes more accurate results. Note that Codacy does not install dependencies, so getting a warning "Unable to import 'external_library'" is probably not a real issue.   
+
+### Building documentation
+Go to the directory where the repository is cloned and run `./setup.py build_sphinx`


### PR DESCRIPTION
I noticed that it is not at all clear how to get started working with the esmvaltool 2 development branch or how to perform certain tasks. Putting this section prominently in the README.md file should remedy that, because then we only need to point people to the right branch.

Once we get to a release, this information should probably be moved to CONTRIBUTING.md.