### PR TITLE
Get latest version of data only if exists

### DIFF
--- a/esmvaltool/data_finder.py
+++ b/esmvaltool/data_finder.py
@@ -181,9 +181,11 @@ def get_input_filelist(variable, rootpath, drs):
         part1, part2 = dirname_template.split('[latestversion]')
         part2 = part2.lstrip(os.sep)
         list_versions = os.listdir(part1)
-        list_versions.sort()
-        latest = os.path.basename(list_versions[-1])
-        dirname = os.path.join(part1, latest, part2)
+        list_versions.sort(reverse=True)
+        for version in list_versions:
+            dirname = os.path.join(part1, version, part2)
+            if os.path.isdir(dirname):
+                break
     else:
         dirname = dirname_template
 


### PR DESCRIPTION
For data using `[latestversion]` in their directory structure (e.g. CMIP5 at DKRZ), this fix returns the latest version of the data after checking that the data actually exist in that version. Otherwise it goes back to the previous version and checks again, and so on.