### PR TITLE
Modularize perfmetrics diagnostic

### DIFF
--- a/esmvaltool/diag_scripts/perfmetrics/cycle.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/cycle.ncl
@@ -1,0 +1,131 @@
+;;#############################################################################
+;; SCRIPT TO CALCULATE AND PLOT ANNUAL CYCLE FOR THE PERFORMANCE METRICS
+;; Authors: Mattia Righi (DLR, Germany) and Franziska Frank (DLR, Germany)
+;; ESMVal project
+;;#############################################################################
+;; Description
+;;   Calculates and (optionally) plots annual/seasonal cycles from input T3M or
+;;   T2Ms data.
+;;
+;; Required diag_script_info attributes
+;;
+;;
+;;
+;;
+;;
+;;
+;;#############################################################################
+
+procedure perfmetrics_cycle()
+begin
+
+    ;; Define output variable
+    if (time_avg.eq."seasonalclim") then
+        var_all = new((/dim_MOD, 4, 2/), float)
+        var_all!1 = "season"
+        var_all&season = (/"DJF", "MAM", "JJA", "SON"/)
+    else if (time_avg.eq."monthlyclim") then
+        var_all = new((/dim_MOD, 12, 2/), float)
+        var_all!1 = "month"
+        var_all&month = (/"J", "F", "M", "A", "M", "J",\
+                          "J", "A", "S", "O", "N", "D"/)
+    else
+        error_msg("f", diag_script, "", "time_avg option " + time_avg + \
+                  " not compatible with plot_type " + ptype)
+    end if
+    end if
+    var_all!0 = "model"
+    var_all!2 = "statistic"
+    var_all&model = modelnames
+    var_all&statistic = (/"mean", "stddev"/)
+
+    ;; Attach attributes
+    var_all@var = var0
+    var_all@diag_script = (/diag_script/)
+    copy_VarAtts(diag_script_info, var_all)
+    var_all@ref_model = str_get_field(ref_models(0), 1, ",")
+
+    ;; Loop over models
+    do imod = 0, dim_MOD - 1
+
+        log_debug("Processing " + modelnames(imod))
+
+        ;; Set path for saving processed data ;; FIX-ME add preproc_id
+        fullpath = config_user_info@work_dir + "/"
+        system("mkdir -p " + fullpath)
+        fname = basename(systemfunc("basename " + model_info@filename(imod)))
+        fname = fname + "_" + basename(diag_script) + "_cycle"
+        fname = fname + "_" + diag_script_info@time_avg
+        if (isatt(diag_script_info, "level")) then
+            fname = fname + "_" + diag_script_info@level  ; FIX-ME
+        end if
+        fname = fname + "_" + str_sub_str(diag_script_info@region, " ", "")
+        procpath = fullpath + fname + ".nc"
+
+        ;; Determine start/end year
+        start_year = get_start_year(imod)
+        end_year = get_end_year(imod)
+
+        ;; Read data
+        var = read_data(imod, var0, field_type0)
+        dnames = getVarDimNames(var)
+
+        ;; Extract region and average over latitude and longitude
+        if (any(field_type0.eq.(/"T0M", "T0Ms", "T1M"/))) then
+            var_reg = var
+        else if (any(dnames.eq."lat") .and. any(dnames.eq."lon")) then
+            var_reg = area_operations(var, region(0), region(1), \
+                                      region(2), region(3), "average", True)
+        else
+            error_msg("f", diag_script, "", "dimensionality not " + \
+                      "implemented")  ; FIXME
+        end if
+        end if
+        delete(var)
+
+        ;; Calculate time average
+        var_avg = time_operations(var_reg, start_year, end_year, "average", \
+                                  time_avg, True)
+
+        ;; Calculate time standard deviation (with lower/upper bounds)
+        if (start_year.lt.end_year) then
+            var_std = time_operations(var_reg, start_year, end_year, \
+                                      "stddev", time_avg, True)
+        else
+            var_std = 0.
+        end if
+        delete(var_reg)
+
+        var_all(imod, :, 0) = var_avg
+        var_all(imod, :, 1) = var_std
+
+        if (config_user_info@write_netcdf.eq."True") then
+            var_all@ncdf = procpath
+            ncdf_outfile = ncdf_write(var_all(imod, :, :), procpath)
+        end if
+
+    end do
+
+    ;; Plotting
+    if (.not.diag_script_info@draw_plots) then
+        return
+    end if
+
+    ;; Convert units for plotting (if required)
+    if (isatt(variable_info, "plot_units")) then
+        var_all = convert_units(var_all, variable_info@plot_units)
+    end if
+
+    outfile = config_user_info@plot_dir + var0 + "_" + ptype + "_" + \
+        time_avg + "_" + region_name
+    wks = gsn_open_wks(file_type, outfile)
+    wks@legendfile = outfile + "_legend"
+    var_all@res_tiMainString = varstring
+    var_all@res_tiMainString = var_all@res_tiMainString + \
+        location + altitude
+    plot = cycle_plot(wks, var_all, var0)
+    draw(plot)
+    frame(wks)
+    log_info(" gv " + outfile + "." + file_type)
+
+end

--- a/esmvaltool/diag_scripts/perfmetrics/cycle.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/cycle.ncl
@@ -8,7 +8,6 @@ procedure perfmetrics_ptype_script()
 begin
 
     ;; Define output variable
-    modelnames = project_style(diag_script_info, "annots")
     if (diag_script_info@time_avg.eq."seasonalclim") then
         var_all = new((/dim_MOD, 4, 2/), float)
         var_all!1 = "season"

--- a/esmvaltool/diag_scripts/perfmetrics/cycle.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/cycle.ncl
@@ -7,7 +7,7 @@
 procedure perfmetrics_ptype_script()
 begin
 
-    ;; Define output variable
+    ;; Define output array
     if (diag_script_info@time_avg.eq."seasonalclim") then
         var_all = new((/dim_MOD, 4, 2/), float)
         var_all!1 = "season"
@@ -33,6 +33,9 @@ begin
     var_all@diag_script = (/diag_script/)
     copy_VarAtts(diag_script_info, var_all)
     var_all@ref_model = variable_info@reference_model
+
+    ;; Define region
+    region = select_region(diag_script_info@region)
 
     ;; Loop over models
     do imod = 0, dim_MOD - 1
@@ -60,7 +63,6 @@ begin
         dnames = getVarDimNames(var)
 
         ;; Extract region and average over latitude and longitude
-        region = select_region(diag_script_info@region)
         if (any(field_type0.eq.(/"T0M", "T0Ms", "T1M"/))) then
             var_reg = var
         else if (any(dnames.eq."lat") .and. any(dnames.eq."lon")) then

--- a/esmvaltool/diag_scripts/perfmetrics/cycle.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/cycle.ncl
@@ -34,9 +34,6 @@ begin
     copy_VarAtts(diag_script_info, var_all)
     var_all@ref_model = variable_info@reference_model
 
-    ;; Define region
-    region = select_region(diag_script_info@region)
-
     ;; Loop over models
     do imod = 0, dim_MOD - 1
 

--- a/esmvaltool/diag_scripts/perfmetrics/cycle.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/cycle.ncl
@@ -77,6 +77,7 @@ begin
         ;; Calculate time average
         var_avg = time_operations(var_reg, start_year, end_year, "average", \
                                   diag_script_info@time_avg, True)
+        delete(var_reg)
 
         ;; Calculate time standard deviation (with lower/upper bounds)
         if (start_year.lt.end_year) then
@@ -88,11 +89,11 @@ begin
         end if
         delete(var_reg)
 
+        ;; Write output
         var_all(imod, :, 0) = var_avg
         var_all(imod, :, 1) = var_std
         delete(var_avg)
         delete(var_std)
-
         if (config_user_info@write_netcdf.eq."True") then
             var_all@ncdf = procpath
             ncdf_outfile = ncdf_write(var_all(imod, :, :), procpath)

--- a/esmvaltool/diag_scripts/perfmetrics/cycle.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/cycle.ncl
@@ -77,7 +77,6 @@ begin
         ;; Calculate time average
         var_avg = time_operations(var_reg, start_year, end_year, "average", \
                                   diag_script_info@time_avg, True)
-        delete(var_reg)
 
         ;; Calculate time standard deviation (with lower/upper bounds)
         if (start_year.lt.end_year) then
@@ -107,8 +106,8 @@ begin
     end if
 
     ;; Convert units for plotting (if required)
-    if (isatt(variable_info, "plot_units")) then
-        var_all = convert_units(var_all, variable_info@plot_units)
+    if (isatt(diag_script_info, "plot_units")) then
+        var_all = convert_units(var_all, diag_script_info@plot_units)
     end if
 
     ;; Annotation and file names

--- a/esmvaltool/diag_scripts/perfmetrics/cycle.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/cycle.ncl
@@ -1,37 +1,27 @@
 ;;#############################################################################
-;; SCRIPT TO CALCULATE AND PLOT ANNUAL CYCLE FOR THE PERFORMANCE METRICS
+;; PROCEDURE FOR THE ANNUAL CYCLE PLOT OF THE PERFORMANCE METRICS
 ;; Authors: Mattia Righi (DLR, Germany) and Franziska Frank (DLR, Germany)
 ;; ESMVal project
 ;;#############################################################################
-;; Description
-;;   Calculates and (optionally) plots annual/seasonal cycles from input T3M or
-;;   T2Ms data.
-;;
-;; Required diag_script_info attributes
-;;
-;;
-;;
-;;
-;;
-;;
-;;#############################################################################
 
-procedure perfmetrics_cycle()
+procedure perfmetrics_ptype_script()
 begin
 
     ;; Define output variable
-    if (time_avg.eq."seasonalclim") then
+    modelnames = project_style(diag_script_info, "annots")
+    if (diag_script_info@time_avg.eq."seasonalclim") then
         var_all = new((/dim_MOD, 4, 2/), float)
         var_all!1 = "season"
         var_all&season = (/"DJF", "MAM", "JJA", "SON"/)
-    else if (time_avg.eq."monthlyclim") then
+    else if (diag_script_info@time_avg.eq."monthlyclim") then
         var_all = new((/dim_MOD, 12, 2/), float)
         var_all!1 = "month"
         var_all&month = (/"J", "F", "M", "A", "M", "J",\
                           "J", "A", "S", "O", "N", "D"/)
     else
-        error_msg("f", diag_script, "", "time_avg option " + time_avg + \
-                  " not compatible with plot_type " + ptype)
+        error_msg("f", diag_script, "", "time_avg option " + \
+                  diag_script_info@time_avg + \
+                  " not compatible with plot_type cycle")
     end if
     end if
     var_all!0 = "model"
@@ -43,7 +33,7 @@ begin
     var_all@var = var0
     var_all@diag_script = (/diag_script/)
     copy_VarAtts(diag_script_info, var_all)
-    var_all@ref_model = str_get_field(ref_models(0), 1, ",")
+    var_all@ref_model = variable_info@reference_model
 
     ;; Loop over models
     do imod = 0, dim_MOD - 1
@@ -71,6 +61,7 @@ begin
         dnames = getVarDimNames(var)
 
         ;; Extract region and average over latitude and longitude
+        region = select_region(diag_script_info@region)
         if (any(field_type0.eq.(/"T0M", "T0Ms", "T1M"/))) then
             var_reg = var
         else if (any(dnames.eq."lat") .and. any(dnames.eq."lon")) then
@@ -85,12 +76,13 @@ begin
 
         ;; Calculate time average
         var_avg = time_operations(var_reg, start_year, end_year, "average", \
-                                  time_avg, True)
+                                  diag_script_info@time_avg, True)
 
         ;; Calculate time standard deviation (with lower/upper bounds)
         if (start_year.lt.end_year) then
             var_std = time_operations(var_reg, start_year, end_year, \
-                                      "stddev", time_avg, True)
+                                      "stddev", diag_script_info@time_avg, \
+                                      True)
         else
             var_std = 0.
         end if
@@ -98,6 +90,8 @@ begin
 
         var_all(imod, :, 0) = var_avg
         var_all(imod, :, 1) = var_std
+        delete(var_avg)
+        delete(var_std)
 
         if (config_user_info@write_netcdf.eq."True") then
             var_all@ncdf = procpath
@@ -116,8 +110,44 @@ begin
         var_all = convert_units(var_all, variable_info@plot_units)
     end if
 
-    outfile = config_user_info@plot_dir + var0 + "_" + ptype + "_" + \
-        time_avg + "_" + region_name
+    ;; Annotation and file names
+    region_name = ""  ; priority 3
+    location = ""  ; priority 3
+    if (isatt(diag_script_info, "aux_info")) then
+        region_name = "_" + diag_script_info@aux_info  ; priority 2
+        location = " - " + diag_script_info@aux_info  ; priority 2
+    end if
+    if (isatt(diag_script_info, "location")) then
+        location = " - " + diag_script_info@location  ; priority 1
+    end if
+    if (isatt(diag_script_info, "region")) then
+        region_name = "_" + region@name  ; priority 1
+        location = " - " + diag_script_info@region
+    end if
+    if (isatt(var_all, "long_name")) then
+        varstring = var_all@long_name  ; priority 3
+    end if
+    if (isatt(var_all, "short_name")) then
+        varstring = var_all@short_name  ; priority 2
+    end if
+    if (isStrSubset(var0, "vmr").and.isStrSubset(var0, "_")) then
+        varstring = var0  ; priority 1
+    end if
+    altitude = ""  ; priority 2
+    if (any(field_type0.eq.(/"T0M", "T0Ms"/))) then
+        if (isatt(diag_script_info, "altitude")) then
+            altitude = " - " + diag_script_info@altitude  ; priority 1
+        end if
+    else
+        if (isatt(diag_script_info, "level")) then  ; FIX-ME
+            if (diag_script_info@level.ne."all") then
+                altitude = " - " + diag_script_info@level + " hPa"
+            end if
+        end if
+    end if
+    outfile = config_user_info@plot_dir + var0 + "_cycle_" + \
+        diag_script_info@time_avg + "_" + region_name
+
     wks = gsn_open_wks(file_type, outfile)
     wks@legendfile = outfile + "_legend"
     var_all@res_tiMainString = varstring
@@ -126,6 +156,7 @@ begin
     plot = cycle_plot(wks, var_all, var0)
     draw(plot)
     frame(wks)
+
     log_info(" gv " + outfile + "." + file_type)
 
 end

--- a/esmvaltool/diag_scripts/perfmetrics/cycle_latlon.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/cycle_latlon.ncl
@@ -7,11 +7,10 @@
 procedure perfmetrics_ptype_script()
 begin
 
-    ;; Start loop over models, make sure reference and alternative models are
-    ;; calculated first
+    ;; Set model indexes, with reference and alternative models first
     modidx = ispan(0, dim_MOD - 1, 1)
     if (l_altern) then
-        modidx := array_append_record(ref_ind, \
+        modidx := array_append_record((/ref_ind, alt_ind/), \
                                       modidx(ind(modidx.ne.ref_ind .and. \
                                                  modidx.ne.alt_ind)), 0)
     else
@@ -19,6 +18,10 @@ begin
                                       modidx(ind(modidx.ne.ref_ind)), 0)
     end if
 
+    ;; Define region
+    region = select_region(diag_script_info@region)
+
+    ;; Loop over models
     do ii = 0, dimsizes(modidx) - 1
         
         imod = modidx(ii)
@@ -29,7 +32,7 @@ begin
         fullpath = config_user_info@work_dir + "/"
         system("mkdir -p " + fullpath)
         fname = basename(systemfunc("basename " + model_info@filename(imod)))
-        fname = fname + "_" + basename(diag_script) + "_latlon"
+        fname = fname + "_" + basename(diag_script) + "_cycle_latlon"
         fname = fname + "_" + diag_script_info@time_avg
         if (isatt(diag_script_info, "level")) then
             fname = fname + "_" + diag_script_info@level  ; FIX-ME
@@ -52,7 +55,7 @@ begin
 
         ;; Calculate time average
         var_avg = time_operations(var_reg, start_year, end_year, \
-                                  "average", time_avg, True)
+                                  "average", diag_script_info@time_avg, True)
         delete(var_reg)
 
         ;; Standard deviation calculation for this ptype is not implemented
@@ -60,10 +63,9 @@ begin
 
         ;; Write output
         var_all = new(array_append_record(dimsizes(var_avg), 2, 0), float)
-        var_all!2 = "statistic"
+        var_all!3 = "statistic"
         var_all&statistic = (/"mean", "stddev"/)
         var_all(:, :, :, 0) = var_avg
-        var_all(:, :, :, 1) = var_std
         var_all@var = var0
         var_all@diag_script = (/diag_script/)
         copy_VarAtts(diag_script_info, var_all)
@@ -80,7 +82,7 @@ begin
 
         ;; Store alternative model
         if (l_altern) then
-            if (imod.eq.ref_alt) then
+            if (imod.eq.alt_ind) then
                 var_alt = var_all
             end if
         end if

--- a/esmvaltool/diag_scripts/perfmetrics/cycle_latlon.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/cycle_latlon.ncl
@@ -18,9 +18,6 @@ begin
                                       modidx(ind(modidx.ne.ref_ind)), 0)
     end if
 
-    ;; Define region
-    region = select_region(diag_script_info@region)
-
     ;; Loop over models
     do ii = 0, dimsizes(modidx) - 1
         
@@ -75,6 +72,11 @@ begin
             ncdf_outfile = ncdf_write(var_all, procpath)
         end if
 
+        ;; Calculate grading
+        if (.not.diag_script_info@calc_grading) then
+            continue
+        end if
+
         ;; Store reference model
         if (imod.eq.ref_ind) then
             var_ref = var_all
@@ -88,10 +90,34 @@ begin
         end if
 
         ;; Calculate grading
-        if (.not.diag_script_info@calc_grading) then
+        locidx = ind(modelnames(imod).eq.grading&models)
+        if (ismissing(locidx)) then
             continue
+        end if
+        if (diag_script_info@metric.eq."taylor") then
+            grading(0, locidx, 0) = \
+                calculate_metric(var_all(:, :, :, 0), \
+                                 var_ref(:, :, :, 0), \
+                                 "stddev_ratio")
+            grading(0, locidx, 1) = \
+                calculate_metric(var_all(:, :, :, 0), \
+                                 var_ref(:, :, :, 0), \
+                                 "correlation")
+        else
+            grading(0, locidx, 0) = \
+                calculate_metric(var_all(:, :, :, 0), \
+                                 var_ref(:, :, :, 0), \
+                                 diag_script_info@metric)
+            if (l_altern) then
+                grading(0, locidx, 1) = \
+                    calculate_metric(var_all(:, :, :, 0), \
+                                     var_alt(:, :, :, 0), \
+                                     diag_script_info@metric)
+            end if
         end if
 
     end do
+
+
 
 end

--- a/esmvaltool/diag_scripts/perfmetrics/cycle_latlon.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/cycle_latlon.ncl
@@ -1,0 +1,95 @@
+;;#############################################################################
+;; PROCEDURE FOR THE CYCLE-LATLON PLOT OF THE PERFORMANCE METRICS
+;; Authors: Mattia Righi (DLR, Germany) and Franziska Frank (DLR, Germany)
+;; ESMVal project
+;;#############################################################################
+
+procedure perfmetrics_ptype_script()
+begin
+
+    ;; Start loop over models, make sure reference and alternative models are
+    ;; calculated first
+    modidx = ispan(0, dim_MOD - 1, 1)
+    if (l_altern) then
+        modidx := array_append_record(ref_ind, \
+                                      modidx(ind(modidx.ne.ref_ind .and. \
+                                                 modidx.ne.alt_ind)), 0)
+    else
+        modidx := array_append_record(ref_ind, \
+                                      modidx(ind(modidx.ne.ref_ind)), 0)
+    end if
+
+    do ii = 0, dimsizes(modidx) - 1
+        
+        imod = modidx(ii)
+
+        log_debug("Processing " + modelnames(imod))
+
+        ;; Set path for saving processed data ;; FIX-ME add preproc_id
+        fullpath = config_user_info@work_dir + "/"
+        system("mkdir -p " + fullpath)
+        fname = basename(systemfunc("basename " + model_info@filename(imod)))
+        fname = fname + "_" + basename(diag_script) + "_latlon"
+        fname = fname + "_" + diag_script_info@time_avg
+        if (isatt(diag_script_info, "level")) then
+            fname = fname + "_" + diag_script_info@level  ; FIX-ME
+        end if
+        fname = fname + "_" + str_sub_str(diag_script_info@region, " ", "")
+        procpath = fullpath + fname + ".nc"
+
+        ;; Determine start/end year
+        start_year = get_start_year(imod)
+        end_year = get_end_year(imod)
+
+        ;; Read data
+        var = read_data(imod, var0, field_type0)
+        dnames = getVarDimNames(var)
+
+        ;; Extract region
+        var_reg = area_operations(var, region(0), region(1), \
+                                  region(2), region(3), "extract", True)
+        delete(var)
+
+        ;; Calculate time average
+        var_avg = time_operations(var_reg, start_year, end_year, \
+                                  "average", time_avg, True)
+        delete(var_reg)
+
+        ;; Standard deviation calculation for this ptype is not implemented
+        ;; yet in statistics.ncl (but is anyway not required here)
+
+        ;; Write output
+        var_all = new(array_append_record(dimsizes(var_avg), 2, 0), float)
+        var_all!2 = "statistic"
+        var_all&statistic = (/"mean", "stddev"/)
+        var_all(:, :, :, 0) = var_avg
+        var_all(:, :, :, 1) = var_std
+        var_all@var = var0
+        var_all@diag_script = (/diag_script/)
+        copy_VarAtts(diag_script_info, var_all)
+        var_all@ref_model = variable_info@reference_model
+        if (config_user_info@write_netcdf.eq."True") then
+            var_all@ncdf = procpath
+            ncdf_outfile = ncdf_write(var_all, procpath)
+        end if
+
+        ;; Store reference model
+        if (imod.eq.ref_ind) then
+            var_ref = var_all
+        end if
+
+        ;; Store alternative model
+        if (l_altern) then
+            if (imod.eq.ref_alt) then
+                var_alt = var_all
+            end if
+        end if
+
+        ;; Calculate grading
+        if (.not.diag_script_info@calc_grading) then
+            continue
+        end if
+
+    end do
+
+end

--- a/esmvaltool/diag_scripts/perfmetrics/latlon.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/latlon.ncl
@@ -129,6 +129,7 @@ begin
         wks = gsn_open_wks(file_type, outfile)
         gsn_merge_colormaps(wks, "temp_19lev", "gray70")
         plot = contour_map_ce(wks, plot_var, var0)
+        delete(plot_var@res_cnLevels)
 
         ;; Apply t-test (assuming different population variances)
         if (.not.diag_script_info@t_test) then
@@ -141,7 +142,8 @@ begin
         n1 = get_end_year(imod) - get_start_year(imod) + 1
         n2 = get_end_year(ref_ind) - get_start_year(ref_ind) + 1
         prob = ttest(x1, s1, n1, x2, s2, n2, True, False)
-        plot_var = 1. - prob
+        mask_var = 1. - prob
+        copy_VarCoords(plot_var, mask_var)
         delete(prob)
 
         res2 = True
@@ -152,7 +154,7 @@ begin
         res2@cnLineLabelsOn = False
         res2@gsnDraw = False
         res2@gsnFrame = False
-        plot2 = gsn_csm_contour(wks, plot_var, res2)
+        plot2 = gsn_csm_contour(wks, mask_var, res2)
         opt = True
         if (diag_script_info@stippling) then
             opt@gsnShadeFillType = "pattern"
@@ -167,10 +169,10 @@ begin
         draw(plot)
         frame(wks)
         log_info(" gv " + outfile + "." + file_type)
-        delete(plot_var@res_cnLevels)
         delete(wks)
         delete(plot)
         delete(plot2)
+        delete(mask_var)
         delete(plot_var)
 
     end do

--- a/esmvaltool/diag_scripts/perfmetrics/latlon.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/latlon.ncl
@@ -7,9 +7,6 @@
 procedure perfmetrics_ptype_script()
 begin
 
-    ;; Define output variable
-    modelnames = project_style(diag_script_info, "annots")
-
     ;; Start loop over models, make sure reference model is calculated first
     modidx = ispan(0, dim_MOD - 1, 1)
     modidx := array_append_record(ref_ind, modidx(ind(modidx.ne.ref_ind)), 0)
@@ -146,6 +143,7 @@ begin
         copy_VarCoords(plot_var, mask_var)
         delete(prob)
 
+        ;; Mask non-significant values
         res2 = True
         res2@cnLevelSelectionMode = "ExplicitLevels"
         res2@cnLevels = (/0.0, diag_script_info@conf_level, 1.0/)
@@ -158,7 +156,7 @@ begin
         opt = True
         if (diag_script_info@stippling) then
             opt@gsnShadeFillType = "pattern"
-            opt@gsnShadeMid = 17
+            opt@gsnShadeLow = 17
         else
             opt@gsnShadeFillType = "color"
             opt@gsnShadeLow = "gray70"

--- a/esmvaltool/diag_scripts/perfmetrics/latlon.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/latlon.ncl
@@ -1,0 +1,178 @@
+;;#############################################################################
+;; PROCEDURE FOR THE ZONAL PLOT OF THE PERFORMANCE METRICS
+;; Authors: Mattia Righi (DLR, Germany) and Franziska Frank (DLR, Germany)
+;; ESMVal project
+;;#############################################################################
+
+procedure perfmetrics_ptype_script()
+begin
+
+    ;; Define output variable
+    modelnames = project_style(diag_script_info, "annots")
+
+    ;; Start loop over models, make sure reference model is calculated first
+    modidx = ispan(0, dim_MOD - 1, 1)
+    modidx := array_append_record(ref_ind, modidx(ind(modidx.ne.ref_ind)), 0)
+
+    do ii = 0, dimsizes(modidx) - 1
+        
+        imod = modidx(ii)
+
+        log_debug("Processing " + modelnames(imod))
+
+        ;; Set path for saving processed data
+        fullpath = config_user_info@work_dir + "/"
+        system("mkdir -p " + fullpath)
+        fname = basename(systemfunc("basename " + model_info@filename(imod)))
+        fname = fname + "_" + basename(diag_script) + "_latlon"
+        fname = fname + "_" + diag_script_info@time_avg
+        procpath = fullpath + fname + "_Global.nc"
+
+        ;; Determine start/end year
+        start_year = get_start_year(imod)
+        end_year = get_end_year(imod)
+
+        ;; Read data
+        var = read_data(imod, var0, field_type0)
+        dnames = getVarDimNames(var)
+
+        ;; Calculate time average and standard deviation w.r.t.
+        ;; interannual variability
+        var_avg = time_operations(var, start_year, end_year, \
+                                  "average", diag_script_info@time_avg, True)
+        var_std = interannual_variability(var, start_year, end_year, \
+                                          diag_script_info@time_avg)
+        delete(var)
+
+        ;; Write output
+        var_all = new(array_append_record(dimsizes(var_avg), 2, 0), float)
+        var_all!2 = "statistic"
+        var_all&statistic = (/"mean", "stddev"/)
+        var_all(:, :, 0) = var_avg
+        var_all(:, :, 1) = var_std
+        var_all@var = var0
+        var_all@diag_script = (/diag_script/)
+        copy_VarAtts(diag_script_info, var_all)
+        var_all@ref_model = variable_info@reference_model
+        if (config_user_info@write_netcdf.eq."True") then
+            var_all@ncdf = procpath
+            ncdf_outfile = ncdf_write(var_all, procpath)
+        end if
+
+        ;; Store reference model
+        if (imod.eq.ref_ind) then
+            var_ref = var_all
+        end if
+
+        ;; Plotting
+        if (.not.diag_script_info@draw_plots) then
+            continue
+        end if
+
+        ;; Convert units for plotting (if required)
+        if (isatt(diag_script_info, "plot_units")) then
+            var_all = convert_units(var_all, diag_script_info@plot_units)
+        end if
+
+        ;; Absolute plot
+        outfile = config_user_info@plot_dir + modelnames(imod) + "_" + var0 + \
+            "_latlon_" + diag_script_info@time_avg + "_Glob"
+        plot_var = var_all(:, :, 0)
+        plot_var@projection = diag_script_info@projection
+        plot_var@res_cnLinesOn = False
+        plot_var@res_cnLevelSelectionMode = "ExplicitLevels"
+        plot_var@res_tiMainString = modelnames(imod)
+        plot_var@res_cnLevels = diag_script_info@abs_levs
+        plot_var@res_gsnLeftString = \
+            plot_var@long_name + " [" + format_units(plot_var@units) + "]"
+        if (diag_script_info@show_global_avg) then  ;; append global average
+            gavg = \
+                area_operations(plot_var, -90., 90., 0., 360., "average", True)
+            plot_var@res_gsnRightString = \
+                sprintf("%5.2f", gavg) + " " + format_units(plot_var@units)
+        end if
+        wks = gsn_open_wks(file_type, outfile)
+        gsn_define_colormap(wks, diag_script_info@latlon_cmap)
+        plot = contour_map_ce(wks, plot_var, var0)
+        draw(plot)
+        frame(wks)
+        log_info(" gv " + outfile + "." + file_type)
+        delete(plot_var@res_cnLevels)
+        delete(wks)
+        delete(plot)
+
+        ;; Difference plot to the reference
+        if (.not.diag_script_info@plot_diff .or. imod.eq.ref_ind) then
+            continue
+        end if
+        plot_var = var_all(:, :, 0) - var_ref(:, :, 0)
+        outfile = config_user_info@plot_dir + modelnames(imod) + "-" + \
+            modelnames(ref_ind) + "_" + var0 + "_latlon_" + \
+            diag_script_info@time_avg + "_Glob"
+        plot_var@res_tiMainString = \
+            modelnames(imod) + " - " + modelnames(ref_ind)
+        if (isatt(diag_script_info, "t_test")) then
+            plot_var@res_gsnLeftString = plot_var@res_gsnLeftString + " - " + \
+            sprinti("%2i", toint(100 * diag_script_info@conf_level)) + "% c.l."
+        end if
+        plot_var@res_cnLevelSelectionMode = "ExplicitLevels"
+        plot_var@res_cnLevels = diag_script_info@diff_levs
+        plot_var@res_cnMissingValFillColor = "gray70"
+        plot_var@res_gsnSpreadColorEnd = -2
+        plot_var@projection = diag_script_info@projection
+        if (diag_script_info@show_global_avg) then  ;; append global average
+            gavg = \
+                area_operations(plot_var, -90., 90., 0., 360., "average", True)
+            plot_var@res_gsnRightString = \
+                sprintf("%5.2f", gavg) + " " + format_units(plot_var@units)
+        end if
+        wks = gsn_open_wks(file_type, outfile)
+        gsn_merge_colormaps(wks, "temp_19lev", "gray70")
+        plot = contour_map_ce(wks, plot_var, var0)
+
+        ;; Apply t-test (assuming different population variances)
+        if (.not.diag_script_info@t_test) then
+            continue
+        end if
+        x1 = var_all(:, :, 0)
+        x2 = var_ref(:, :, 0)
+        s1 = var_all(:, :, 1) ^ 2
+        s2 = var_ref(:, :, 1) ^ 2
+        n1 = get_end_year(imod) - get_start_year(imod) + 1
+        n2 = get_end_year(ref_ind) - get_start_year(ref_ind) + 1
+        prob = ttest(x1, s1, n1, x2, s2, n2, True, False)
+        plot_var = 1. - prob
+        delete(prob)
+
+        res2 = True
+        res2@cnLevelSelectionMode = "ExplicitLevels"
+        res2@cnLevels = (/0.0, diag_script_info@conf_level, 1.0/)
+        res2@cnInfoLabelOn = False
+        res2@cnLinesOn = False
+        res2@cnLineLabelsOn = False
+        res2@gsnDraw = False
+        res2@gsnFrame = False
+        plot2 = gsn_csm_contour(wks, plot_var, res2)
+        opt = True
+        if (diag_script_info@stippling) then
+            opt@gsnShadeFillType = "pattern"
+            opt@gsnShadeMid = 17
+        else
+            opt@gsnShadeFillType = "color"
+            opt@gsnShadeLow = "gray70"
+        end if
+        plot2 = \
+            gsn_contour_shade(plot2, diag_script_info@conf_level, 999., opt)
+        overlay(plot, plot2)
+        draw(plot)
+        frame(wks)
+        log_info(" gv " + outfile + "." + file_type)
+        delete(plot_var@res_cnLevels)
+        delete(wks)
+        delete(plot)
+        delete(plot2)
+        delete(plot_var)
+
+    end do
+
+end

--- a/esmvaltool/diag_scripts/perfmetrics/latlon.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/latlon.ncl
@@ -1,5 +1,5 @@
 ;;#############################################################################
-;; PROCEDURE FOR THE ZONAL PLOT OF THE PERFORMANCE METRICS
+;; PROCEDURE FOR THE LATLON PLOT OF THE PERFORMANCE METRICS
 ;; Authors: Mattia Righi (DLR, Germany) and Franziska Frank (DLR, Germany)
 ;; ESMVal project
 ;;#############################################################################
@@ -7,10 +7,11 @@
 procedure perfmetrics_ptype_script()
 begin
 
-    ;; Start loop over models, make sure reference model is calculated first
+    ;; Set model indexes, with reference model first
     modidx = ispan(0, dim_MOD - 1, 1)
     modidx := array_append_record(ref_ind, modidx(ind(modidx.ne.ref_ind)), 0)
 
+    ;; Loop over models
     do ii = 0, dimsizes(modidx) - 1
         
         imod = modidx(ii)

--- a/esmvaltool/diag_scripts/perfmetrics/main.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/main.ncl
@@ -140,6 +140,11 @@ begin
                              (/"legend_outside", "styleset", "plot_stddev"/))
     end if
 
+    if (ptye.eq."zonal" .and. region.ne."Global") then
+        error_msg("f", diag_script, "", "plot_type " + ptype + \
+                  "implemented only for region='Global'")
+    end if
+
     ;; Check valid field
     if ((ptype.eq."zonal" .and. \
          all(field_type0.ne.(/"T3M", "T2Mz"/))) .or. \
@@ -162,6 +167,8 @@ begin
     set_default_att(diag_script_info, "stippling", False)
     set_default_att(diag_script_info, "t_test", False)
     set_default_att(diag_script_info, "show_global_avg", False)
+    set_default_att(diag_script_info, "zonal_ymin", 5.)
+    set_default_att(diag_script_info, "zonal_ref_cmap", "amwg_blueyellowred")
 
     ;; Check consistency of diff plots settings
     if (diag_script_info@t_test .and. .not.diag_script_info@plot_diff) then
@@ -242,30 +249,6 @@ end
 ;;     delete(data)
 ;;     delete(rank)
 
-;;     ;; Case cycle: (model, time, stats)
-;;     if (ptype.eq."cycle") then
-;;         if (time_avg.eq."seasonalclim") then
-;;             var_all = new((/dim_MOD, 4, 2/), float)
-;;             var_all!1 = "season"
-;;             var_all&season = (/"DJF", "MAM", "JJA", "SON"/)
-;;         else if (time_avg.eq."monthlyclim") then
-;;             var_all = new((/dim_MOD, 12, 2/), float)
-;;             var_all!1 = "month"
-;;             var_all&month = (/"J", "F", "M", "A", "M", "J",\
-;;                               "J", "A", "S", "O", "N", "D"/)
-;;         else
-;;             error_msg("f", diag_script, "", "time_avg option " + time_avg + \
-;;                       " not compatible with plot_type " + ptype)
-;;         end if
-;;         end if
-;;         var_all!0 = "model"
-;;         var_all!2 = "statistic"
-;;         var_all&model = modelnames
-;;         var_all&statistic = (/"mean", "stddev"/)
-;;         if (diag_script_info@plot_diff) then
-;;             var_diff = var_all(:, :, 0)
-;;         end if
-;;     end if
 
 ;;     ;; Case cycle_latlon: (model, time, lat, lon, stats)
 ;;     if (ptype.eq."cycle_latlon") then
@@ -377,44 +360,6 @@ end
 ;;         var = read_data(imod, var0, field_type0)
 ;;         dnames = getVarDimNames(var)
 
-;;         ;; CASE: cycle ########################################################
-;;         if (ptype.eq."cycle") then
-
-;;             ;; Extract region and average over latitude and longitude
-;;             if (any(field_type0.eq.(/"T0M", "T0Ms", "T1M"/))) then
-;;                 var_reg = var
-;;             else if (any(dnames.eq."lat") .and. any(dnames.eq."lon")) then
-;;                 var_reg = area_operations(var, region(0), region(1), \
-;;                                           region(2), region(3), "average", \
-;;                                           True)
-;;             else
-;;                 error_msg("f", diag_script, "", "dimensionality not " + \
-;;                           "implemented")  ; FIXME
-;;             end if
-;;             end if
-;;             delete(var)
-
-;;             ;; Calculate time average
-;;             var_avg = time_operations(var_reg, start_year, end_year, \
-;;                                       "average", time_avg, True)
-
-;;             ;; Calculate time standard deviation (with lower/upper bounds)
-;;             if (start_year.lt.end_year) then
-;;                 var_std = time_operations(var_reg, start_year, end_year, \
-;;                                           "stddev", time_avg, True)
-;;             else
-;;                 var_std = 0.
-;;             end if
-;;             delete(var_reg)
-
-;;             ;; Assign to global array
-;;             var_all(imod, :, 0) = var_avg
-;;             var_all(imod, :, 1) = var_std
-;;             var = var_all(imod, :, :)
-;;             delete(var_avg)
-;;             delete(var_std)
-
-;;         end if
 
 ;;         ;; CASE: cycle_latlon #################################################
 ;;         if (ptype.eq."cycle_latlon") then

--- a/esmvaltool/diag_scripts/perfmetrics/main.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/main.ncl
@@ -136,10 +136,10 @@ begin
                              (/"legend_outside", "styleset", "plot_stddev"/))
     end if
 
-    if (ptype.eq."zonal" .or. ptype.eq."latlon" .and. \
+    if ((ptype.eq."zonal" .or. ptype.eq."latlon") .and. \
         diag_script_info@region.ne."Global") then
         error_msg("f", diag_script, "", "plot_type " + ptype + \
-                  "implemented only for region='Global'")
+                  " implemented only for region='Global'")
     end if
 
     ;; Check valid field
@@ -190,7 +190,7 @@ begin
 ;;TBR    diag_script_base = basename(diag_script)
 
     ;; Unique names for models
-;;TBR    modelnames = project_style(diag_script_info, "annots")
+    modelnames = project_style(diag_script_info, "annots")
 
     ;; Check for reference model definition
     if (variable_info@reference_model.eq."None") then

--- a/esmvaltool/diag_scripts/perfmetrics/main.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/main.ncl
@@ -88,7 +88,6 @@
 
 load "interface_scripts/interface.ncl"
 
-
 load "./diag_scripts/shared/latlon.ncl"
 load "./diag_scripts/shared/statistics.ncl"
 load "./diag_scripts/shared/regridding.ncl"
@@ -120,11 +119,6 @@ begin
                      (/"E_ncep", "E_erainterim", "E_airs", \
                        "E_ceresebaf", "E_srb"/), \
                      (/"P_embrace", "P_esmval"/))
-end
-
-begin
-
-    ;; ### CHECK CONFIGURATION SETTINGS AND SET DEFAULTS ######################
 
     ;; Check required diag_script_info attributes
     exit_if_missing_atts(diag_script_info, \
@@ -132,8 +126,8 @@ begin
 
     ;; Store required attributes
     ptype = diag_script_info@plot_type
-    time_avg = diag_script_info@time_avg
-    region = select_region(diag_script_info@region)
+;;TBR    time_avg = diag_script_info@time_avg
+;;TBR    region = select_region(diag_script_info@region)
 
     if (all(ptype.ne.(/"cycle", "zonal", "latlon", "cycle_latlon"/))) then
         error_msg("f", diag_script, "", "plot_type " + ptype + " is not a " + \
@@ -188,20 +182,20 @@ begin
     end if
 
     ;; Basename of diag_script
-    diag_script_base = basename(diag_script)
+;;TBR    diag_script_base = basename(diag_script)
 
     ;; Unique names for models
-    modelnames = project_style(diag_script_info, "annots")
+;;TBR    modelnames = project_style(diag_script_info, "annots")
 
     ;; Check for reference model definition
-    ref_models = \
-        (/variable_info@reference_model, variable_info@alternative_model/)
-    if (ref_models(0).eq."None") then
+    if (variable_info@reference_model.eq."None") then
         error_msg("f", diag_script, "", "no reference model is specified")
     end if
 
     ;; Set index of the reference (and alternative) model
-    ref_inds = get_ref_model_idx(model_info, ref_models)
+    ref_inds = get_ref_model_idx(model_info, \
+                                 (/variable_info@reference_model, \
+                                   variable_info@alternative_model/))
     ref_ind = ref_inds(0)
     if (dimsizes(ref_inds).gt.1) then
         alt_ind = ref_inds(1)
@@ -220,761 +214,736 @@ begin
         file_type = "ps"
     end if
 
-    ;; ### DEFINE GLOBAL ARRAYS FOR COLLECTING MODEL DATA #####################
+    ;; Load plot-type-specific script
+    print("diag_scripts/perfmetrics/" + ptype + ".ncl")
+    loadscript("diag_scripts/perfmetrics/" + ptype + ".ncl")
 
-    ;; Read common grid from the first model
-    ;; (all models are expected to be regridded to a common grid)
-    data = read_data(0, var0, field_type0)
-    rank = dimsizes(dimsizes(data))
-    if (rank.eq.4) then
-        grid = data(0, :, :, :)  ; plev, lat, lon
-    end if
-    if (rank.eq.3) then
-        grid = data(0, :, :)  ; lat, lon
-    end if
-    delete(data)
-    delete(rank)
+end
 
-    ;; Case cycle: (model, time, stats)
-    if (ptype.eq."cycle") then
-        if (time_avg.eq."seasonalclim") then
-            var_all = new((/dim_MOD, 4, 2/), float)
-            var_all!1 = "season"
-            var_all&season = (/"DJF", "MAM", "JJA", "SON"/)
-        else if (time_avg.eq."monthlyclim") then
-            var_all = new((/dim_MOD, 12, 2/), float)
-            var_all!1 = "month"
-            var_all&month = (/"J", "F", "M", "A", "M", "J",\
-                              "J", "A", "S", "O", "N", "D"/)
-        else
-            error_msg("f", diag_script, "", "time_avg option " + time_avg + \
-                      " not compatible with plot_type " + ptype)
-        end if
-        end if
-        var_all!0 = "model"
-        var_all!2 = "statistic"
-        var_all&model = modelnames
-        var_all&statistic = (/"mean", "stddev"/)
-        if (diag_script_info@plot_diff) then
-            var_diff = var_all(:, :, 0)
-        end if
-    end if
+begin
 
-    ;; Case cycle_latlon: (model, time, lat, lon, stats)
-    if (ptype.eq."cycle_latlon") then
-        sgrid = area_operations(grid, region(0), region(1), region(2), \
-                                region(3), "extract", False)
-        if (time_avg.eq."seasonalclim") then
-            var_all = new((/dim_MOD, 4, dimsizes(sgrid&lat), \
-                          dimsizes(sgrid&lon), 2/), float)
-            var_all!1 = "season"
-            var_all&season = (/"DJF", "MAM", "JJA", "SON"/)
-        else if (time_avg.eq."monthlyclim") then
-            var_all = new((/dim_MOD, 12, dimsizes(sgrid&lat), \
-                          dimsizes(sgrid&lon), 2/), float)
-            var_all!1 = "month"
-            var_all&month = (/"J", "F", "M", "A", "M", "J",\
-                              "J", "A", "S", "O", "N", "D"/)
-        else
-            error_msg("f", diag_script, "", "time_avg option " + time_avg + \
-                      " not compatible with plot_type " + ptype)
-        end if
-        end if
-        var_all!0 = "model"
-        var_all!2 = "lat"
-        var_all!3 = "lon"
-        var_all!4 = "statistic"
-        var_all&model = modelnames
-        var_all&lat = sgrid&lat
-        var_all&lon = sgrid&lon
-        var_all&statistic = (/"mean", "stddev"/)
-        if (diag_script_info@plot_diff) then
-            var_diff = var_all(:, :, :, :, 0)
-        end if
-        delete(sgrid)
-    end if
-
-    ;; Case zonal: (model, level, lat, stats)
-    if (ptype.eq."zonal") then
-        var_all = new((/dim_MOD, dimsizes(grid&plev), \
-                      dimsizes(grid&lat), 2/), float)
-        var_all!0 = "model"
-        var_all!1 = "plev"
-        var_all!2 = "lat"
-        var_all!3 = "statistic"
-        var_all&model = modelnames
-        var_all&plev = grid&plev
-        var_all&lat = grid&lat
-        var_all&statistic = (/"mean", "stddev"/)
-        if (diag_script_info@plot_diff) then
-            var_diff = var_all(:, :, :, 0)
-        end if
-    end if
-
-    ;; Case latlon: (model, lat, lon, stats)
-    if (ptype.eq."latlon") then
-        var_all = new((/dim_MOD, dimsizes(grid&lat), \
-                      dimsizes(grid&lon), 2/), float)
-        var_all!0 = "model"
-        var_all!1 = "lat"
-        var_all!2 = "lon"
-        var_all!3 = "statistic"
-        var_all&model = modelnames
-        var_all&lat = grid&lat
-        var_all&lon = grid&lon
-        var_all&statistic = (/"mean", "stddev"/)
-        if (diag_script_info@plot_diff) then
-            var_diff = var_all(:, :, :, 0)
-        end if
-    end if
-
-    ; If needed, create array for statistically significant grid cells
-    if (diag_script_info@t_test) then
-        var_sig = var_diff
-    end if
-
-    ;; Variable rank: cycle:3, zonal/latlon:4, cycle_latlon:5
-    irank = dimsizes(dimsizes(var_all))
-
-    ;; Attach attributes
-    var_all@var = var0
-    var_all@diag_script = (/diag_script/)
-    copy_VarAtts(diag_script_info, var_all)
-    var_all@ref_model = str_get_field(ref_models(0), 1, ",")
-
-    ;; ### MAIN LOOP OVER MODELS AND DATA PROCESSING ##########################
-
-    ;; Loop over models
-    do imod = 0, dim_MOD - 1
-
-        log_debug("Processing " + modelnames(imod))
-
-        ;; Set path for saving processed data ;; FIX-ME add preproc_id
-        fullpath = config_user_info@work_dir + "/"
-        system("mkdir -p " + fullpath)
-        fname = basename(systemfunc("basename " + model_info@filename(imod)))
-        fname = fname + "_" + basename(diag_script)
-        fname = fname + "_" + diag_script_info@plot_type
-        fname = fname + "_" + diag_script_info@time_avg
-        if (isatt(diag_script_info, "level")) then
-            fname = fname + "_" + diag_script_info@level  ; FIX-ME
-        end if
-        fname = fname + "_" + str_sub_str(diag_script_info@region, " ", "")
-        procpath = fullpath + fname + ".nc"
-
-        ;; Determine start/end year
-        start_year = get_start_year(imod)
-        end_year = get_end_year(imod)
-
-        ;; Read data
-        var = read_data(imod, var0, field_type0)
-        dnames = getVarDimNames(var)
-
-        ;; CASE: cycle ########################################################
-        if (ptype.eq."cycle") then
-
-            ;; Extract region and average over latitude and longitude
-            if (any(field_type0.eq.(/"T0M", "T0Ms", "T1M"/))) then
-                var_reg = var
-            else if (any(dnames.eq."lat") .and. any(dnames.eq."lon")) then
-                var_reg = area_operations(var, region(0), region(1), \
-                                          region(2), region(3), "average", \
-                                          True)
-            else
-                error_msg("f", diag_script, "", "dimensionality not " + \
-                          "implemented")  ; FIXME
-            end if
-            end if
-            delete(var)
-
-            ;; Calculate time average
-            var_avg = time_operations(var_reg, start_year, end_year, \
-                                      "average", time_avg, True)
-
-            ;; Calculate time standard deviation (with lower/upper bounds)
-            if (start_year.lt.end_year) then
-                var_std = time_operations(var_reg, start_year, end_year, \
-                                          "stddev", time_avg, True)
-            else
-                var_std = 0.
-            end if
-            delete(var_reg)
-
-            ;; Assign to global array
-            var_all(imod, :, 0) = var_avg
-            var_all(imod, :, 1) = var_std
-            var = var_all(imod, :, :)
-            delete(var_avg)
-            delete(var_std)
-
-        end if
-
-        ;; CASE: cycle_latlon #################################################
-        if (ptype.eq."cycle_latlon") then
-
-            ;; Extract region
-            var_reg = area_operations(var, region(0), region(1), \
-                                      region(2), region(3), "extract", True)
-            delete(var)
-
-            ;; Calculate time average
-            var_avg = time_operations(var_reg, start_year, end_year, \
-                                      "average", time_avg, True)
-            delete(var_reg)
-
-            ;; Standard deviation calculation for this rank is not implemented
-            ;; yet in statistics.ncl (but is anyway not required here)
-
-            ;; Assign to global array
-            var_all(imod, :, :, :, 0) = var_avg
-            delete(var_avg)
-            var = var_all(imod, :, :, :, :)
-
-        end if
-
-        ;; CASE: zonal ########################################################
-        if (ptype.eq."zonal") then
-
-            ;; Calculate zonal mean
-            var_zon = dim_avg_Wrap(var)
-            delete(var)
-
-            ;; Calculate time average and standard deviation w.r.t.
-            ;; interannual variability
-            var_avg = time_operations(var_zon, start_year, end_year, \
-                                      "average", time_avg, True)
-            var_std = interannual_variability(var_zon, start_year, end_year, \
-                                              time_avg)
-            delete(var_zon)
-
-            ;; Assign to global array
-            var_all(imod, :, :, 0) = var_avg
-            var_all(imod, :, :, 1) = var_std
-            var = var_all(imod, :, :, :)
-            delete(var_avg)
-            delete(var_std)
-
-        end if
-
-        ;; CASE: latlon #######################################################
-        if (ptype.eq."latlon") then
-
-            ;; Calculate time average and standard deviation w.r.t.
-            ;; interannual variability
-            var_avg = time_operations(var, start_year, end_year, \
-                                      "average", time_avg, True)
-            var_std = interannual_variability(var, start_year, end_year, \
-                                              time_avg)
-            delete(var)
-
-            ;; Assign to global array
-            var_all(imod, :, :, 0) = var_avg
-            var_all(imod, :, :, 1) = var_std
-            var = var_all(imod, :, :, :)
-            delete(var_avg)
-            delete(var_std)
-        end if
-
-        ;; Optional output to NetCDF
-        if (config_user_info@write_netcdf.eq."True") then
-            var@ncdf = procpath
-            ncdf_outfile = ncdf_write(var, procpath)
-        end if
-        delete(var)
-        delete(procpath)
-
-    end do
-
-    ;; ### CALCULATE DIFFERENCES AND APPLY STATISTICAL TESTS ##################
-
-    ;; Calculate differences and apply t-test
-    if (diag_script_info@plot_diff) then
-
-        do imod = 0, dim_MOD - 1
-
-            ;; Skip the reference model as result will be zero
-            if (imod.eq.ref_ind) then
-                continue
-            end if
-
-            if (irank.eq.4) then
-
-                ;; Difference
-                var_diff(imod, :, :) = var_all(imod, :, :, 0)  ; save metadata
-                var_diff(imod, :, :) = var_all(imod, :, :, 0) - \
-                    var_all(ref_ind, :, :, 0)
-
-                ;; t-test (assuming different population variances)
-                if (diag_script_info@t_test) then
-                    x1 = var_all(imod, :, :, 0)
-                    x2 = var_all(ref_ind, :, :, 0)
-                    s1 = var_all(imod, :, :, 1) ^ 2
-                    s2 = var_all(ref_ind, :, :, 1) ^ 2
-                    n1 = get_end_year(imod) - get_start_year(imod) + 1
-                    n2 = get_end_year(ref_ind) - get_start_year(ref_ind) + 1
-                    prob = ttest(x1, s1, n1, x2, s2, n2, True, False)
-                    var_sig(imod, :, :) = 1. - prob
-                    var_diff@conf_level = diag_script_info@conf_level
-                    delete(prob)
-                end if
-
-            end if
-
-            if (irank.eq.3) then
-
-                ;; Difference
-                var_diff(imod, :) = var_all(imod, :, 0)  ; save metadata
-                var_diff(imod, :) = var_all(imod, :, 0) - \
-                    var_all(ref_ind, :, 0)
-
-                ;; t-test (assuming different population variances)
-                if (diag_script_info@t_test) then
-                    x1 = var_all(imod, :, 0)
-                    x2 = var_all(ref_ind, :, 0)
-                    s1 = var_all(imod, :, 1) ^ 2
-                    s2 = var_all(ref_ind, :, 1) ^ 2
-                    n1 = get_end_year(imod) - get_start_year(imod) + 1
-                    n2 = get_end_year(ref_ind) - get_start_year(ref_ind) + 1
-                    prob = ttest(x1, s1, n1, x2, s2, n2, True, False)
-                    var_sig(imod, :) = 1. - prob
-                    delete(prob)
-                end if
-
-            end if
-
-        end do
-    end if
-
-    ;; ### GRADING ############################################################
-
-    if (diag_script_info@calc_grading) then  ; FIX-ME loop over metrics?
-
-        ;; Annotation & file names
-        region_name = ""  ; priority 3
-        location = ""  ; priority 3
-        if(isatt(diag_script_info, "aux_info")) then
-            region_name = "_" + diag_script_info@aux_info  ; priority 2
-            location = " - " + diag_script_info@aux_info  ; priority 2
-        end if
-        if(isatt(diag_script_info, "location")) then
-            location = " - " + diag_script_info@location  ; priority 1
-        end if
-        if(isatt(diag_script_info, "region")) then
-            region_name = "_" + region@name  ; priority 1
-            location = " - " + diag_script_info@region
-        end if
-        altitude = ""  ; priority 2
-        if(any(field_type0.eq.(/"T0M", "T0Ms"/))) then
-            if(isatt(diag_script_info, "altitude")) then
-                altitude = " - " + diag_script_info@altitude  ; priority 1
-            end if
-        else
-            if(isatt(diag_script_info, "level")) then
-                altitude = " - " + diag_script_info@level + " hPa"  ; priority1
-            end if
-        end if
-
-        ;; Set variable name
-        var0_new = var0
-        var0_new = var0_new + region_name
-        if(isatt(diag_script_info, "level").and. \
-            any(field_type0.eq.(/"T3M", "T1M"/))) then
-            var0_new = var0_new + "-" + diag_script_info@level
-        end if
-
-        ;; Define grading filename
-        ncdf_dir = config_user_info@work_dir + "/" + \
-            diag_script_info@metric + "_" + var0_new + ".nc"
-
-        ;; Create separate arrays for models and observations
-        if (diag_script_info@metric.eq."taylor") then
-            id_remove = ref_ind
-        else
-            id_remove = ref_inds
-        end if
-        super_array = var_all
-        models_only = remove_index(super_array, id_remove)
-        nmodels = dimsizes(models_only&model)
-        if (l_altern .and. diag_script_info@metric.ne."taylor") then
-            if (irank.eq.3) then
-                obs_only = super_array(id_remove, :, :)
-            end if
-            if (irank.eq.4) then
-                obs_only = super_array(id_remove, :, :, :)
-            end if
-            if (irank.eq.5) then
-                obs_only = super_array(id_remove, :, :, :, :)
-            end if
-        else  ; avoid dimension reduction
-            if (irank.eq.3) then
-                obs_only = super_array(id_remove:id_remove, :, :)
-            end if
-            if (irank.eq.4) then
-                obs_only = super_array(id_remove:id_remove, :, :, :)
-            end if
-            if (irank.eq.5) then
-                obs_only = super_array(id_remove:id_remove, :, :, :, :)
-            end if
-        end if
-        nobs = dimsizes(obs_only&model)
-        delete(super_array)
-
-        ;; Define result variable
-        ;; A dummy coordinate "diagnostics" (size 1) is added to facilitate
-        ;; appending different variable in the _collect script
-        if (diag_script_info@metric.eq."taylor") then
-            grading = new((/dim_VAR, nmodels, 2/), float)
-            grading!2 = "statistic"
-            grading&statistic = (/"stddev_ratio", "correlation"/)
-        else
-            grading = new((/dim_VAR, nmodels, nobs/), float)
-            grading!2 = "reference"
-            grading&reference = obs_only&model
-        end if
-        grading!0 = "diagnostics"
-        grading!1 = "models"
-        grading&diagnostics = var0_new
-        grading&models = models_only&model
-
-        grading@ncdf_dir = ncdf_dir
-
-        ;; Loop over models, calculate metric
-        do imod = 0, nmodels - 1
-            do iobs = 0, nobs - 1
-                if (irank.eq.3) then
-                    model = models_only(imod, :, 0)
-                    obs = obs_only(iobs, :, 0)
-                end if
-                if (irank.eq.4) then
-                    model = models_only(imod, :, :, 0)
-                    obs = obs_only(iobs, :, :, 0)
-                end if
-                if (irank.eq.5) then
-                    model = models_only(imod, :, :, :, 0)
-                    obs = obs_only(iobs, :, :, :, 0)
-                end if
-                if (diag_script_info@metric.eq."taylor") then
-                    grading(0, imod, 0) = \
-                        calculate_metric(model, obs, "stddev_ratio")
-                    grading(0, imod, 1) = \
-                        calculate_metric(model, obs, "correlation")
-                else
-                    grading(0, imod, iobs) = \
-                        calculate_metric(model, obs, diag_script_info@metric)
-                end if
-            end do
-        end do
-
-        ;; Apply normalization
-        if (diag_script_info@metric.ne."taylor") then
-            do iobs = 0, nobs - 1
-                grading(:, :, iobs) = \
-                    normalize_metric(grading(:, :, iobs), \
-                                     diag_script_info@normalization)
-            end do
-        end if
-
-        ;; Reduce dimensionality if no alternative model
-        if (.not.l_altern .and. diag_script_info@metric.ne."taylor") then
-            grading := grading(:, :, 0)
-            delete(grading@reference)
-        end if
-
-        ;; Attach attributes to the results
-        grading@title = diag_script_info@metric + "metric"
-        grading@long_name = \
-            "Grading table of metric " + diag_script_info@metric
-        grading@metric = diag_script_info@metric
-        grading@diag_script = (/diag_script/)
-        grading@var = "grade"  ; FIX-ME ?
-        grading@region = location
-        grading@num_climofiles = dimsizes(model_info@model)  ; for tagging
-        do imod = 0, dimsizes(model_info@model) - 1
-            num_climo = "climofile_" + imod
-            grading@$num_climo$ = input_file_info@filename(imod)
-        end do
-
-        ;; Write NetCDF output
-        ncdf_outfile = ncdf_write(grading, grading@ncdf_dir)
-
-        ;; Write results of temporary grading list
-        temp_dir = config_user_info@work_dir + "/"
-        if (diag_script_info@metric.eq."taylor") then
-            temp_dir = temp_dir + "taylor.nc"
-        else
-            temp_dir = temp_dir + "grading.nc"
-        end if
-
-        if (fileexists(temp_dir)) then
-            temp_file = addfile(temp_dir, "r")
-            temp_list = temp_file->temp_list
-            temp_list_string = tostring(temp_list)
-            temp_list_new_string = array_append_record(temp_list_string, \
-                                                       ncdf_dir, 0)
-            temp_list_new = tochar(temp_list_new_string)
-            system("rm -f " + temp_dir)
-        else
-            ncdf_char = tochar(ncdf_dir)
-            temp_list_new = new((/1, dimsizes(ncdf_char)/), character)
-            temp_list_new(0, :) = ncdf_char
-        end if
-
-        ;; Create new file and add list
-        temp = addfile(temp_dir, "c")
-        temp->temp_list = temp_list_new
-
-    end if
-
-    ;; ### PLOTTING ###########################################################
-
-    if (diag_script_info@draw_plots) then
-
-        ;; Convert units for plotting (if required)
-        if (isatt(variable_info, "plot_units")) then
-            var_all = convert_units(var_all, variable_info@plot_units)
-            if (diag_script_info@plot_diff) then
-                var_diff = convert_units(var_diff, variable_info@plot_units)
-            end if
-        end if
-
-        ;; Plot output directory
-        output_dir = config_user_info@plot_dir
-
-        ;; Annotation and file names
-        region_name = ""  ; priority 3
-        location = ""  ; priority 3
-        if (isatt(diag_script_info, "aux_info")) then
-            region_name = "_" + diag_script_info@aux_info  ; priority 2
-            location = " - " + diag_script_info@aux_info  ; priority 2
-        end if
-        if (isatt(diag_script_info, "location")) then
-            location = " - " + diag_script_info@location  ; priority 1
-        end if
-        if (isatt(diag_script_info, "region")) then
-            region_name = "_" + region@name  ; priority 1
-            location = " - " + diag_script_info@region
-        end if
-        if (isatt(var_all, "long_name")) then
-            varstring = var_all@long_name  ; priority 3
-        end if
-        if (isatt(var_all, "short_name")) then
-            varstring = var_all@short_name  ; priority 2
-        end if
-        if (isStrSubset(var0, "vmr").and.isStrSubset(var0, "_")) then
-            varstring = var0  ; priority 1
-        end if
-        altitude = ""  ; priority 2
-        if (any(field_type0.eq.(/"T0M", "T0Ms"/))) then
-            if (isatt(diag_script_info, "altitude")) then
-                altitude = " - " + diag_script_info@altitude  ; priority 1
-            end if
-        else
-            if (isatt(diag_script_info, "level")) then  ; FIX-ME
-                if (diag_script_info@level.ne."all") then
-                    altitude = " - " + diag_script_info@level + " hPa"
-                end if
-            end if
-        end if
-
-        ;; CASE: cycle ########################################################
-        if (ptype.eq."cycle") then
-            outfile = output_dir + var0 + "_" + \
-                ptype + "_" + time_avg + "_" + region_name
-            wks = gsn_open_wks(file_type, outfile)
-            wks@legendfile = outfile + "_legend"
-            var_all@res_tiMainString = varstring
-            var_all@res_tiMainString = var_all@res_tiMainString + \
-                location + altitude
-            plot = cycle_plot(wks, var_all, var0)
-            draw(plot)
-            frame(wks)
-            log_info(" gv " + outfile + "." + file_type)
-        end if
-
-        ;; CASE: zonal ########################################################
-        if (ptype.eq."zonal") then
-            do imod = 0, dim_MOD - 1
-                outfile = output_dir + \
-                    modelnames(imod) + "_" + var0 + "_" + ptype + "_" + \
-                    time_avg + region_name
-                var = var_all(imod, :, :, 0)
-                var@res_tiMainString = modelnames(imod)
-                var@res_cnLevelSelectionMode = "ExplicitLevels"
-                var@res_cnLevels = diag_script_info@abs_levs
-                if (isatt(variable_info, "zonal_ymin")) then
-                    var@res_trYMinF = variable_info@zonal_ymin
-                else
-                    var@res_trYMinF = 5.
-                end if
-                var@res_gsnLeftString = var@long_name + " [" + \
-                    format_units(var@units) + "]"
-                wks = gsn_open_wks(file_type, outfile)
-                if (isatt(variable_info, "zonal_ref_cmap")) then
-                    gsn_define_colormap(wks, variable_info@zonal_ref_cmap)
-                else
-                    gsn_define_colormap(wks, "amwg_blueyellowred")
-                end if
-                plot = zonalmean_profile(wks, var, var0)
-                draw(plot)
-                frame(wks)
-                log_info(" gv " + outfile + "." + file_type)
-                delete(var@res_cnLevels)
-                delete(wks)
-                delete(plot)
-
-                ;; Difference plot to the reference
-                if (.not.diag_script_info@plot_diff .or. imod.eq.ref_ind) then
-                    continue
-                end if
-                var = var_diff(imod, :, :)
-                outfile = output_dir + \
-                    modelnames(imod) + "-" + modelnames(ref_ind) + "_" + \
-                    var0 + "_" + ptype + "_" + time_avg + region_name
-                var@res_tiMainString = modelnames(imod) + " - " + \
-                    modelnames(ref_ind)
-                if (isatt(diag_script_info, "conf_level")) then
-                    var@res_gsnLeftString = var@res_gsnLeftString + " - " + \
-                    sprinti("%2i", toint(100 * diag_script_info@conf_level)) \
-                    + "% c.l."
-                end if
-                var@res_cnLevelSelectionMode = "ExplicitLevels"
-                var@res_cnLevels = diag_script_info@diff_levs
-                var@res_cnMissingValFillColor = "gray70"
-                var@res_gsnSpreadColorEnd = -2
-                wks = gsn_open_wks(file_type, outfile)
-                gsn_merge_colormaps(wks, "temp_19lev", "gray70")
-                plot = zonalmean_profile(wks, var, var0)
-
-                ;; Stippling ;; FIX-ME False option not considered (see below)
-                var = var_sig(imod, :, :)
-                var@res_cnMissingValFillColor = -1
-                var@res_gsnSpreadColorEnd = -2
-                var@res_gsnDraw = False
-                var@res_gsnFrame = False
-                var@res_cnLevelSelectionMode = "ExplicitLevels"
-                var@res_cnFillColors = (/"transparent", "black"/)
-                var@res_cnLevels := diag_script_info@conf_level
-                var@res_cnInfoLabelOn = False
-                var@res_cnLinesOn = False
-                var@res_cnLineLabelsOn = False
-                var@res_lbLabelBarOn = False
-                var@res_cnFillPattern = 17
-                delete(var@long_name)
-                plot2 = zonalmean_profile(wks, var, var0)
-                overlay(plot, plot2)
-                draw(plot)
-                frame(wks)
-                log_info(" gv " + outfile + "." + file_type)
-                delete(var@res_cnLevels)
-                delete(wks)
-                delete(plot)
-                delete(plot2)
-                delete(var)
-            end do
-        end if
-
-        ;; CASE: latlon #######################################################
-        if (ptype.eq."latlon") then
-            do imod = 0, dim_MOD - 1
-                outfile = output_dir + \
-                    modelnames(imod) + "_" + var0 + "_" + ptype + "_" + \
-                    time_avg + "_" + region_name
-                var = var_all(imod, :, :, 0)
-                var@projection = diag_script_info@projection
-                var@res_cnLinesOn = False
-                var@res_cnLevelSelectionMode = "ExplicitLevels"
-                var@res_tiMainString = modelnames(imod)
-                var@res_cnLevels = diag_script_info@abs_levs
-                var@res_gsnLeftString = var@long_name + " [" + \
-                    format_units(var@units) + "]"
-
-                ;; Append global field average
-                if (diag_script_info@show_global_avg) then
-                    gavg = area_operations(var, -90., 90., 0., 360., \
-                                           "average", True)
-                    var@res_gsnRightString = \
-                        sprintf("%5.2f", gavg) + " " + format_units(var@units)
-                end if
-                wks = gsn_open_wks(file_type, outfile)
-                if (isatt(variable_info, "map_ref_cmap")) then
-                    gsn_define_colormap(wks, variable_info@map_ref_cmap)
-                else
-                    gsn_define_colormap(wks, "amwg_blueyellowred")
-                end if
-                plot = contour_map_ce(wks, var, var0)
-                draw(plot)
-                frame(wks)
-                log_info(" gv " + outfile + "." + file_type)
-                delete(var@res_cnLevels)
-                delete(wks)
-                delete(plot)
-
-                ;; Difference plot to the reference
-                if (.not.diag_script_info@plot_diff .or. imod.eq.ref_ind) then
-                    continue
-                end if
-                var = var_diff(imod, :, :)
-                outfile = output_dir + \
-                    modelnames(imod) + "-" + modelnames(ref_ind) + "_" + \
-                    var0 + "_" + ptype + "_" + time_avg + "_" + region_name
-                var@res_tiMainString = modelnames(imod) + " - " + \
-                    modelnames(ref_ind)
-                if (isatt(diag_script_info, "conf_level")) then
-                    var@res_gsnLeftString = var@res_gsnLeftString + " - " + \
-                    sprinti("%2i", toint(100 * diag_script_info@conf_level)) \
-                    + "% c.l."
-                end if
-                var@res_cnLevelSelectionMode = "ExplicitLevels"
-                var@res_cnLevels = diag_script_info@diff_levs
-                var@res_cnMissingValFillColor = "gray70"
-                var@res_gsnSpreadColorEnd = -2
-                var@projection = diag_script_info@projection
-
-                ;; Append global field averag
-                if (diag_script_info@show_global_avg) then
-                    gavg = area_operations(var, -90., 90., 0., 360., \
-                                           "average", True)
-                    var@res_gsnRightString = \
-                        sprintf("%5.2f", gavg) + " " + format_units(var@units)
-                end if
-                wks = gsn_open_wks(file_type, outfile)
-                gsn_merge_colormaps(wks, "temp_19lev", "gray70")
-                plot = contour_map_ce(wks, var, var0)
-
-                ;; Stippling/masking
-                res2 = True
-                res2@cnLevelSelectionMode = "ExplicitLevels"
-                res2@cnLevels = (/0.0, diag_script_info@conf_level, 1.0/)
-                res2@cnInfoLabelOn = False
-                res2@cnLinesOn = False
-                res2@cnLineLabelsOn = False
-                res2@gsnDraw = False
-                res2@gsnFrame = False
-                plot2 = gsn_csm_contour(wks, var_sig(imod, :, :), res2)
-                opt = True
-                if (diag_script_info@stippling) then
-                    opt@gsnShadeFillType = "pattern"
-                    opt@gsnShadeMid = 17
-                else
-                    opt@gsnShadeFillType = "color"
-                    opt@gsnShadeLow = "gray70"
-                end if
-                plot2 = gsn_contour_shade(plot2, diag_script_info@conf_level, \
-                                          999., opt)
-                overlay(plot, plot2)
-                draw(plot)
-                frame(wks)
-                log_info(" gv " + outfile + "." + file_type)
-                delete(var@res_cnLevels)
-                delete(wks)
-                delete(plot)
-                delete(plot2)
-                delete(var)
-            end do
-
-        end if
-    end if
-
+    perfmetrics_ptype_script()
     leave_msg(diag_script, "")
 
 end
+
+;;     ;; ### DEFINE GLOBAL ARRAYS FOR COLLECTING MODEL DATA #####################
+
+;;     ;; Read common grid from the first model
+;;     ;; (all models are expected to be regridded to a common grid)
+;;     data = read_data(0, var0, field_type0)
+;;     rank = dimsizes(dimsizes(data))
+;;     if (rank.eq.4) then
+;;         grid = data(0, :, :, :)  ; plev, lat, lon
+;;     end if
+;;     if (rank.eq.3) then
+;;         grid = data(0, :, :)  ; lat, lon
+;;     end if
+;;     delete(data)
+;;     delete(rank)
+
+;;     ;; Case cycle: (model, time, stats)
+;;     if (ptype.eq."cycle") then
+;;         if (time_avg.eq."seasonalclim") then
+;;             var_all = new((/dim_MOD, 4, 2/), float)
+;;             var_all!1 = "season"
+;;             var_all&season = (/"DJF", "MAM", "JJA", "SON"/)
+;;         else if (time_avg.eq."monthlyclim") then
+;;             var_all = new((/dim_MOD, 12, 2/), float)
+;;             var_all!1 = "month"
+;;             var_all&month = (/"J", "F", "M", "A", "M", "J",\
+;;                               "J", "A", "S", "O", "N", "D"/)
+;;         else
+;;             error_msg("f", diag_script, "", "time_avg option " + time_avg + \
+;;                       " not compatible with plot_type " + ptype)
+;;         end if
+;;         end if
+;;         var_all!0 = "model"
+;;         var_all!2 = "statistic"
+;;         var_all&model = modelnames
+;;         var_all&statistic = (/"mean", "stddev"/)
+;;         if (diag_script_info@plot_diff) then
+;;             var_diff = var_all(:, :, 0)
+;;         end if
+;;     end if
+
+;;     ;; Case cycle_latlon: (model, time, lat, lon, stats)
+;;     if (ptype.eq."cycle_latlon") then
+;;         sgrid = area_operations(grid, region(0), region(1), region(2), \
+;;                                 region(3), "extract", False)
+;;         if (time_avg.eq."seasonalclim") then
+;;             var_all = new((/dim_MOD, 4, dimsizes(sgrid&lat), \
+;;                           dimsizes(sgrid&lon), 2/), float)
+;;             var_all!1 = "season"
+;;             var_all&season = (/"DJF", "MAM", "JJA", "SON"/)
+;;         else if (time_avg.eq."monthlyclim") then
+;;             var_all = new((/dim_MOD, 12, dimsizes(sgrid&lat), \
+;;                           dimsizes(sgrid&lon), 2/), float)
+;;             var_all!1 = "month"
+;;             var_all&month = (/"J", "F", "M", "A", "M", "J",\
+;;                               "J", "A", "S", "O", "N", "D"/)
+;;         else
+;;             error_msg("f", diag_script, "", "time_avg option " + time_avg + \
+;;                       " not compatible with plot_type " + ptype)
+;;         end if
+;;         end if
+;;         var_all!0 = "model"
+;;         var_all!2 = "lat"
+;;         var_all!3 = "lon"
+;;         var_all!4 = "statistic"
+;;         var_all&model = modelnames
+;;         var_all&lat = sgrid&lat
+;;         var_all&lon = sgrid&lon
+;;         var_all&statistic = (/"mean", "stddev"/)
+;;         if (diag_script_info@plot_diff) then
+;;             var_diff = var_all(:, :, :, :, 0)
+;;         end if
+;;         delete(sgrid)
+;;     end if
+
+;;     ;; Case zonal: (model, level, lat, stats)
+;;     if (ptype.eq."zonal") then
+;;         var_all = new((/dim_MOD, dimsizes(grid&plev), \
+;;                       dimsizes(grid&lat), 2/), float)
+;;         var_all!0 = "model"
+;;         var_all!1 = "plev"
+;;         var_all!2 = "lat"
+;;         var_all!3 = "statistic"
+;;         var_all&model = modelnames
+;;         var_all&plev = grid&plev
+;;         var_all&lat = grid&lat
+;;         var_all&statistic = (/"mean", "stddev"/)
+;;         if (diag_script_info@plot_diff) then
+;;             var_diff = var_all(:, :, :, 0)
+;;         end if
+;;     end if
+
+;;     ;; Case latlon: (model, lat, lon, stats)
+;;     if (ptype.eq."latlon") then
+;;         var_all = new((/dim_MOD, dimsizes(grid&lat), \
+;;                       dimsizes(grid&lon), 2/), float)
+;;         var_all!0 = "model"
+;;         var_all!1 = "lat"
+;;         var_all!2 = "lon"
+;;         var_all!3 = "statistic"
+;;         var_all&model = modelnames
+;;         var_all&lat = grid&lat
+;;         var_all&lon = grid&lon
+;;         var_all&statistic = (/"mean", "stddev"/)
+;;         if (diag_script_info@plot_diff) then
+;;             var_diff = var_all(:, :, :, 0)
+;;         end if
+;;     end if
+
+;;     ; If needed, create array for statistically significant grid cells
+;;     if (diag_script_info@t_test) then
+;;         var_sig = var_diff
+;;     end if
+
+;;     ;; Variable rank: cycle:3, zonal/latlon:4, cycle_latlon:5
+;;     irank = dimsizes(dimsizes(var_all))
+
+;;     ;; Attach attributes
+;;     var_all@var = var0
+;;     var_all@diag_script = (/diag_script/)
+;;     copy_VarAtts(diag_script_info, var_all)
+;;     var_all@ref_model = variable_info@reference_model
+
+;;     ;; ### MAIN LOOP OVER MODELS AND DATA PROCESSING ##########################
+
+;;     ;; Loop over models
+;;     do imod = 0, dim_MOD - 1
+
+;;         log_debug("Processing " + modelnames(imod))
+
+;;         ;; Set path for saving processed data ;; FIX-ME add preproc_id
+;;         fullpath = config_user_info@work_dir + "/"
+;;         system("mkdir -p " + fullpath)
+;;         fname = basename(systemfunc("basename " + model_info@filename(imod)))
+;;         fname = fname + "_" + basename(diag_script)
+;;         fname = fname + "_" + diag_script_info@plot_type
+;;         fname = fname + "_" + diag_script_info@time_avg
+;;         if (isatt(diag_script_info, "level")) then
+;;             fname = fname + "_" + diag_script_info@level  ; FIX-ME
+;;         end if
+;;         fname = fname + "_" + str_sub_str(diag_script_info@region, " ", "")
+;;         procpath = fullpath + fname + ".nc"
+
+;;         ;; Determine start/end year
+;;         start_year = get_start_year(imod)
+;;         end_year = get_end_year(imod)
+
+;;         ;; Read data
+;;         var = read_data(imod, var0, field_type0)
+;;         dnames = getVarDimNames(var)
+
+;;         ;; CASE: cycle ########################################################
+;;         if (ptype.eq."cycle") then
+
+;;             ;; Extract region and average over latitude and longitude
+;;             if (any(field_type0.eq.(/"T0M", "T0Ms", "T1M"/))) then
+;;                 var_reg = var
+;;             else if (any(dnames.eq."lat") .and. any(dnames.eq."lon")) then
+;;                 var_reg = area_operations(var, region(0), region(1), \
+;;                                           region(2), region(3), "average", \
+;;                                           True)
+;;             else
+;;                 error_msg("f", diag_script, "", "dimensionality not " + \
+;;                           "implemented")  ; FIXME
+;;             end if
+;;             end if
+;;             delete(var)
+
+;;             ;; Calculate time average
+;;             var_avg = time_operations(var_reg, start_year, end_year, \
+;;                                       "average", time_avg, True)
+
+;;             ;; Calculate time standard deviation (with lower/upper bounds)
+;;             if (start_year.lt.end_year) then
+;;                 var_std = time_operations(var_reg, start_year, end_year, \
+;;                                           "stddev", time_avg, True)
+;;             else
+;;                 var_std = 0.
+;;             end if
+;;             delete(var_reg)
+
+;;             ;; Assign to global array
+;;             var_all(imod, :, 0) = var_avg
+;;             var_all(imod, :, 1) = var_std
+;;             var = var_all(imod, :, :)
+;;             delete(var_avg)
+;;             delete(var_std)
+
+;;         end if
+
+;;         ;; CASE: cycle_latlon #################################################
+;;         if (ptype.eq."cycle_latlon") then
+
+;;             ;; Extract region
+;;             var_reg = area_operations(var, region(0), region(1), \
+;;                                       region(2), region(3), "extract", True)
+;;             delete(var)
+
+;;             ;; Calculate time average
+;;             var_avg = time_operations(var_reg, start_year, end_year, \
+;;                                       "average", time_avg, True)
+;;             delete(var_reg)
+
+;;             ;; Standard deviation calculation for this rank is not implemented
+;;             ;; yet in statistics.ncl (but is anyway not required here)
+
+;;             ;; Assign to global array
+;;             var_all(imod, :, :, :, 0) = var_avg
+;;             delete(var_avg)
+;;             var = var_all(imod, :, :, :, :)
+
+;;         end if
+
+;;         ;; CASE: zonal ########################################################
+;;         if (ptype.eq."zonal") then
+
+;;             ;; Calculate zonal mean
+;;             var_zon = dim_avg_Wrap(var)
+;;             delete(var)
+
+;;             ;; Calculate time average and standard deviation w.r.t.
+;;             ;; interannual variability
+;;             var_avg = time_operations(var_zon, start_year, end_year, \
+;;                                       "average", time_avg, True)
+;;             var_std = interannual_variability(var_zon, start_year, end_year, \
+;;                                               time_avg)
+;;             delete(var_zon)
+
+;;             ;; Assign to global array
+;;             var_all(imod, :, :, 0) = var_avg
+;;             var_all(imod, :, :, 1) = var_std
+;;             var = var_all(imod, :, :, :)
+;;             delete(var_avg)
+;;             delete(var_std)
+
+;;         end if
+
+;;         ;; CASE: latlon #######################################################
+;;         if (ptype.eq."latlon") then
+
+;;             ;; Calculate time average and standard deviation w.r.t.
+;;             ;; interannual variability
+;;             var_avg = time_operations(var, start_year, end_year, \
+;;                                       "average", time_avg, True)
+;;             var_std = interannual_variability(var, start_year, end_year, \
+;;                                               time_avg)
+;;             delete(var)
+
+;;             ;; Assign to global array
+;;             var_all(imod, :, :, 0) = var_avg
+;;             var_all(imod, :, :, 1) = var_std
+;;             var = var_all(imod, :, :, :)
+;;             delete(var_avg)
+;;             delete(var_std)
+;;         end if
+
+;;         ;; Optional output to NetCDF
+;;         if (config_user_info@write_netcdf.eq."True") then
+;;             var@ncdf = procpath
+;;             ncdf_outfile = ncdf_write(var, procpath)
+;;         end if
+;;         delete(var)
+;;         delete(procpath)
+
+;;     end do
+
+;;     ;; ### CALCULATE DIFFERENCES AND APPLY STATISTICAL TESTS ##################
+
+;;     ;; Calculate differences and apply t-test
+;;     if (diag_script_info@plot_diff) then
+
+;;         do imod = 0, dim_MOD - 1
+
+;;             ;; Skip the reference model as result will be zero
+;;             if (imod.eq.ref_ind) then
+;;                 continue
+;;             end if
+
+;;             if (irank.eq.4) then
+
+;;                 ;; Difference
+;;                 var_diff(imod, :, :) = var_all(imod, :, :, 0)  ; save metadata
+;;                 var_diff(imod, :, :) = var_all(imod, :, :, 0) - \
+;;                     var_all(ref_ind, :, :, 0)
+
+;;                 ;; t-test (assuming different population variances)
+;;                 if (diag_script_info@t_test) then
+;;                     x1 = var_all(imod, :, :, 0)
+;;                     x2 = var_all(ref_ind, :, :, 0)
+;;                     s1 = var_all(imod, :, :, 1) ^ 2
+;;                     s2 = var_all(ref_ind, :, :, 1) ^ 2
+;;                     n1 = get_end_year(imod) - get_start_year(imod) + 1
+;;                     n2 = get_end_year(ref_ind) - get_start_year(ref_ind) + 1
+;;                     prob = ttest(x1, s1, n1, x2, s2, n2, True, False)
+;;                     var_sig(imod, :, :) = 1. - prob
+;;                     var_diff@conf_level = diag_script_info@conf_level
+;;                     delete(prob)
+;;                 end if
+
+;;             end if
+
+;;             if (irank.eq.3) then
+
+;;                 ;; Difference
+;;                 var_diff(imod, :) = var_all(imod, :, 0)  ; save metadata
+;;                 var_diff(imod, :) = var_all(imod, :, 0) - \
+;;                     var_all(ref_ind, :, 0)
+
+;;                 ;; t-test (assuming different population variances)
+;;                 if (diag_script_info@t_test) then
+;;                     x1 = var_all(imod, :, 0)
+;;                     x2 = var_all(ref_ind, :, 0)
+;;                     s1 = var_all(imod, :, 1) ^ 2
+;;                     s2 = var_all(ref_ind, :, 1) ^ 2
+;;                     n1 = get_end_year(imod) - get_start_year(imod) + 1
+;;                     n2 = get_end_year(ref_ind) - get_start_year(ref_ind) + 1
+;;                     prob = ttest(x1, s1, n1, x2, s2, n2, True, False)
+;;                     var_sig(imod, :) = 1. - prob
+;;                     delete(prob)
+;;                 end if
+
+;;             end if
+
+;;         end do
+;;     end if
+
+;;     ;; ### GRADING ############################################################
+
+;;     if (diag_script_info@calc_grading) then  ; FIX-ME loop over metrics?
+
+;;         ;; Annotation & file names
+;;         region_name = ""  ; priority 3
+;;         location = ""  ; priority 3
+;;         if(isatt(diag_script_info, "aux_info")) then
+;;             region_name = "_" + diag_script_info@aux_info  ; priority 2
+;;             location = " - " + diag_script_info@aux_info  ; priority 2
+;;         end if
+;;         if(isatt(diag_script_info, "location")) then
+;;             location = " - " + diag_script_info@location  ; priority 1
+;;         end if
+;;         if(isatt(diag_script_info, "region")) then
+;;             region_name = "_" + region@name  ; priority 1
+;;             location = " - " + diag_script_info@region
+;;         end if
+;;         altitude = ""  ; priority 2
+;;         if(any(field_type0.eq.(/"T0M", "T0Ms"/))) then
+;;             if(isatt(diag_script_info, "altitude")) then
+;;                 altitude = " - " + diag_script_info@altitude  ; priority 1
+;;             end if
+;;         else
+;;             if(isatt(diag_script_info, "level")) then
+;;                 altitude = " - " + diag_script_info@level + " hPa"  ; priority1
+;;             end if
+;;         end if
+
+;;         ;; Set variable name
+;;         var0_new = var0
+;;         var0_new = var0_new + region_name
+;;         if(isatt(diag_script_info, "level").and. \
+;;             any(field_type0.eq.(/"T3M", "T1M"/))) then
+;;             var0_new = var0_new + "-" + diag_script_info@level
+;;         end if
+
+;;         ;; Define grading filename
+;;         ncdf_dir = config_user_info@work_dir + "/" + \
+;;             diag_script_info@metric + "_" + var0_new + ".nc"
+
+;;         ;; Create separate arrays for models and observations
+;;         if (diag_script_info@metric.eq."taylor") then
+;;             id_remove = ref_ind
+;;         else
+;;             id_remove = ref_inds
+;;         end if
+;;         super_array = var_all
+;;         models_only = remove_index(super_array, id_remove)
+;;         nmodels = dimsizes(models_only&model)
+;;         if (l_altern .and. diag_script_info@metric.ne."taylor") then
+;;             if (irank.eq.3) then
+;;                 obs_only = super_array(id_remove, :, :)
+;;             end if
+;;             if (irank.eq.4) then
+;;                 obs_only = super_array(id_remove, :, :, :)
+;;             end if
+;;             if (irank.eq.5) then
+;;                 obs_only = super_array(id_remove, :, :, :, :)
+;;             end if
+;;         else  ; avoid dimension reduction
+;;             if (irank.eq.3) then
+;;                 obs_only = super_array(id_remove:id_remove, :, :)
+;;             end if
+;;             if (irank.eq.4) then
+;;                 obs_only = super_array(id_remove:id_remove, :, :, :)
+;;             end if
+;;             if (irank.eq.5) then
+;;                 obs_only = super_array(id_remove:id_remove, :, :, :, :)
+;;             end if
+;;         end if
+;;         nobs = dimsizes(obs_only&model)
+;;         delete(super_array)
+
+;;         ;; Define result variable
+;;         ;; A dummy coordinate "diagnostics" (size 1) is added to facilitate
+;;         ;; appending different variable in the _collect script
+;;         if (diag_script_info@metric.eq."taylor") then
+;;             grading = new((/dim_VAR, nmodels, 2/), float)
+;;             grading!2 = "statistic"
+;;             grading&statistic = (/"stddev_ratio", "correlation"/)
+;;         else
+;;             grading = new((/dim_VAR, nmodels, nobs/), float)
+;;             grading!2 = "reference"
+;;             grading&reference = obs_only&model
+;;         end if
+;;         grading!0 = "diagnostics"
+;;         grading!1 = "models"
+;;         grading&diagnostics = var0_new
+;;         grading&models = models_only&model
+
+;;         grading@ncdf_dir = ncdf_dir
+
+;;         ;; Loop over models, calculate metric
+;;         do imod = 0, nmodels - 1
+;;             do iobs = 0, nobs - 1
+;;                 if (irank.eq.3) then
+;;                     model = models_only(imod, :, 0)
+;;                     obs = obs_only(iobs, :, 0)
+;;                 end if
+;;                 if (irank.eq.4) then
+;;                     model = models_only(imod, :, :, 0)
+;;                     obs = obs_only(iobs, :, :, 0)
+;;                 end if
+;;                 if (irank.eq.5) then
+;;                     model = models_only(imod, :, :, :, 0)
+;;                     obs = obs_only(iobs, :, :, :, 0)
+;;                 end if
+;;                 if (diag_script_info@metric.eq."taylor") then
+;;                     grading(0, imod, 0) = \
+;;                         calculate_metric(model, obs, "stddev_ratio")
+;;                     grading(0, imod, 1) = \
+;;                         calculate_metric(model, obs, "correlation")
+;;                 else
+;;                     grading(0, imod, iobs) = \
+;;                         calculate_metric(model, obs, diag_script_info@metric)
+;;                 end if
+;;             end do
+;;         end do
+
+;;         ;; Apply normalization
+;;         if (diag_script_info@metric.ne."taylor") then
+;;             do iobs = 0, nobs - 1
+;;                 grading(:, :, iobs) = \
+;;                     normalize_metric(grading(:, :, iobs), \
+;;                                      diag_script_info@normalization)
+;;             end do
+;;         end if
+
+;;         ;; Reduce dimensionality if no alternative model
+;;         if (.not.l_altern .and. diag_script_info@metric.ne."taylor") then
+;;             grading := grading(:, :, 0)
+;;             delete(grading@reference)
+;;         end if
+
+;;         ;; Attach attributes to the results
+;;         grading@title = diag_script_info@metric + "metric"
+;;         grading@long_name = \
+;;             "Grading table of metric " + diag_script_info@metric
+;;         grading@metric = diag_script_info@metric
+;;         grading@diag_script = (/diag_script/)
+;;         grading@var = "grade"  ; FIX-ME ?
+;;         grading@region = location
+;;         grading@num_climofiles = dimsizes(model_info@model)  ; for tagging
+;;         do imod = 0, dimsizes(model_info@model) - 1
+;;             num_climo = "climofile_" + imod
+;;             grading@$num_climo$ = input_file_info@filename(imod)
+;;         end do
+
+;;         ;; Write NetCDF output
+;;         ncdf_outfile = ncdf_write(grading, grading@ncdf_dir)
+
+;;         ;; Write results of temporary grading list
+;;         temp_dir = config_user_info@work_dir + "/"
+;;         if (diag_script_info@metric.eq."taylor") then
+;;             temp_dir = temp_dir + "taylor.nc"
+;;         else
+;;             temp_dir = temp_dir + "grading.nc"
+;;         end if
+
+;;         if (fileexists(temp_dir)) then
+;;             temp_file = addfile(temp_dir, "r")
+;;             temp_list = temp_file->temp_list
+;;             temp_list_string = tostring(temp_list)
+;;             temp_list_new_string = array_append_record(temp_list_string, \
+;;                                                        ncdf_dir, 0)
+;;             temp_list_new = tochar(temp_list_new_string)
+;;             system("rm -f " + temp_dir)
+;;         else
+;;             ncdf_char = tochar(ncdf_dir)
+;;             temp_list_new = new((/1, dimsizes(ncdf_char)/), character)
+;;             temp_list_new(0, :) = ncdf_char
+;;         end if
+
+;;         ;; Create new file and add list
+;;         temp = addfile(temp_dir, "c")
+;;         temp->temp_list = temp_list_new
+
+;;     end if
+
+;;     ;; ### PLOTTING ###########################################################
+
+;;     if (diag_script_info@draw_plots) then
+
+;;         ;; Convert units for plotting (if required)
+;;         if (isatt(variable_info, "plot_units")) then
+;;             var_all = convert_units(var_all, variable_info@plot_units)
+;;             if (diag_script_info@plot_diff) then
+;;                 var_diff = convert_units(var_diff, variable_info@plot_units)
+;;             end if
+;;         end if
+
+;;         ;; Plot output directory
+;;         output_dir = config_user_info@plot_dir
+
+
+;;         ;; CASE: cycle ########################################################
+;;         if (ptype.eq."cycle") then
+;;             outfile = output_dir + var0 + "_" + \
+;;                 ptype + "_" + time_avg + "_" + region_name
+;;             wks = gsn_open_wks(file_type, outfile)
+;;             wks@legendfile = outfile + "_legend"
+;;             var_all@res_tiMainString = varstring
+;;             var_all@res_tiMainString = var_all@res_tiMainString + \
+;;                 location + altitude
+;;             plot = cycle_plot(wks, var_all, var0)
+;;             draw(plot)
+;;             frame(wks)
+;;             log_info(" gv " + outfile + "." + file_type)
+;;         end if
+
+;;         ;; CASE: zonal ########################################################
+;;         if (ptype.eq."zonal") then
+;;             do imod = 0, dim_MOD - 1
+;;                 outfile = output_dir + \
+;;                     modelnames(imod) + "_" + var0 + "_" + ptype + "_" + \
+;;                     time_avg + region_name
+;;                 var = var_all(imod, :, :, 0)
+;;                 var@res_tiMainString = modelnames(imod)
+;;                 var@res_cnLevelSelectionMode = "ExplicitLevels"
+;;                 var@res_cnLevels = diag_script_info@abs_levs
+;;                 if (isatt(variable_info, "zonal_ymin")) then
+;;                     var@res_trYMinF = variable_info@zonal_ymin
+;;                 else
+;;                     var@res_trYMinF = 5.
+;;                 end if
+;;                 var@res_gsnLeftString = var@long_name + " [" + \
+;;                     format_units(var@units) + "]"
+;;                 wks = gsn_open_wks(file_type, outfile)
+;;                 if (isatt(variable_info, "zonal_ref_cmap")) then
+;;                     gsn_define_colormap(wks, variable_info@zonal_ref_cmap)
+;;                 else
+;;                     gsn_define_colormap(wks, "amwg_blueyellowred")
+;;                 end if
+;;                 plot = zonalmean_profile(wks, var, var0)
+;;                 draw(plot)
+;;                 frame(wks)
+;;                 log_info(" gv " + outfile + "." + file_type)
+;;                 delete(var@res_cnLevels)
+;;                 delete(wks)
+;;                 delete(plot)
+
+;;                 ;; Difference plot to the reference
+;;                 if (.not.diag_script_info@plot_diff .or. imod.eq.ref_ind) then
+;;                     continue
+;;                 end if
+;;                 var = var_diff(imod, :, :)
+;;                 outfile = output_dir + \
+;;                     modelnames(imod) + "-" + modelnames(ref_ind) + "_" + \
+;;                     var0 + "_" + ptype + "_" + time_avg + region_name
+;;                 var@res_tiMainString = modelnames(imod) + " - " + \
+;;                     modelnames(ref_ind)
+;;                 if (isatt(diag_script_info, "conf_level")) then
+;;                     var@res_gsnLeftString = var@res_gsnLeftString + " - " + \
+;;                     sprinti("%2i", toint(100 * diag_script_info@conf_level)) \
+;;                     + "% c.l."
+;;                 end if
+;;                 var@res_cnLevelSelectionMode = "ExplicitLevels"
+;;                 var@res_cnLevels = diag_script_info@diff_levs
+;;                 var@res_cnMissingValFillColor = "gray70"
+;;                 var@res_gsnSpreadColorEnd = -2
+;;                 wks = gsn_open_wks(file_type, outfile)
+;;                 gsn_merge_colormaps(wks, "temp_19lev", "gray70")
+;;                 plot = zonalmean_profile(wks, var, var0)
+
+;;                 ;; Stippling ;; FIX-ME False option not considered (see below)
+;;                 var = var_sig(imod, :, :)
+;;                 var@res_cnMissingValFillColor = -1
+;;                 var@res_gsnSpreadColorEnd = -2
+;;                 var@res_gsnDraw = False
+;;                 var@res_gsnFrame = False
+;;                 var@res_cnLevelSelectionMode = "ExplicitLevels"
+;;                 var@res_cnFillColors = (/"transparent", "black"/)
+;;                 var@res_cnLevels := diag_script_info@conf_level
+;;                 var@res_cnInfoLabelOn = False
+;;                 var@res_cnLinesOn = False
+;;                 var@res_cnLineLabelsOn = False
+;;                 var@res_lbLabelBarOn = False
+;;                 var@res_cnFillPattern = 17
+;;                 delete(var@long_name)
+;;                 plot2 = zonalmean_profile(wks, var, var0)
+;;                 overlay(plot, plot2)
+;;                 draw(plot)
+;;                 frame(wks)
+;;                 log_info(" gv " + outfile + "." + file_type)
+;;                 delete(var@res_cnLevels)
+;;                 delete(wks)
+;;                 delete(plot)
+;;                 delete(plot2)
+;;                 delete(var)
+;;             end do
+;;         end if
+
+;;         ;; CASE: latlon #######################################################
+;;         if (ptype.eq."latlon") then
+;;             do imod = 0, dim_MOD - 1
+;;                 outfile = output_dir + \
+;;                     modelnames(imod) + "_" + var0 + "_" + ptype + "_" + \
+;;                     time_avg + "_" + region_name
+;;                 var = var_all(imod, :, :, 0)
+;;                 var@projection = diag_script_info@projection
+;;                 var@res_cnLinesOn = False
+;;                 var@res_cnLevelSelectionMode = "ExplicitLevels"
+;;                 var@res_tiMainString = modelnames(imod)
+;;                 var@res_cnLevels = diag_script_info@abs_levs
+;;                 var@res_gsnLeftString = var@long_name + " [" + \
+;;                     format_units(var@units) + "]"
+
+;;                 ;; Append global field average
+;;                 if (diag_script_info@show_global_avg) then
+;;                     gavg = area_operations(var, -90., 90., 0., 360., \
+;;                                            "average", True)
+;;                     var@res_gsnRightString = \
+;;                         sprintf("%5.2f", gavg) + " " + format_units(var@units)
+;;                 end if
+;;                 wks = gsn_open_wks(file_type, outfile)
+;;                 if (isatt(variable_info, "map_ref_cmap")) then
+;;                     gsn_define_colormap(wks, variable_info@map_ref_cmap)
+;;                 else
+;;                     gsn_define_colormap(wks, "amwg_blueyellowred")
+;;                 end if
+;;                 plot = contour_map_ce(wks, var, var0)
+;;                 draw(plot)
+;;                 frame(wks)
+;;                 log_info(" gv " + outfile + "." + file_type)
+;;                 delete(var@res_cnLevels)
+;;                 delete(wks)
+;;                 delete(plot)
+
+;;                 ;; Difference plot to the reference
+;;                 if (.not.diag_script_info@plot_diff .or. imod.eq.ref_ind) then
+;;                     continue
+;;                 end if
+;;                 var = var_diff(imod, :, :)
+;;                 outfile = output_dir + \
+;;                     modelnames(imod) + "-" + modelnames(ref_ind) + "_" + \
+;;                     var0 + "_" + ptype + "_" + time_avg + "_" + region_name
+;;                 var@res_tiMainString = modelnames(imod) + " - " + \
+;;                     modelnames(ref_ind)
+;;                 if (isatt(diag_script_info, "conf_level")) then
+;;                     var@res_gsnLeftString = var@res_gsnLeftString + " - " + \
+;;                     sprinti("%2i", toint(100 * diag_script_info@conf_level)) \
+;;                     + "% c.l."
+;;                 end if
+;;                 var@res_cnLevelSelectionMode = "ExplicitLevels"
+;;                 var@res_cnLevels = diag_script_info@diff_levs
+;;                 var@res_cnMissingValFillColor = "gray70"
+;;                 var@res_gsnSpreadColorEnd = -2
+;;                 var@projection = diag_script_info@projection
+
+;;                 ;; Append global field averag
+;;                 if (diag_script_info@show_global_avg) then
+;;                     gavg = area_operations(var, -90., 90., 0., 360., \
+;;                                            "average", True)
+;;                     var@res_gsnRightString = \
+;;                         sprintf("%5.2f", gavg) + " " + format_units(var@units)
+;;                 end if
+;;                 wks = gsn_open_wks(file_type, outfile)
+;;                 gsn_merge_colormaps(wks, "temp_19lev", "gray70")
+;;                 plot = contour_map_ce(wks, var, var0)
+
+;;                 ;; Stippling/masking
+;;                 res2 = True
+;;                 res2@cnLevelSelectionMode = "ExplicitLevels"
+;;                 res2@cnLevels = (/0.0, diag_script_info@conf_level, 1.0/)
+;;                 res2@cnInfoLabelOn = False
+;;                 res2@cnLinesOn = False
+;;                 res2@cnLineLabelsOn = False
+;;                 res2@gsnDraw = False
+;;                 res2@gsnFrame = False
+;;                 plot2 = gsn_csm_contour(wks, var_sig(imod, :, :), res2)
+;;                 opt = True
+;;                 if (diag_script_info@stippling) then
+;;                     opt@gsnShadeFillType = "pattern"
+;;                     opt@gsnShadeMid = 17
+;;                 else
+;;                     opt@gsnShadeFillType = "color"
+;;                     opt@gsnShadeLow = "gray70"
+;;                 end if
+;;                 plot2 = gsn_contour_shade(plot2, diag_script_info@conf_level, \
+;;                                           999., opt)
+;;                 overlay(plot, plot2)
+;;                 draw(plot)
+;;                 frame(wks)
+;;                 log_info(" gv " + outfile + "." + file_type)
+;;                 delete(var@res_cnLevels)
+;;                 delete(wks)
+;;                 delete(plot)
+;;                 delete(plot2)
+;;                 delete(var)
+;;             end do
+
+;;         end if
+;;     end if
+

--- a/esmvaltool/diag_scripts/perfmetrics/main.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/main.ncl
@@ -43,19 +43,15 @@
 ;;    altitude: additional information for stations data (altitude)
 ;;    abs_levs: (min, max, spacing) contour levels for absolute plot
 ;;    diff_levs: (min, max, spacing) contour levels for difference plot
-;;
-;; Optional variable_info attributes (variable specific) FIX-ME: to be removed
-;;    zonal_ref_cmap: color table for the zonal plot
-;;    zonal_ymin: minimum pressure for the zonal plots
-;;    global_avg: attach global field average as right string on the plot
+;;    zonal_cmap (for zonal): color table (default: "amwg_blueyellowred")
+;;    zonal_ymin (for zonal): minimum pressure on the plots (default: 5. hPa)
+;;    latlon_cmap (for latlon): color table (default: "amwg_blueyellowred")
 ;;    plot_units: plotting units (if different from standard CMOR units)
 ;;
 ;; Caveats
-;;    The reference model must be specified in the main namelist in the
-;;    variables dictionary as ref_model key. An alternative model can be also
-;;    given, using a python list.
 ;;
 ;; Modification history
+;;    20180503-A_righ_ma: completely rewritten and modularized
 ;;    20171215-A_righ_ma: merged with perfmetrics_grading and
 ;;                        permetrics_taylor.ncl
 ;;    20171124-A_righ_ma: completely revised to adapt it to the new backend
@@ -140,7 +136,7 @@ begin
                              (/"legend_outside", "styleset", "plot_stddev"/))
     end if
 
-    if (ptye.eq."zonal" .and. region.ne."Global") then
+    if (ptype.eq."zonal" .and. diag_script_info@region.ne."Global") then
         error_msg("f", diag_script, "", "plot_type " + ptype + \
                   "implemented only for region='Global'")
     end if
@@ -168,7 +164,7 @@ begin
     set_default_att(diag_script_info, "t_test", False)
     set_default_att(diag_script_info, "show_global_avg", False)
     set_default_att(diag_script_info, "zonal_ymin", 5.)
-    set_default_att(diag_script_info, "zonal_ref_cmap", "amwg_blueyellowred")
+    set_default_att(diag_script_info, "zonal_cmap", "amwg_blueyellowred")
 
     ;; Check consistency of diff plots settings
     if (diag_script_info@t_test .and. .not.diag_script_info@plot_diff) then
@@ -682,10 +678,10 @@ end
 ;;     if (diag_script_info@draw_plots) then
 
 ;;         ;; Convert units for plotting (if required)
-;;         if (isatt(variable_info, "plot_units")) then
-;;             var_all = convert_units(var_all, variable_info@plot_units)
+;;         if (isatt(diag_script_info, "plot_units")) then
+;;             var_all = convert_units(var_all, diag_script_info@plot_units)
 ;;             if (diag_script_info@plot_diff) then
-;;                 var_diff = convert_units(var_diff, variable_info@plot_units)
+;;                 var_diff = convert_units(var_diff, diag_script_info@plot_units)
 ;;             end if
 ;;         end if
 
@@ -718,16 +714,16 @@ end
 ;;                 var@res_tiMainString = modelnames(imod)
 ;;                 var@res_cnLevelSelectionMode = "ExplicitLevels"
 ;;                 var@res_cnLevels = diag_script_info@abs_levs
-;;                 if (isatt(variable_info, "zonal_ymin")) then
-;;                     var@res_trYMinF = variable_info@zonal_ymin
+;;                 if (isatt(diag_script_info, "zonal_ymin")) then
+;;                     var@res_trYMinF = diag_script_info@zonal_ymin
 ;;                 else
 ;;                     var@res_trYMinF = 5.
 ;;                 end if
 ;;                 var@res_gsnLeftString = var@long_name + " [" + \
 ;;                     format_units(var@units) + "]"
 ;;                 wks = gsn_open_wks(file_type, outfile)
-;;                 if (isatt(variable_info, "zonal_ref_cmap")) then
-;;                     gsn_define_colormap(wks, variable_info@zonal_ref_cmap)
+;;                 if (isatt(diag_script_info, "zonal_cmap")) then
+;;                     gsn_define_colormap(wks, diag_script_info@zonal_cmap)
 ;;                 else
 ;;                     gsn_define_colormap(wks, "amwg_blueyellowred")
 ;;                 end if
@@ -813,8 +809,8 @@ end
 ;;                         sprintf("%5.2f", gavg) + " " + format_units(var@units)
 ;;                 end if
 ;;                 wks = gsn_open_wks(file_type, outfile)
-;;                 if (isatt(variable_info, "map_ref_cmap")) then
-;;                     gsn_define_colormap(wks, variable_info@map_ref_cmap)
+;;                 if (isatt(diag_script_info, "latlon_cmap")) then
+;;                     gsn_define_colormap(wks, diag_script_info@latlon_cmap)
 ;;                 else
 ;;                     gsn_define_colormap(wks, "amwg_blueyellowred")
 ;;                 end if

--- a/esmvaltool/diag_scripts/perfmetrics/main.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/main.ncl
@@ -136,7 +136,8 @@ begin
                              (/"legend_outside", "styleset", "plot_stddev"/))
     end if
 
-    if (ptype.eq."zonal" .and. diag_script_info@region.ne."Global") then
+    if (ptype.eq."zonal" .or. ptype.eq."latlon" .and. \
+        diag_script_info@region.ne."Global") then
         error_msg("f", diag_script, "", "plot_type " + ptype + \
                   "implemented only for region='Global'")
     end if

--- a/esmvaltool/diag_scripts/perfmetrics/main.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/main.ncl
@@ -166,6 +166,7 @@ begin
     set_default_att(diag_script_info, "show_global_avg", False)
     set_default_att(diag_script_info, "zonal_ymin", 5.)
     set_default_att(diag_script_info, "zonal_cmap", "amwg_blueyellowred")
+    set_default_att(diag_script_info, "latlon_cmap", "amwg_blueyellowred")
 
     ;; Check consistency of diff plots settings
     if (diag_script_info@t_test .and. .not.diag_script_info@plot_diff) then

--- a/esmvaltool/diag_scripts/perfmetrics/main.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/main.ncl
@@ -120,6 +120,9 @@ begin
     exit_if_missing_atts(diag_script_info, \
                          (/"plot_type", "time_avg", "region"/))
 
+    ;; Define region
+    region = select_region(diag_script_info@region)
+
     ;; Store required attributes
     ptype = diag_script_info@plot_type
 
@@ -193,14 +196,20 @@ begin
     end if
 
     ;; Set index of the reference (and alternative) model
-    ref_inds = get_ref_model_idx(model_info, \
-                                 (/variable_info@reference_model, \
-                                   variable_info@alternative_model/))
-    ref_ind = ref_inds(0)
-    if (dimsizes(ref_inds).gt.1) then
-        alt_ind = ref_inds(1)
+    if (isatt(variable_info, "alternative_model")) then
         l_altern = True
+        nobs = 2
+        tmp = get_ref_model_idx(model_info, \
+                                (/variable_info@reference_model, \
+                                  variable_info@alternative_model/))
+        ref_ind = tmp(0)
+        alt_ind = tmp(1)
+    else
+        l_altern = False
+        nobs = 1
+        tmp = get_ref_model_idx(model_info, variable_info@reference_model)
     end if
+    delete(tmp)
 
     ;; Create output plot directory
     if (diag_script_info@draw_plots) then
@@ -214,6 +223,77 @@ begin
         file_type = "ps"
     end if
 
+    ;; Grading settings
+    if (diag_script_info@calc_grading) then
+
+        ;; Define variable name
+        region_name = ""  ; priority 3
+        location = ""  ; priority 3
+        if(isatt(diag_script_info, "aux_info")) then
+            region_name = "_" + diag_script_info@aux_info  ; priority 2
+            location = " - " + diag_script_info@aux_info  ; priority 2
+        end if
+        if(isatt(diag_script_info, "location")) then
+            location = " - " + diag_script_info@location  ; priority 1
+        end if
+        if(isatt(diag_script_info, "region")) then
+            region_name = "_" + region@name  ; priority 1
+            location = " - " + diag_script_info@region
+        end if
+        altitude = ""  ; priority 2
+        if(any(field_type0.eq.(/"T0M", "T0Ms"/))) then
+            if(isatt(diag_script_info, "altitude")) then
+                altitude = " - " + diag_script_info@altitude  ; priority 1
+            end if
+        else
+            if(isatt(diag_script_info, "level")) then
+                altitude = " - " + diag_script_info@level + " hPa"  ; priority1
+            end if
+        end if
+        var0_grade = var0
+        var0_grade = var0_grade + region_name
+        if(isatt(diag_script_info, "level").and. \
+            any(field_type0.eq.(/"T3M", "T1M"/))) then
+            var0_grade = var0_grade + "-" + diag_script_info@level ;; FIX-ME
+        end if
+
+        ;; Define grading filename
+        ncdf_dir = config_user_info@work_dir + "/" + \
+            diag_script_info@metric + "_" + var0_grade + ".nc"
+
+        ;; Array of grades
+        if (diag_script_info@metric.eq."taylor") then
+            nmodels = dimsizes(modelnames) - 1  ;; always 1 reference model
+            grading = new((/1, nmodels, 2/), float)
+            grading!0 = "diagnostics"  ;; dummy coord. to facilitate appending
+            grading!1 = "models"
+            grading!2 = "statistic"
+            grading&diagnostics = var0_grade
+            grading&statistic = (/"stddev_ratio", "correlation"/)
+            grading&models = remove_index(modelnames, ref_ind)
+        else
+            nmodels = dimsizes(modelnames) - nobs
+            grading = new((/1, nmodels, nobs/), float)
+            grading!0 = "diagnostics"  ;; dummy coord. to facilitate appending
+            grading!1 = "models"
+            grading!2 = "reference"
+            grading&diagnostics = var0_grade
+            if (l_altern) then
+                grading&models = remove_index(modelnames, (/ref_ind, alt_ind/))
+                if (isdim(grading, "reference")) then
+                    grading&reference = modelnames((/ref_ind, alt_ind/))
+                end if
+            else
+                grading&models = remove_index(modelnames, ref_ind)
+                if (isdim(grading, "reference")) then
+                    grading&reference = modelnames(ref_ind)
+                end if
+            end if
+        end if
+        grading@ncdf_dir = ncdf_dir
+
+    end if
+
     ;; Load plot-type-specific script
     print("diag_scripts/perfmetrics/" + ptype + ".ncl")
     loadscript("diag_scripts/perfmetrics/" + ptype + ".ncl")
@@ -223,340 +303,70 @@ end
 begin
 
     perfmetrics_ptype_script()
+
+    ;; Finalize grading calculations
+    if (diag_script_info@calc_grading) then
+
+        ;; Apply normalization
+        if (diag_script_info@metric.ne."taylor") then
+            do iobs = 0, nobs - 1
+                grading(:, :, iobs) = \
+                    normalize_metric(grading(:, :, iobs), \
+                                     diag_script_info@normalization)
+            end do
+        end if
+
+        ;; Reduce dimensionality if no alternative model
+        if (.not.l_altern .and. diag_script_info@metric.ne."taylor") then
+            grading := grading(:, :, 0)
+            delete(grading@reference)
+        end if
+
+        ;; Attach attributes to the results
+        grading@title = diag_script_info@metric + "metric"
+        grading@long_name = \
+            "Grading table of metric " + diag_script_info@metric
+        grading@metric = diag_script_info@metric
+        grading@diag_script = (/diag_script/)
+        grading@var = "grade"
+        grading@region = location
+        grading@num_climofiles = dimsizes(model_info@model) ;; FIX-ME ?
+        do imod = 0, dimsizes(model_info@model) - 1
+            num_climo = "climofile_" + imod
+            grading@$num_climo$ = input_file_info@filename(imod)
+        end do
+
+        ;; Write NetCDF output
+        ncdf_outfile = ncdf_write(grading, grading@ncdf_dir)
+
+        ;; Write results of temporary grading list
+        temp_dir = config_user_info@work_dir + "/"
+        if (diag_script_info@metric.eq."taylor") then
+            temp_dir = temp_dir + "taylor.nc"
+        else
+            temp_dir = temp_dir + "grading.nc"
+        end if
+
+        if (fileexists(temp_dir)) then
+            temp_file = addfile(temp_dir, "r")
+            temp_list = temp_file->temp_list
+            temp_list_string = tostring(temp_list)
+            temp_list_new_string = array_append_record(temp_list_string, \
+                                                       ncdf_dir, 0)
+            temp_list_new = tochar(temp_list_new_string)
+            system("rm -f " + temp_dir)
+        else
+            ncdf_char = tochar(ncdf_dir)
+            temp_list_new = new((/1, dimsizes(ncdf_char)/), character)
+            temp_list_new(0, :) = ncdf_char
+        end if
+
+        ;; Create new file and add list
+        temp = addfile(temp_dir, "c")
+        temp->temp_list = temp_list_new
+
+    end if
+
     leave_msg(diag_script, "")
 
 end
-
-;;     ;; ### DEFINE GLOBAL ARRAYS FOR COLLECTING MODEL DATA #####################
-
-;;     ;; Read common grid from the first model
-;;     ;; (all models are expected to be regridded to a common grid)
-;;     data = read_data(0, var0, field_type0)
-;;     rank = dimsizes(dimsizes(data))
-;;     if (rank.eq.4) then
-;;         grid = data(0, :, :, :)  ; plev, lat, lon
-;;     end if
-;;     if (rank.eq.3) then
-;;         grid = data(0, :, :)  ; lat, lon
-;;     end if
-;;     delete(data)
-;;     delete(rank)
-
-
-;;     ;; Case cycle_latlon: (model, time, lat, lon, stats)
-;;     if (ptype.eq."cycle_latlon") then
-;;         sgrid = area_operations(grid, region(0), region(1), region(2), \
-;;                                 region(3), "extract", False)
-;;         if (time_avg.eq."seasonalclim") then
-;;             var_all = new((/dim_MOD, 4, dimsizes(sgrid&lat), \
-;;                           dimsizes(sgrid&lon), 2/), float)
-;;             var_all!1 = "season"
-;;             var_all&season = (/"DJF", "MAM", "JJA", "SON"/)
-;;         else if (time_avg.eq."monthlyclim") then
-;;             var_all = new((/dim_MOD, 12, dimsizes(sgrid&lat), \
-;;                           dimsizes(sgrid&lon), 2/), float)
-;;             var_all!1 = "month"
-;;             var_all&month = (/"J", "F", "M", "A", "M", "J",\
-;;                               "J", "A", "S", "O", "N", "D"/)
-;;         else
-;;             error_msg("f", diag_script, "", "time_avg option " + time_avg + \
-;;                       " not compatible with plot_type " + ptype)
-;;         end if
-;;         end if
-;;         var_all!0 = "model"
-;;         var_all!2 = "lat"
-;;         var_all!3 = "lon"
-;;         var_all!4 = "statistic"
-;;         var_all&model = modelnames
-;;         var_all&lat = sgrid&lat
-;;         var_all&lon = sgrid&lon
-;;         var_all&statistic = (/"mean", "stddev"/)
-;;         if (diag_script_info@plot_diff) then
-;;             var_diff = var_all(:, :, :, :, 0)
-;;         end if
-;;         delete(sgrid)
-;;     end if
-
-;;     ;; Case zonal: (model, level, lat, stats)
-;;     if (ptype.eq."zonal") then
-;;         var_all = new((/dim_MOD, dimsizes(grid&plev), \
-;;                       dimsizes(grid&lat), 2/), float)
-;;         var_all!0 = "model"
-;;         var_all!1 = "plev"
-;;         var_all!2 = "lat"
-;;         var_all!3 = "statistic"
-;;         var_all&model = modelnames
-;;         var_all&plev = grid&plev
-;;         var_all&lat = grid&lat
-;;         var_all&statistic = (/"mean", "stddev"/)
-;;         if (diag_script_info@plot_diff) then
-;;             var_diff = var_all(:, :, :, 0)
-;;         end if
-;;     end if
-
-;;     ;; Case latlon: (model, lat, lon, stats)
-;;     if (ptype.eq."latlon") then
-;;         var_all = new((/dim_MOD, dimsizes(grid&lat), \
-;;                       dimsizes(grid&lon), 2/), float)
-;;         var_all!0 = "model"
-;;         var_all!1 = "lat"
-;;         var_all!2 = "lon"
-;;         var_all!3 = "statistic"
-;;         var_all&model = modelnames
-;;         var_all&lat = grid&lat
-;;         var_all&lon = grid&lon
-;;         var_all&statistic = (/"mean", "stddev"/)
-;;         if (diag_script_info@plot_diff) then
-;;             var_diff = var_all(:, :, :, 0)
-;;         end if
-;;     end if
-
-;;     ; If needed, create array for statistically significant grid cells
-;;     if (diag_script_info@t_test) then
-;;         var_sig = var_diff
-;;     end if
-
-;;     ;; Variable rank: cycle:3, zonal/latlon:4, cycle_latlon:5
-;;     irank = dimsizes(dimsizes(var_all))
-
-;;     ;; Attach attributes
-;;     var_all@var = var0
-;;     var_all@diag_script = (/diag_script/)
-;;     copy_VarAtts(diag_script_info, var_all)
-;;     var_all@ref_model = variable_info@reference_model
-
-;;     ;; ### MAIN LOOP OVER MODELS AND DATA PROCESSING ##########################
-
-;;     ;; Loop over models
-;;     do imod = 0, dim_MOD - 1
-
-;;         log_debug("Processing " + modelnames(imod))
-
-;;         ;; Set path for saving processed data ;; FIX-ME add preproc_id
-;;         fullpath = config_user_info@work_dir + "/"
-;;         system("mkdir -p " + fullpath)
-;;         fname = basename(systemfunc("basename " + model_info@filename(imod)))
-;;         fname = fname + "_" + basename(diag_script)
-;;         fname = fname + "_" + diag_script_info@plot_type
-;;         fname = fname + "_" + diag_script_info@time_avg
-;;         if (isatt(diag_script_info, "level")) then
-;;             fname = fname + "_" + diag_script_info@level  ; FIX-ME
-;;         end if
-;;         fname = fname + "_" + str_sub_str(diag_script_info@region, " ", "")
-;;         procpath = fullpath + fname + ".nc"
-
-;;         ;; Determine start/end year
-;;         start_year = get_start_year(imod)
-;;         end_year = get_end_year(imod)
-
-;;         ;; Read data
-;;         var = read_data(imod, var0, field_type0)
-;;         dnames = getVarDimNames(var)
-
-
-;;         ;; CASE: cycle_latlon #################################################
-;;         if (ptype.eq."cycle_latlon") then
-
-;;             ;; Extract region
-;;             var_reg = area_operations(var, region(0), region(1), \
-;;                                       region(2), region(3), "extract", True)
-;;             delete(var)
-
-;;             ;; Calculate time average
-;;             var_avg = time_operations(var_reg, start_year, end_year, \
-;;                                       "average", time_avg, True)
-;;             delete(var_reg)
-
-;;             ;; Standard deviation calculation for this rank is not implemented
-;;             ;; yet in statistics.ncl (but is anyway not required here)
-
-;;             ;; Assign to global array
-;;             var_all(imod, :, :, :, 0) = var_avg
-;;             delete(var_avg)
-;;             var = var_all(imod, :, :, :, :)
-
-;;         end if
-
-
-
-;;     ;; ### GRADING ############################################################
-
-;;     if (diag_script_info@calc_grading) then  ; FIX-ME loop over metrics?
-
-;;         ;; Annotation & file names
-;;         region_name = ""  ; priority 3
-;;         location = ""  ; priority 3
-;;         if(isatt(diag_script_info, "aux_info")) then
-;;             region_name = "_" + diag_script_info@aux_info  ; priority 2
-;;             location = " - " + diag_script_info@aux_info  ; priority 2
-;;         end if
-;;         if(isatt(diag_script_info, "location")) then
-;;             location = " - " + diag_script_info@location  ; priority 1
-;;         end if
-;;         if(isatt(diag_script_info, "region")) then
-;;             region_name = "_" + region@name  ; priority 1
-;;             location = " - " + diag_script_info@region
-;;         end if
-;;         altitude = ""  ; priority 2
-;;         if(any(field_type0.eq.(/"T0M", "T0Ms"/))) then
-;;             if(isatt(diag_script_info, "altitude")) then
-;;                 altitude = " - " + diag_script_info@altitude  ; priority 1
-;;             end if
-;;         else
-;;             if(isatt(diag_script_info, "level")) then
-;;                 altitude = " - " + diag_script_info@level + " hPa"  ; priority1
-;;             end if
-;;         end if
-
-;;         ;; Set variable name
-;;         var0_new = var0
-;;         var0_new = var0_new + region_name
-;;         if(isatt(diag_script_info, "level").and. \
-;;             any(field_type0.eq.(/"T3M", "T1M"/))) then
-;;             var0_new = var0_new + "-" + diag_script_info@level
-;;         end if
-
-;;         ;; Define grading filename
-;;         ncdf_dir = config_user_info@work_dir + "/" + \
-;;             diag_script_info@metric + "_" + var0_new + ".nc"
-
-;;         ;; Create separate arrays for models and observations
-;;         if (diag_script_info@metric.eq."taylor") then
-;;             id_remove = ref_ind
-;;         else
-;;             id_remove = ref_inds
-;;         end if
-;;         super_array = var_all
-;;         models_only = remove_index(super_array, id_remove)
-;;         nmodels = dimsizes(models_only&model)
-;;         if (l_altern .and. diag_script_info@metric.ne."taylor") then
-;;             if (irank.eq.3) then
-;;                 obs_only = super_array(id_remove, :, :)
-;;             end if
-;;             if (irank.eq.4) then
-;;                 obs_only = super_array(id_remove, :, :, :)
-;;             end if
-;;             if (irank.eq.5) then
-;;                 obs_only = super_array(id_remove, :, :, :, :)
-;;             end if
-;;         else  ; avoid dimension reduction
-;;             if (irank.eq.3) then
-;;                 obs_only = super_array(id_remove:id_remove, :, :)
-;;             end if
-;;             if (irank.eq.4) then
-;;                 obs_only = super_array(id_remove:id_remove, :, :, :)
-;;             end if
-;;             if (irank.eq.5) then
-;;                 obs_only = super_array(id_remove:id_remove, :, :, :, :)
-;;             end if
-;;         end if
-;;         nobs = dimsizes(obs_only&model)
-;;         delete(super_array)
-
-;;         ;; Define result variable
-;;         ;; A dummy coordinate "diagnostics" (size 1) is added to facilitate
-;;         ;; appending different variable in the _collect script
-;;         if (diag_script_info@metric.eq."taylor") then
-;;             grading = new((/dim_VAR, nmodels, 2/), float)
-;;             grading!2 = "statistic"
-;;             grading&statistic = (/"stddev_ratio", "correlation"/)
-;;         else
-;;             grading = new((/dim_VAR, nmodels, nobs/), float)
-;;             grading!2 = "reference"
-;;             grading&reference = obs_only&model
-;;         end if
-;;         grading!0 = "diagnostics"
-;;         grading!1 = "models"
-;;         grading&diagnostics = var0_new
-;;         grading&models = models_only&model
-
-;;         grading@ncdf_dir = ncdf_dir
-
-;;         ;; Loop over models, calculate metric
-;;         do imod = 0, nmodels - 1
-;;             do iobs = 0, nobs - 1
-;;                 if (irank.eq.3) then
-;;                     model = models_only(imod, :, 0)
-;;                     obs = obs_only(iobs, :, 0)
-;;                 end if
-;;                 if (irank.eq.4) then
-;;                     model = models_only(imod, :, :, 0)
-;;                     obs = obs_only(iobs, :, :, 0)
-;;                 end if
-;;                 if (irank.eq.5) then
-;;                     model = models_only(imod, :, :, :, 0)
-;;                     obs = obs_only(iobs, :, :, :, 0)
-;;                 end if
-;;                 if (diag_script_info@metric.eq."taylor") then
-;;                     grading(0, imod, 0) = \
-;;                         calculate_metric(model, obs, "stddev_ratio")
-;;                     grading(0, imod, 1) = \
-;;                         calculate_metric(model, obs, "correlation")
-;;                 else
-;;                     grading(0, imod, iobs) = \
-;;                         calculate_metric(model, obs, diag_script_info@metric)
-;;                 end if
-;;             end do
-;;         end do
-
-;;         ;; Apply normalization
-;;         if (diag_script_info@metric.ne."taylor") then
-;;             do iobs = 0, nobs - 1
-;;                 grading(:, :, iobs) = \
-;;                     normalize_metric(grading(:, :, iobs), \
-;;                                      diag_script_info@normalization)
-;;             end do
-;;         end if
-
-;;         ;; Reduce dimensionality if no alternative model
-;;         if (.not.l_altern .and. diag_script_info@metric.ne."taylor") then
-;;             grading := grading(:, :, 0)
-;;             delete(grading@reference)
-;;         end if
-
-;;         ;; Attach attributes to the results
-;;         grading@title = diag_script_info@metric + "metric"
-;;         grading@long_name = \
-;;             "Grading table of metric " + diag_script_info@metric
-;;         grading@metric = diag_script_info@metric
-;;         grading@diag_script = (/diag_script/)
-;;         grading@var = "grade"  ; FIX-ME ?
-;;         grading@region = location
-;;         grading@num_climofiles = dimsizes(model_info@model)  ; for tagging
-;;         do imod = 0, dimsizes(model_info@model) - 1
-;;             num_climo = "climofile_" + imod
-;;             grading@$num_climo$ = input_file_info@filename(imod)
-;;         end do
-
-;;         ;; Write NetCDF output
-;;         ncdf_outfile = ncdf_write(grading, grading@ncdf_dir)
-
-;;         ;; Write results of temporary grading list
-;;         temp_dir = config_user_info@work_dir + "/"
-;;         if (diag_script_info@metric.eq."taylor") then
-;;             temp_dir = temp_dir + "taylor.nc"
-;;         else
-;;             temp_dir = temp_dir + "grading.nc"
-;;         end if
-
-;;         if (fileexists(temp_dir)) then
-;;             temp_file = addfile(temp_dir, "r")
-;;             temp_list = temp_file->temp_list
-;;             temp_list_string = tostring(temp_list)
-;;             temp_list_new_string = array_append_record(temp_list_string, \
-;;                                                        ncdf_dir, 0)
-;;             temp_list_new = tochar(temp_list_new_string)
-;;             system("rm -f " + temp_dir)
-;;         else
-;;             ncdf_char = tochar(ncdf_dir)
-;;             temp_list_new = new((/1, dimsizes(ncdf_char)/), character)
-;;             temp_list_new(0, :) = ncdf_char
-;;         end if
-
-;;         ;; Create new file and add list
-;;         temp = addfile(temp_dir, "c")
-;;         temp->temp_list = temp_list_new
-
-;;     end if
-
-

--- a/esmvaltool/diag_scripts/perfmetrics/main.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/main.ncl
@@ -38,15 +38,15 @@
 ;;                     (default: False)
 ;;    metric: grading metric (if calc_grading is True)
 ;;    normalization: metric normalization (for RMSD and BIAS metrics)
-;;    aux_info: additional information for stations data
-;;    location: additional information for stations data (location)
-;;    altitude: additional information for stations data (altitude)
 ;;    abs_levs: (min, max, spacing) contour levels for absolute plot
 ;;    diff_levs: (min, max, spacing) contour levels for difference plot
 ;;    zonal_cmap (for zonal): color table (default: "amwg_blueyellowred")
 ;;    zonal_ymin (for zonal): minimum pressure on the plots (default: 5. hPa)
 ;;    latlon_cmap (for latlon): color table (default: "amwg_blueyellowred")
 ;;    plot_units: plotting units (if different from standard CMOR units)
+;;    aux_info: additional information for stations data
+;;    location: additional information for stations data (location)
+;;    altitude: additional information for stations data (altitude)
 ;;
 ;; Caveats
 ;;
@@ -122,8 +122,6 @@ begin
 
     ;; Store required attributes
     ptype = diag_script_info@plot_type
-;;TBR    time_avg = diag_script_info@time_avg
-;;TBR    region = select_region(diag_script_info@region)
 
     if (all(ptype.ne.(/"cycle", "zonal", "latlon", "cycle_latlon"/))) then
         error_msg("f", diag_script, "", "plot_type " + ptype + " is not a " + \
@@ -185,9 +183,6 @@ begin
             exit_if_missing_atts(diag_script_info, (/"normalization"/))
         end if
     end if
-
-    ;; Basename of diag_script
-;;TBR    diag_script_base = basename(diag_script)
 
     ;; Unique names for models
     modelnames = project_style(diag_script_info, "annots")
@@ -382,118 +377,7 @@ end
 
 ;;         end if
 
-;;         ;; CASE: zonal ########################################################
-;;         if (ptype.eq."zonal") then
 
-;;             ;; Calculate zonal mean
-;;             var_zon = dim_avg_Wrap(var)
-;;             delete(var)
-
-;;             ;; Calculate time average and standard deviation w.r.t.
-;;             ;; interannual variability
-;;             var_avg = time_operations(var_zon, start_year, end_year, \
-;;                                       "average", time_avg, True)
-;;             var_std = interannual_variability(var_zon, start_year, end_year, \
-;;                                               time_avg)
-;;             delete(var_zon)
-
-;;             ;; Assign to global array
-;;             var_all(imod, :, :, 0) = var_avg
-;;             var_all(imod, :, :, 1) = var_std
-;;             var = var_all(imod, :, :, :)
-;;             delete(var_avg)
-;;             delete(var_std)
-
-;;         end if
-
-;;         ;; CASE: latlon #######################################################
-;;         if (ptype.eq."latlon") then
-
-;;             ;; Calculate time average and standard deviation w.r.t.
-;;             ;; interannual variability
-;;             var_avg = time_operations(var, start_year, end_year, \
-;;                                       "average", time_avg, True)
-;;             var_std = interannual_variability(var, start_year, end_year, \
-;;                                               time_avg)
-;;             delete(var)
-
-;;             ;; Assign to global array
-;;             var_all(imod, :, :, 0) = var_avg
-;;             var_all(imod, :, :, 1) = var_std
-;;             var = var_all(imod, :, :, :)
-;;             delete(var_avg)
-;;             delete(var_std)
-;;         end if
-
-;;         ;; Optional output to NetCDF
-;;         if (config_user_info@write_netcdf.eq."True") then
-;;             var@ncdf = procpath
-;;             ncdf_outfile = ncdf_write(var, procpath)
-;;         end if
-;;         delete(var)
-;;         delete(procpath)
-
-;;     end do
-
-;;     ;; ### CALCULATE DIFFERENCES AND APPLY STATISTICAL TESTS ##################
-
-;;     ;; Calculate differences and apply t-test
-;;     if (diag_script_info@plot_diff) then
-
-;;         do imod = 0, dim_MOD - 1
-
-;;             ;; Skip the reference model as result will be zero
-;;             if (imod.eq.ref_ind) then
-;;                 continue
-;;             end if
-
-;;             if (irank.eq.4) then
-
-;;                 ;; Difference
-;;                 var_diff(imod, :, :) = var_all(imod, :, :, 0)  ; save metadata
-;;                 var_diff(imod, :, :) = var_all(imod, :, :, 0) - \
-;;                     var_all(ref_ind, :, :, 0)
-
-;;                 ;; t-test (assuming different population variances)
-;;                 if (diag_script_info@t_test) then
-;;                     x1 = var_all(imod, :, :, 0)
-;;                     x2 = var_all(ref_ind, :, :, 0)
-;;                     s1 = var_all(imod, :, :, 1) ^ 2
-;;                     s2 = var_all(ref_ind, :, :, 1) ^ 2
-;;                     n1 = get_end_year(imod) - get_start_year(imod) + 1
-;;                     n2 = get_end_year(ref_ind) - get_start_year(ref_ind) + 1
-;;                     prob = ttest(x1, s1, n1, x2, s2, n2, True, False)
-;;                     var_sig(imod, :, :) = 1. - prob
-;;                     var_diff@conf_level = diag_script_info@conf_level
-;;                     delete(prob)
-;;                 end if
-
-;;             end if
-
-;;             if (irank.eq.3) then
-
-;;                 ;; Difference
-;;                 var_diff(imod, :) = var_all(imod, :, 0)  ; save metadata
-;;                 var_diff(imod, :) = var_all(imod, :, 0) - \
-;;                     var_all(ref_ind, :, 0)
-
-;;                 ;; t-test (assuming different population variances)
-;;                 if (diag_script_info@t_test) then
-;;                     x1 = var_all(imod, :, 0)
-;;                     x2 = var_all(ref_ind, :, 0)
-;;                     s1 = var_all(imod, :, 1) ^ 2
-;;                     s2 = var_all(ref_ind, :, 1) ^ 2
-;;                     n1 = get_end_year(imod) - get_start_year(imod) + 1
-;;                     n2 = get_end_year(ref_ind) - get_start_year(ref_ind) + 1
-;;                     prob = ttest(x1, s1, n1, x2, s2, n2, True, False)
-;;                     var_sig(imod, :) = 1. - prob
-;;                     delete(prob)
-;;                 end if
-
-;;             end if
-
-;;         end do
-;;     end if
 
 ;;     ;; ### GRADING ############################################################
 
@@ -675,218 +559,4 @@ end
 
 ;;     end if
 
-;;     ;; ### PLOTTING ###########################################################
-
-;;     if (diag_script_info@draw_plots) then
-
-;;         ;; Convert units for plotting (if required)
-;;         if (isatt(diag_script_info, "plot_units")) then
-;;             var_all = convert_units(var_all, diag_script_info@plot_units)
-;;             if (diag_script_info@plot_diff) then
-;;                 var_diff = convert_units(var_diff, diag_script_info@plot_units)
-;;             end if
-;;         end if
-
-;;         ;; Plot output directory
-;;         output_dir = config_user_info@plot_dir
-
-
-;;         ;; CASE: cycle ########################################################
-;;         if (ptype.eq."cycle") then
-;;             outfile = output_dir + var0 + "_" + \
-;;                 ptype + "_" + time_avg + "_" + region_name
-;;             wks = gsn_open_wks(file_type, outfile)
-;;             wks@legendfile = outfile + "_legend"
-;;             var_all@res_tiMainString = varstring
-;;             var_all@res_tiMainString = var_all@res_tiMainString + \
-;;                 location + altitude
-;;             plot = cycle_plot(wks, var_all, var0)
-;;             draw(plot)
-;;             frame(wks)
-;;             log_info(" gv " + outfile + "." + file_type)
-;;         end if
-
-;;         ;; CASE: zonal ########################################################
-;;         if (ptype.eq."zonal") then
-;;             do imod = 0, dim_MOD - 1
-;;                 outfile = output_dir + \
-;;                     modelnames(imod) + "_" + var0 + "_" + ptype + "_" + \
-;;                     time_avg + region_name
-;;                 var = var_all(imod, :, :, 0)
-;;                 var@res_tiMainString = modelnames(imod)
-;;                 var@res_cnLevelSelectionMode = "ExplicitLevels"
-;;                 var@res_cnLevels = diag_script_info@abs_levs
-;;                 if (isatt(diag_script_info, "zonal_ymin")) then
-;;                     var@res_trYMinF = diag_script_info@zonal_ymin
-;;                 else
-;;                     var@res_trYMinF = 5.
-;;                 end if
-;;                 var@res_gsnLeftString = var@long_name + " [" + \
-;;                     format_units(var@units) + "]"
-;;                 wks = gsn_open_wks(file_type, outfile)
-;;                 if (isatt(diag_script_info, "zonal_cmap")) then
-;;                     gsn_define_colormap(wks, diag_script_info@zonal_cmap)
-;;                 else
-;;                     gsn_define_colormap(wks, "amwg_blueyellowred")
-;;                 end if
-;;                 plot = zonalmean_profile(wks, var, var0)
-;;                 draw(plot)
-;;                 frame(wks)
-;;                 log_info(" gv " + outfile + "." + file_type)
-;;                 delete(var@res_cnLevels)
-;;                 delete(wks)
-;;                 delete(plot)
-
-;;                 ;; Difference plot to the reference
-;;                 if (.not.diag_script_info@plot_diff .or. imod.eq.ref_ind) then
-;;                     continue
-;;                 end if
-;;                 var = var_diff(imod, :, :)
-;;                 outfile = output_dir + \
-;;                     modelnames(imod) + "-" + modelnames(ref_ind) + "_" + \
-;;                     var0 + "_" + ptype + "_" + time_avg + region_name
-;;                 var@res_tiMainString = modelnames(imod) + " - " + \
-;;                     modelnames(ref_ind)
-;;                 if (isatt(diag_script_info, "conf_level")) then
-;;                     var@res_gsnLeftString = var@res_gsnLeftString + " - " + \
-;;                     sprinti("%2i", toint(100 * diag_script_info@conf_level)) \
-;;                     + "% c.l."
-;;                 end if
-;;                 var@res_cnLevelSelectionMode = "ExplicitLevels"
-;;                 var@res_cnLevels = diag_script_info@diff_levs
-;;                 var@res_cnMissingValFillColor = "gray70"
-;;                 var@res_gsnSpreadColorEnd = -2
-;;                 wks = gsn_open_wks(file_type, outfile)
-;;                 gsn_merge_colormaps(wks, "temp_19lev", "gray70")
-;;                 plot = zonalmean_profile(wks, var, var0)
-
-;;                 ;; Stippling ;; FIX-ME False option not considered (see below)
-;;                 var = var_sig(imod, :, :)
-;;                 var@res_cnMissingValFillColor = -1
-;;                 var@res_gsnSpreadColorEnd = -2
-;;                 var@res_gsnDraw = False
-;;                 var@res_gsnFrame = False
-;;                 var@res_cnLevelSelectionMode = "ExplicitLevels"
-;;                 var@res_cnFillColors = (/"transparent", "black"/)
-;;                 var@res_cnLevels := diag_script_info@conf_level
-;;                 var@res_cnInfoLabelOn = False
-;;                 var@res_cnLinesOn = False
-;;                 var@res_cnLineLabelsOn = False
-;;                 var@res_lbLabelBarOn = False
-;;                 var@res_cnFillPattern = 17
-;;                 delete(var@long_name)
-;;                 plot2 = zonalmean_profile(wks, var, var0)
-;;                 overlay(plot, plot2)
-;;                 draw(plot)
-;;                 frame(wks)
-;;                 log_info(" gv " + outfile + "." + file_type)
-;;                 delete(var@res_cnLevels)
-;;                 delete(wks)
-;;                 delete(plot)
-;;                 delete(plot2)
-;;                 delete(var)
-;;             end do
-;;         end if
-
-;;         ;; CASE: latlon #######################################################
-;;         if (ptype.eq."latlon") then
-;;             do imod = 0, dim_MOD - 1
-;;                 outfile = output_dir + \
-;;                     modelnames(imod) + "_" + var0 + "_" + ptype + "_" + \
-;;                     time_avg + "_" + region_name
-;;                 var = var_all(imod, :, :, 0)
-;;                 var@projection = diag_script_info@projection
-;;                 var@res_cnLinesOn = False
-;;                 var@res_cnLevelSelectionMode = "ExplicitLevels"
-;;                 var@res_tiMainString = modelnames(imod)
-;;                 var@res_cnLevels = diag_script_info@abs_levs
-;;                 var@res_gsnLeftString = var@long_name + " [" + \
-;;                     format_units(var@units) + "]"
-
-;;                 ;; Append global field average
-;;                 if (diag_script_info@show_global_avg) then
-;;                     gavg = area_operations(var, -90., 90., 0., 360., \
-;;                                            "average", True)
-;;                     var@res_gsnRightString = \
-;;                         sprintf("%5.2f", gavg) + " " + format_units(var@units)
-;;                 end if
-;;                 wks = gsn_open_wks(file_type, outfile)
-;;                 if (isatt(diag_script_info, "latlon_cmap")) then
-;;                     gsn_define_colormap(wks, diag_script_info@latlon_cmap)
-;;                 else
-;;                     gsn_define_colormap(wks, "amwg_blueyellowred")
-;;                 end if
-;;                 plot = contour_map_ce(wks, var, var0)
-;;                 draw(plot)
-;;                 frame(wks)
-;;                 log_info(" gv " + outfile + "." + file_type)
-;;                 delete(var@res_cnLevels)
-;;                 delete(wks)
-;;                 delete(plot)
-
-;;                 ;; Difference plot to the reference
-;;                 if (.not.diag_script_info@plot_diff .or. imod.eq.ref_ind) then
-;;                     continue
-;;                 end if
-;;                 var = var_diff(imod, :, :)
-;;                 outfile = output_dir + \
-;;                     modelnames(imod) + "-" + modelnames(ref_ind) + "_" + \
-;;                     var0 + "_" + ptype + "_" + time_avg + "_" + region_name
-;;                 var@res_tiMainString = modelnames(imod) + " - " + \
-;;                     modelnames(ref_ind)
-;;                 if (isatt(diag_script_info, "conf_level")) then
-;;                     var@res_gsnLeftString = var@res_gsnLeftString + " - " + \
-;;                     sprinti("%2i", toint(100 * diag_script_info@conf_level)) \
-;;                     + "% c.l."
-;;                 end if
-;;                 var@res_cnLevelSelectionMode = "ExplicitLevels"
-;;                 var@res_cnLevels = diag_script_info@diff_levs
-;;                 var@res_cnMissingValFillColor = "gray70"
-;;                 var@res_gsnSpreadColorEnd = -2
-;;                 var@projection = diag_script_info@projection
-
-;;                 ;; Append global field averag
-;;                 if (diag_script_info@show_global_avg) then
-;;                     gavg = area_operations(var, -90., 90., 0., 360., \
-;;                                            "average", True)
-;;                     var@res_gsnRightString = \
-;;                         sprintf("%5.2f", gavg) + " " + format_units(var@units)
-;;                 end if
-;;                 wks = gsn_open_wks(file_type, outfile)
-;;                 gsn_merge_colormaps(wks, "temp_19lev", "gray70")
-;;                 plot = contour_map_ce(wks, var, var0)
-
-;;                 ;; Stippling/masking
-;;                 res2 = True
-;;                 res2@cnLevelSelectionMode = "ExplicitLevels"
-;;                 res2@cnLevels = (/0.0, diag_script_info@conf_level, 1.0/)
-;;                 res2@cnInfoLabelOn = False
-;;                 res2@cnLinesOn = False
-;;                 res2@cnLineLabelsOn = False
-;;                 res2@gsnDraw = False
-;;                 res2@gsnFrame = False
-;;                 plot2 = gsn_csm_contour(wks, var_sig(imod, :, :), res2)
-;;                 opt = True
-;;                 if (diag_script_info@stippling) then
-;;                     opt@gsnShadeFillType = "pattern"
-;;                     opt@gsnShadeMid = 17
-;;                 else
-;;                     opt@gsnShadeFillType = "color"
-;;                     opt@gsnShadeLow = "gray70"
-;;                 end if
-;;                 plot2 = gsn_contour_shade(plot2, diag_script_info@conf_level, \
-;;                                           999., opt)
-;;                 overlay(plot, plot2)
-;;                 draw(plot)
-;;                 frame(wks)
-;;                 log_info(" gv " + outfile + "." + file_type)
-;;                 delete(var@res_cnLevels)
-;;                 delete(wks)
-;;                 delete(plot)
-;;                 delete(plot2)
-;;                 delete(var)
-;;             end do
-
-;;         end if
-;;     end if
 

--- a/esmvaltool/diag_scripts/perfmetrics/zonal.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/zonal.ncl
@@ -80,7 +80,7 @@ begin
 
         ;; Absolute plot
         outfile = config_user_info@plot_dir + modelnames(imod) + "_" + var0 + \
-            "_zonal_" + diag_script_info@time_avg + "_Global"
+            "_zonal_" + diag_script_info@time_avg + "_Glob"
         plot_var = var_all(:, :, 0)
         plot_var@res_tiMainString = modelnames(imod)
         plot_var@res_cnLevelSelectionMode = "ExplicitLevels"
@@ -105,7 +105,7 @@ begin
         plot_var = var_all(:, :, 0) - var_ref(:, :, 0)
         outfile = config_user_info@plot_dir + modelnames(imod) + "-" + \
             modelnames(ref_ind) + "_" + var0 + "_zonal_" + \
-            diag_script_info@time_avg + "_Global"
+            diag_script_info@time_avg + "_Glob"
         plot_var@res_tiMainString = \
             modelnames(imod) + " - " + modelnames(ref_ind)
         if (isatt(diag_script_info, "t_test")) then

--- a/esmvaltool/diag_scripts/perfmetrics/zonal.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/zonal.ncl
@@ -1,0 +1,165 @@
+;;#############################################################################
+;; PROCEDURE FOR THE ZONAL PLOT OF THE PERFORMANCE METRICS
+;; Authors: Mattia Righi (DLR, Germany) and Franziska Frank (DLR, Germany)
+;; ESMVal project
+;;#############################################################################
+
+procedure perfmetrics_ptype_script()
+begin
+
+    ;; Define output variable
+    modelnames = project_style(diag_script_info, "annots")
+
+    ;; Attach attributes
+    var_all@var = var0
+    var_all@diag_script = (/diag_script/)
+    copy_VarAtts(diag_script_info, var_all)
+    var_all@ref_model = variable_info@reference_model
+
+    ;; Start loop over models, make sure reference model is calculated first
+    modidx = ispan(0, dim_MOD, 1)
+    modidx := array_append_record(ref_ind, modidx(ind(modidx.ne.ref_ind)), 0)
+
+    do ii = 0, dimsizes(modidx) - 1
+        
+        imod = modidx(ii)
+
+        log_debug("Processing " + modelnames(imod))
+
+        ;; Set path for saving processed data
+        fullpath = config_user_info@work_dir + "/"
+        system("mkdir -p " + fullpath)
+        fname = basename(systemfunc("basename " + model_info@filename(imod)))
+        fname = fname + "_" + basename(diag_script) + "_zonal"
+        fname = fname + "_" + diag_script_info@time_avg
+        procpath = fullpath + fname + "_Global.nc"
+
+        ;; Determine start/end year
+        start_year = get_start_year(imod)
+        end_year = get_end_year(imod)
+
+        ;; Read data
+        var = read_data(imod, var0, field_type0)
+        dnames = getVarDimNames(var)
+
+        ;; Calculate zonal mean
+        var_zon = dim_avg_Wrap(var)
+        delete(var)
+
+        ;; Calculate time average and standard deviation w.r.t.
+        ;; interannual variability
+        var_avg = time_operations(var_zon, start_year, end_year, \
+                                  "average", diag_script_info@time_avg, True)
+        var_std = interannual_variability(var_zon, start_year, end_year, \
+                                          diag_script_info@time_avg)
+        delete(var_zon)
+
+        ;; Store reference model
+        if (imod.eq.ref_ind) then
+            var_ref = var_all
+        end if
+
+        ;; Write output
+        var_all = new(array_append_record(dimsizes(var_avg), 2, 0), float)
+        var_all(:, :, 0) = var_avg
+        var_all(:, :, 1) = var_std
+        if (config_user_info@write_netcdf.eq."True") then
+            var_all@ncdf = procpath
+            ncdf_outfile = ncdf_write(var_all, procpath)
+        end if
+
+        ;; Plotting
+        if (.not.diag_script_info@draw_plots) then
+            continue
+        end if
+
+        ;; Convert units for plotting (if required)
+        if (isatt(diag_script_info, "plot_units")) then
+            var_all = convert_units(var_all, diag_script_info@plot_units)
+        end if
+
+        ;; Absolute plot
+        outfile = output_dir + modelnames(imod) + "_" + var0 + "_zonal_" + \
+            diag_script_info@time_avg + "_Global"
+        plot_var = var_all(:, :, 0)
+        plot_var@res_tiMainString = modelnames(imod)
+        plot_var@res_cnLevelSelectionMode = "ExplicitLevels"
+        plot_var@res_cnLevels = diag_script_info@abs_levs
+        plot_var@res_trYMinF = diag_script_info@zonal_ymin
+        plot_var@res_gsnLeftString = \
+            plot_var@long_name + " [" + format_units(plot_var@units) + "]"
+        wks = gsn_open_wks(file_type, outfile)
+        gsn_define_colormap(wks, diag_script_info@zonal_ref_cmap)
+        plot = zonalmean_profile(wks, plot_var, var0)
+        draw(plot)
+        frame(wks)
+        log_info(" gv " + outfile + "." + file_type)
+        delete(plot_var@res_cnLevels)
+        delete(wks)
+        delete(plot)
+
+        ;; Difference plot to the reference
+        if (.not.diag_script_info@plot_diff .or. imod.eq.ref_ind) then
+            continue
+        end if
+        plot_var = var_all(:, :, 0) - var_ref(:, :, 0)
+        outfile = output_dir + modelnames(imod) + "-" + modelnames(ref_ind) + \
+            "_" + var0 + "_zonal_" + diag_script_info@time_avg + "_Global"
+        plot_var@res_tiMainString = \
+            modelnames(imod) + " - " + modelnames(ref_ind)
+        if (isatt(diag_script_info, "t_test")) then
+            plot_var@res_gsnLeftString = plot_var@res_gsnLeftString + " - " + \
+            sprinti("%2i", toint(100 * diag_script_info@conf_level)) + "% c.l."
+        end if
+        plot_var@res_cnLevelSelectionMode = "ExplicitLevels"
+        plot_var@res_cnLevels = diag_script_info@diff_levs
+        plot_var@res_cnMissingValFillColor = "gray70"
+        plot_var@res_gsnSpreadColorEnd = -2
+        wks = gsn_open_wks(file_type, outfile)
+        gsn_merge_colormaps(wks, "temp_19lev", "gray70")
+        plot = zonalmean_profile(wks, plot_var, var0)
+
+        ;; Apply t-test (assuming different population variances)
+        if (.not.diag_script_info@t_test) then
+            continue
+        end if
+
+        x1 = var_all(:, :, 0)
+        x2 = var_ref(:, :, 0)
+        s1 = var_all(:, :, 1) ^ 2
+        s2 = var_ref(:, :, 1) ^ 2
+        n1 = get_end_year(imod) - get_start_year(imod) + 1
+        n2 = get_end_year(ref_ind) - get_start_year(ref_ind) + 1
+        prob = ttest(x1, s1, n1, x2, s2, n2, True, False)
+        var_sig = 1. - prob
+        delete(prob)
+
+        ;; Stippling ;; FIX-ME False option not considered (see latlon case)
+        plot_var = var_sig(imod, :, :)
+        plot_var@res_cnMissingValFillColor = -1
+        plot_var@res_gsnSpreadColorEnd = -2
+        plot_var@res_gsnDraw = False
+        plot_var@res_gsnFrame = False
+        plot_var@res_cnLevelSelectionMode = "ExplicitLevels"
+        plot_var@res_cnFillColors = (/"transparent", "black"/)
+        plot_var@res_cnLevels := diag_script_info@conf_level
+        plot_var@res_cnInfoLabelOn = False
+        plot_var@res_cnLinesOn = False
+        plot_var@res_cnLineLabelsOn = False
+        plot_var@res_lbLabelBarOn = False
+        plot_var@res_cnFillPattern = 17
+        delete(plot_var@long_name)
+        plot2 = zonalmean_profile(wks, plot_var, var0)
+        overlay(plot, plot2)
+        draw(plot)
+        frame(wks)
+        log_info(" gv " + outfile + "." + file_type)
+        delete(plot_var@res_cnLevels)
+        delete(wks)
+        delete(plot)
+        delete(plot2)
+        delete(plot_var)
+
+    end do
+
+end

--- a/esmvaltool/diag_scripts/perfmetrics/zonal.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/zonal.ncl
@@ -7,9 +7,6 @@
 procedure perfmetrics_ptype_script()
 begin
 
-    ;; Define output variable
-    modelnames = project_style(diag_script_info, "annots")
-
     ;; Start loop over models, make sure reference model is calculated first
     modidx = ispan(0, dim_MOD - 1, 1)
     modidx := array_append_record(ref_ind, modidx(ind(modidx.ne.ref_ind)), 0)
@@ -119,6 +116,7 @@ begin
         wks = gsn_open_wks(file_type, outfile)
         gsn_merge_colormaps(wks, "temp_19lev", "gray70")
         plot = zonalmean_profile(wks, plot_var, var0)
+        delete(plot_var@res_cnLevels)
 
         ;; Apply t-test (assuming different population variances)
         if (.not.diag_script_info@t_test) then
@@ -134,26 +132,29 @@ begin
         plot_var = 1. - prob
         delete(prob)
 
-        ;; Stippling ;; FIX-ME False option not considered (see latlon case)
+        ;; Mask non-significant values
         plot_var@res_cnMissingValFillColor = -1
-        plot_var@res_gsnSpreadColorEnd = -2
         plot_var@res_gsnDraw = False
         plot_var@res_gsnFrame = False
         plot_var@res_cnLevelSelectionMode = "ExplicitLevels"
-        plot_var@res_cnFillColors = (/"transparent", "black"/)
         plot_var@res_cnLevels := diag_script_info@conf_level
+        if (diag_script_info@stippling) then
+            plot_var@res_cnFillColors = (/"transparent", "black"/)
+            plot_var@res_cnFillPattern = 17
+        else
+            plot_var@res_cnFillColors = (/"transparent", "gray70"/)
+        end if
         plot_var@res_cnInfoLabelOn = False
         plot_var@res_cnLinesOn = False
         plot_var@res_cnLineLabelsOn = False
         plot_var@res_lbLabelBarOn = False
-        plot_var@res_cnFillPattern = 17
+        plot_var@res_gsnLeftString = ""
         delete(plot_var@long_name)
         plot2 = zonalmean_profile(wks, plot_var, var0)
         overlay(plot, plot2)
         draw(plot)
         frame(wks)
         log_info(" gv " + outfile + "." + file_type)
-        delete(plot_var@res_cnLevels)
         delete(wks)
         delete(plot)
         delete(plot2)

--- a/esmvaltool/diag_scripts/perfmetrics/zonal.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/zonal.ncl
@@ -10,14 +10,8 @@ begin
     ;; Define output variable
     modelnames = project_style(diag_script_info, "annots")
 
-    ;; Attach attributes
-    var_all@var = var0
-    var_all@diag_script = (/diag_script/)
-    copy_VarAtts(diag_script_info, var_all)
-    var_all@ref_model = variable_info@reference_model
-
     ;; Start loop over models, make sure reference model is calculated first
-    modidx = ispan(0, dim_MOD, 1)
+    modidx = ispan(0, dim_MOD - 1, 1)
     modidx := array_append_record(ref_ind, modidx(ind(modidx.ne.ref_ind)), 0)
 
     do ii = 0, dimsizes(modidx) - 1
@@ -54,18 +48,24 @@ begin
                                           diag_script_info@time_avg)
         delete(var_zon)
 
-        ;; Store reference model
-        if (imod.eq.ref_ind) then
-            var_ref = var_all
-        end if
-
         ;; Write output
         var_all = new(array_append_record(dimsizes(var_avg), 2, 0), float)
+        var_all!2 = "statistic"
+        var_all&statistic = (/"mean", "stddev"/)
         var_all(:, :, 0) = var_avg
         var_all(:, :, 1) = var_std
+        var_all@var = var0
+        var_all@diag_script = (/diag_script/)
+        copy_VarAtts(diag_script_info, var_all)
+        var_all@ref_model = variable_info@reference_model
         if (config_user_info@write_netcdf.eq."True") then
             var_all@ncdf = procpath
             ncdf_outfile = ncdf_write(var_all, procpath)
+        end if
+
+        ;; Store reference model
+        if (imod.eq.ref_ind) then
+            var_ref = var_all
         end if
 
         ;; Plotting
@@ -79,8 +79,8 @@ begin
         end if
 
         ;; Absolute plot
-        outfile = output_dir + modelnames(imod) + "_" + var0 + "_zonal_" + \
-            diag_script_info@time_avg + "_Global"
+        outfile = config_user_info@plot_dir + modelnames(imod) + "_" + var0 + \
+            "_zonal_" + diag_script_info@time_avg + "_Global"
         plot_var = var_all(:, :, 0)
         plot_var@res_tiMainString = modelnames(imod)
         plot_var@res_cnLevelSelectionMode = "ExplicitLevels"
@@ -89,7 +89,7 @@ begin
         plot_var@res_gsnLeftString = \
             plot_var@long_name + " [" + format_units(plot_var@units) + "]"
         wks = gsn_open_wks(file_type, outfile)
-        gsn_define_colormap(wks, diag_script_info@zonal_ref_cmap)
+        gsn_define_colormap(wks, diag_script_info@zonal_cmap)
         plot = zonalmean_profile(wks, plot_var, var0)
         draw(plot)
         frame(wks)
@@ -103,8 +103,9 @@ begin
             continue
         end if
         plot_var = var_all(:, :, 0) - var_ref(:, :, 0)
-        outfile = output_dir + modelnames(imod) + "-" + modelnames(ref_ind) + \
-            "_" + var0 + "_zonal_" + diag_script_info@time_avg + "_Global"
+        outfile = config_user_info@plot_dir + modelnames(imod) + "-" + \
+            modelnames(ref_ind) + "_" + var0 + "_zonal_" + \
+            diag_script_info@time_avg + "_Global"
         plot_var@res_tiMainString = \
             modelnames(imod) + " - " + modelnames(ref_ind)
         if (isatt(diag_script_info, "t_test")) then
@@ -123,7 +124,6 @@ begin
         if (.not.diag_script_info@t_test) then
             continue
         end if
-
         x1 = var_all(:, :, 0)
         x2 = var_ref(:, :, 0)
         s1 = var_all(:, :, 1) ^ 2
@@ -131,11 +131,10 @@ begin
         n1 = get_end_year(imod) - get_start_year(imod) + 1
         n2 = get_end_year(ref_ind) - get_start_year(ref_ind) + 1
         prob = ttest(x1, s1, n1, x2, s2, n2, True, False)
-        var_sig = 1. - prob
+        plot_var = 1. - prob
         delete(prob)
 
         ;; Stippling ;; FIX-ME False option not considered (see latlon case)
-        plot_var = var_sig(imod, :, :)
         plot_var@res_cnMissingValFillColor = -1
         plot_var@res_gsnSpreadColorEnd = -2
         plot_var@res_gsnDraw = False

--- a/esmvaltool/namelists/namelist_perfmetrics_CMIP5.yml
+++ b/esmvaltool/namelists/namelist_perfmetrics_CMIP5.yml
@@ -144,8 +144,6 @@ diagnostics:
         calc_grading: true             # Calculate grading
         metric: RMSD                   # Metric ('RMSD', 'BIAS', taylor')
         normalization: centered_median # Normalization ('mean', 'median', 'centered_median')
-        MultiModelMean: true           # Multi-model mean
-        MultiModelMedian: true         # Multi-model median
       taylor: &taylor_settings
         <<: *grading_settings
         metric: taylor                 # Metric ('RMSD', 'BIAS', taylor')
@@ -171,6 +169,7 @@ diagnostics:
         plot_diff: true          # Draw difference plots
         t_test: true             # Calculate t-test in difference plots
         conf_level: 0.95         # Confidence level for the t-test
+        stippling: true          # Mask non-significant values with stippling
         abs_levs: [200, 210, 220, 230, 240, 250, 260, 270, 280, 290, 300] # Contour levels for absolute plot
         diff_levs: [-10, -8, -6, -4, -2, 0, 2, 4, 6, 8, 10]               # Contour levels for difference plot
       


### PR DESCRIPTION
- split `perfmetrics/main.ncl` in 4 different routines for each `plot_type` (`cycle`, `latlon`, `zonal`, `cycle_latlon`), improving code readability
- optimize each routine to work on a single-model basis (except `cycle): this allow reducing the memory load by a factor of about 2

Next steps:
- merge grading calculations in a single block of code for all metrics (RMSD, BIAS and Taylor), to be run in a loop to avoid current double processing for RMSD and Taylor and further improving the performance
- merge collect scripts in a single one (`collect_grading` and `collect_taylor` are almost identical)