### PR TITLE
added support for standard fill value 1e20 for all lead and save cube…

### DIFF
--- a/esmvaltool/preprocessor/_io.py
+++ b/esmvaltool/preprocessor/_io.py
@@ -6,6 +6,7 @@ from itertools import groupby
 
 import iris
 import yaml
+import numpy as np
 
 from ..task import write_ncl_settings
 
@@ -13,6 +14,8 @@ iris.FUTURE.netcdf_promote = True
 iris.FUTURE.netcdf_no_unlimited = True
 
 logger = logging.getLogger(__name__)
+
+GLOBAL_FILL_VALUE = 1e+20
 
 MODEL_KEYS = {
     'mip',
@@ -58,6 +61,9 @@ def load_cubes(files, filename, metadata, constraints=None, callback=None):
     for cube in cubes:
         cube.attributes['_filename'] = filename
         cube.attributes['metadata'] = yaml.safe_dump(metadata)
+        # always set fillvalue to 1e+20
+        if np.ma.is_masked(cube.data):
+            np.ma.set_fill_value(cube.data, GLOBAL_FILL_VALUE)
 
     return cubes
 
@@ -107,7 +113,7 @@ def save_cubes(cubes, debug=False, step=None):
         paths[filename].append(cube)
 
     for filename in paths:
-        _save_cubes(cubes=paths[filename], target=filename)
+        _save_cubes(cubes=paths[filename], target=filename, fill_value=GLOBAL_FILL_VALUE)
 
     return list(paths)
 

--- a/esmvaltool/preprocessor/_io.py
+++ b/esmvaltool/preprocessor/_io.py
@@ -113,7 +113,8 @@ def save_cubes(cubes, debug=False, step=None):
         paths[filename].append(cube)
 
     for filename in paths:
-        _save_cubes(cubes=paths[filename], target=filename, fill_value=GLOBAL_FILL_VALUE)
+        _save_cubes(cubes=paths[filename], target=filename, 
+                    fill_value=GLOBAL_FILL_VALUE)
 
     return list(paths)
 


### PR DESCRIPTION
hardcoded the fill values for masked cubes data to 1e+20 at load and save stages so it replaces the wonky iris 2.0 default values. Nothing else. tested and it works (at least for me).