### PR TITLE
Fix conda build

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -65,4 +65,4 @@ test:
 about:
   home: https://www.esmvaltool.org
   license: Apache License, Version 2.0
-  license_file: LICENSE.md
+  license_file: LICENSE


### PR DESCRIPTION
Conda build is broken because I forgot to change the name of the license file in the build recipe when fixing #354.