### PR TITLE
Update to cf_units 2

### DIFF
--- a/esmvaltool/cmor/check.py
+++ b/esmvaltool/cmor/check.py
@@ -385,8 +385,7 @@ class CMORCheck(object):
                 cf_units.Unit(
                     'days since 1950-01-01 00:00:00',
                     calendar=coord.units.calendar))
-            simplified_cal = self._simplify_calendars(coord.units.calendar)
-            coord.units = cf_units.Unit(coord.units.name, simplified_cal)
+            coord.units = cf_units.Unit(coord.units.name, coord.units.calendar)
 
         tol = 0.001
         intervals = {
@@ -418,22 +417,6 @@ class CMORCheck(object):
                 msg = '{}: Frequency {} does not match input data'
                 self.report_error(msg, var_name, self.frequency)
                 break
-
-    CALENDARS = [
-        ['standard', 'gregorian'],
-        ['proleptic_gregorian'],
-        ['noleap', '365_day'],
-        ['all_leap', '366_day'],
-        ['360_day'],
-        ['julian'],
-        ['none'],
-    ]
-
-    @staticmethod
-    def _simplify_calendars(calendar):
-        for calendar_type in CMORCheck.CALENDARS:
-            if calendar in calendar_type:
-                return calendar_type[0]
 
     def has_errors(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ REQUIREMENTS = {
     'install': [
         'cartopy',
         'cdo',
-        'cf_units',
+        'cf_units>=2.0.1',
         'cython',
         'esgf-pyclient',
         'matplotlib',

--- a/tests/integration/cmor/_fixes/CMIP5/test_CESM1_BGC.py
+++ b/tests/integration/cmor/_fixes/CMIP5/test_CESM1_BGC.py
@@ -19,7 +19,8 @@ class TestAll(unittest.TestCase):
                 [0, 1],
                 standard_name='time',
                 units=Unit(
-                    'days since 0001-01-01 00:00:00', calendar='standard')), 0)
+                    'days since 0001-01-01 00:00:00', calendar='gregorian')),
+            0)
         self.fix = allvars()
 
     def test_fix_data(self):
@@ -27,7 +28,7 @@ class TestAll(unittest.TestCase):
 
         time = cube.coord('time')
         self.assertEqual(time.units.origin, 'days since 1850-01-01 00:00:00')
-        self.assertEqual(time.units.calendar, 'standard')
+        self.assertEqual(time.units.calendar, 'gregorian')
 
 
 class TestCo2(unittest.TestCase):
@@ -64,8 +65,8 @@ class TestNbp(unittest.TestCase):
 
         new_file = self.fix.fix_file(temp_path, output_dir)
 
-        self.assertNotEqual(os.path.realpath(temp_path),
-                            os.path.realpath(new_file))
+        self.assertNotEqual(
+            os.path.realpath(temp_path), os.path.realpath(new_file))
 
         dataset = netCDF4.Dataset(new_file)
         var = dataset.variables['nbp']

--- a/tests/integration/cmor/_fixes/CMIP5/test_GFDL_ESM2M.py
+++ b/tests/integration/cmor/_fixes/CMIP5/test_GFDL_ESM2M.py
@@ -15,7 +15,8 @@ class TestAll(unittest.TestCase):
                 [0, 1],
                 standard_name='time',
                 units=Unit(
-                    'days since 0001-01-01 00:00:00', calendar='standard')), 0)
+                    'days since 0001-01-01 00:00:00', calendar='gregorian')),
+            0)
         self.fix = allvars()
 
     def test_fix_data(self):
@@ -23,7 +24,7 @@ class TestAll(unittest.TestCase):
 
         time = cube.coord('time')
         self.assertEqual(time.units.origin, 'days since 1850-01-01 00:00:00')
-        self.assertEqual(time.units.calendar, 'standard')
+        self.assertEqual(time.units.calendar, 'gregorian')
 
 
 class TestSftof(unittest.TestCase):

--- a/tests/integration/cmor/_fixes/CMIP5/test_MIROC_ESM.py
+++ b/tests/integration/cmor/_fixes/CMIP5/test_MIROC_ESM.py
@@ -49,7 +49,8 @@ class TestAll(unittest.TestCase):
                 [0, 1],
                 standard_name='time',
                 units=Unit(
-                    'days since 0000-01-01 00:00:00', calendar='standard')), 0)
+                    'days since 0000-01-01 00:00:00', calendar='gregorian')),
+            0)
         self.cube.add_dim_coord(DimCoord([0, 1], long_name='AR5PL35'), 1)
 
         self.fix = allvars()
@@ -58,7 +59,7 @@ class TestAll(unittest.TestCase):
         cube = self.fix.fix_metadata(self.cube)
         time = cube.coord('time')
         self.assertEqual(time.units.origin, 'days since 1849-01-01 00:00:00')
-        self.assertEqual(time.units.calendar, 'standard')
+        self.assertEqual(time.units.calendar, 'gregorian')
 
     def test_fix_metadata_1_1(self):
         time = self.cube.coord('time')
@@ -67,7 +68,7 @@ class TestAll(unittest.TestCase):
 
         time = cube.coord('time')
         self.assertEqual(time.units.origin, 'days since 1850-01-01 00:00:00')
-        self.assertEqual(time.units.calendar, 'standard')
+        self.assertEqual(time.units.calendar, 'gregorian')
 
     def test_fix_metadata_plev(self):
         time = self.cube.coord('time')


### PR DESCRIPTION
The update to cf_units 2 breaks some of our unit tests, because in solving this issue https://github.com/SciTools/cf_units/issues/80, the cf_units developers 'standard' to be an alias for 'gregorian' instead of the other way around.

This PR updates esmvaltool so it works with cf_units 2.
