### PR TITLE
Further extend namelist_perfmetrics

### DIFF
--- a/esmvaltool/namelist_schema.yml
+++ b/esmvaltool/namelist_schema.yml
@@ -19,7 +19,7 @@ model:
   mip: str(required=False)
   realm: str(required=False)
   shift: str(required=False)
-  tier: int(min=2, max=3, required=False)
+  tier: int(min=1, max=3, required=False)
   type: str(required=False)
 
 variable:

--- a/esmvaltool/namelists/namelist_perfmetrics_CMIP5.yml
+++ b/esmvaltool/namelists/namelist_perfmetrics_CMIP5.yml
@@ -52,6 +52,20 @@ preprocessors:
       span: overlap
       statistics: [mean, median]
       exclude: [reference_model, alternative_model]
+
+  pp400:
+    extract_levels:
+      levels: 40000
+      scheme: linear
+    regrid:
+      target_grid: AIRS
+      scheme: linear
+    mask_fillvalues:
+      threshold_fraction: 0.95
+    multi_model_statistics:
+      span: overlap
+      statistics: [mean, median]
+      exclude: [reference_model, alternative_model]      
       
   pp200:
     extract_levels:
@@ -105,7 +119,51 @@ preprocessors:
       span: overlap
       statistics: [mean, median]
       exclude: [reference_model, alternative_model]
-    
+
+  ppNOLEV1x1:
+    regrid:
+      target_grid: 1x1
+      scheme: linear
+    mask_fillvalues:
+      threshold_fraction: 0.95
+    multi_model_statistics:
+      span: overlap
+      statistics: [mean, median]
+      exclude: [reference_model, alternative_model]      
+
+  ppNOLEVpr:
+    regrid:
+      target_grid: GPCP-SG
+      scheme: linear
+    mask_fillvalues:
+      threshold_fraction: 0.95
+    multi_model_statistics:
+      span: overlap
+      statistics: [mean, median]
+      exclude: [reference_model]
+
+  ppNOLEVclt:
+    regrid:
+      target_grid: ESACCI-CLOUD
+      scheme: linear
+    mask_fillvalues:
+      threshold_fraction: 0.95
+    multi_model_statistics:
+      span: overlap
+      statistics: [mean, median]
+      exclude: [reference_model, alternative_model]
+      
+  ppNOLEVrad:
+    regrid:
+      target_grid: CERES-EBAF
+      scheme: linear
+    mask_fillvalues:
+      threshold_fraction: 0.95
+    multi_model_statistics:
+      span: overlap
+      statistics: [mean, median]
+      exclude: [reference_model]      
+      
   ppALL:
     extract_levels:
       levels: ERA-Interim
@@ -342,6 +400,7 @@ diagnostics:
       cycle:
         <<: *cycle_settings
 
+
   ta5:
     description: Air temperature at 5 hPa global.
     variables:
@@ -407,7 +466,8 @@ diagnostics:
     scripts:
       cycle:
         <<: *cycle_settings
-        
+
+
   taZONAL:
     description: Air temperature zonal mean
     variables:
@@ -828,6 +888,65 @@ diagnostics:
 
 ### hus: SPECIFIC HUMIDITY ###########################################################################################################################
 
+  hus400:
+    description: Specific humidity at 400 hPa global.
+    variables:
+      hus:
+        preprocessor: pp400
+        reference_model: AIRS
+        alternative_model: ERA-Interim
+        mip: Amon
+        field: T3M
+    additional_models:
+      - {model: ACCESS1-0,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: ACCESS1-3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: bcc-csm1-1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: bcc-csm1-1-m,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: BNU-ESM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: CanESM2,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: CCSM4,            project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: CESM1-BGC,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: CESM1-CAM5,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: CESM1-CAM5-1-FV2, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: CMCC-CM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: CMCC-CMS,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: CNRM-CM5,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: CSIRO-Mk3-6-0,    project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: FGOALS-g2,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: FGOALS-s2,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: FIO-ESM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: GISS-E2-H-CC,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: GISS-E2-R-CC,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: GFDL-CM2p1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: GFDL-CM3,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: GFDL-ESM2G,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: GFDL-ESM2M,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: HadGEM2-AO,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: HadGEM2-CC,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: HadGEM2-ES,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: inmcm4,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: IPSL-CM5A-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: IPSL-CM5A-MR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: IPSL-CM5B-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: MIROC4h,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: MIROC5,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: MIROC-ESM,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: MIROC-ESM-CHEM,   project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: MPI-ESM-LR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: MPI-ESM-MR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: MRI-CGCM3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: MRI-ESM1,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: NorESM1-M,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: NorESM1-ME,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
+      - {model: AIRS, project: obs4mips, level: L3, version: RetStd-v5, start_year: 2003, end_year: 2004, tier: 1}
+      - {model: ERA-Interim,  project: OBS,  type: reanaly,  version: 1,  start_year: 2003,  end_year: 2004,  tier: 3}     
+    scripts:
+      grading:
+        <<: *grading_settings
+        metric: [RMSD]                   # Metric ('RMSD', 'BIAS', taylor')
+        normalization: [centered_median] # Normalization ('mean', 'median', 'centered_median', 'none')
+
+
 ### tas: NEAR-SURFACE TEMPERATURE ####################################################################################################################
 
   tas:
@@ -913,13 +1032,319 @@ diagnostics:
 
 ### ts: SEA-SURFACE (SKIN) TEMPERATURE ###############################################################################################################
 
+  ts:
+    description: Sea-surface (skin) temperature
+    variables:
+      ts:
+        preprocessor: ppNOLEV1x1
+        reference_model: ESACCI-SST
+        alternative_model: HadISST
+        mip: Amon
+        field: T2Ms
+    additional_models:
+      - {model: ACCESS1-0,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: ACCESS1-3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: bcc-csm1-1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: bcc-csm1-1-m,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: BNU-ESM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CanCM4,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CanESM2,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CCSM4,            project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CESM1-BGC,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CESM1-CAM5,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CESM1-CAM5-1-FV2, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CMCC-CM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CMCC-CMS,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CNRM-CM5,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CSIRO-Mk3-6-0,    project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: FGOALS-g2,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: FIO-ESM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: GFDL-CM2p1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: GFDL-CM3,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: GFDL-ESM2G,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: GFDL-ESM2M,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: GISS-E2-H,        project: CMIP5, exp: historical, ensemble: r1i1p2, start_year: 2000, end_year: 2002}
+      - {model: GISS-E2-H-CC,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: GISS-E2-R,        project: CMIP5, exp: historical, ensemble: r1i1p2, start_year: 2000, end_year: 2002}
+      - {model: GISS-E2-R-CC,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: HadCM3,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: HadGEM2-AO,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: HadGEM2-CC,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: HadGEM2-ES,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: inmcm4,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: IPSL-CM5A-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: IPSL-CM5A-MR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: IPSL-CM5B-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MIROC4h,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MIROC5,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MIROC-ESM,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MIROC-ESM-CHEM,   project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MPI-ESM-LR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MPI-ESM-MR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MRI-CGCM3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: NorESM1-M,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: NorESM1-ME,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: ESACCI-SST,       project: OBS, type: sat,     version: L4-GHRSST-SSTdepth-OSTIA-GLOB, start_year: 2000, end_year: 2002, tier: 2}
+      - {model: HadISST,          project: OBS, type: reanaly, version: 1,                             start_year: 2000, end_year: 2002, tier: 2}
+    scripts:
+      grading:
+        <<: *grading_settings
+        metric: [RMSD]                   # Metric ('RMSD', 'BIAS', taylor')
+        normalization: [centered_median] # Normalization ('mean', 'median', 'centered_median', 'none')
+
+
 ### pr: PRECIPITATIONS ###############################################################################################################################
+
+  pr:
+    description: Precipitations
+    variables:
+      pr:
+        preprocessor: ppNOLEVpr
+        reference_model: GPCP-SG
+        mip: Amon
+        field: T2Ms
+    additional_models:
+      - {model: ACCESS1-0,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: ACCESS1-3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: bcc-csm1-1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: bcc-csm1-1-m,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: BNU-ESM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CanCM4,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CanESM2,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CCSM4,            project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CESM1-BGC,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CESM1-CAM5,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CESM1-CAM5-1-FV2, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CESM1-FASTCHEM,   project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CESM1-WACCM,      project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CMCC-CESM,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CMCC-CM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CMCC-CMS,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CNRM-CM5,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CNRM-CM5-2,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CSIRO-Mk3-6-0,    project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: EC-EARTH,         project: CMIP5, exp: historical, ensemble: r6i1p1, start_year: 2000, end_year: 2002}
+      - {model: FGOALS-g2,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: FIO-ESM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: GFDL-CM2p1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: GFDL-CM3,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: GFDL-ESM2G,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: GFDL-ESM2M,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: GISS-E2-H,        project: CMIP5, exp: historical, ensemble: r1i1p2, start_year: 2000, end_year: 2002}
+      - {model: GISS-E2-H-CC,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: GISS-E2-R,        project: CMIP5, exp: historical, ensemble: r1i1p2, start_year: 2000, end_year: 2002}
+      - {model: GISS-E2-R-CC,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: HadCM3,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: HadGEM2-AO,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: HadGEM2-CC,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: HadGEM2-ES,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: inmcm4,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: IPSL-CM5A-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: IPSL-CM5A-MR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: IPSL-CM5B-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MIROC4h,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MIROC5,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MIROC-ESM,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MIROC-ESM-CHEM,   project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MPI-ESM-LR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MPI-ESM-MR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MPI-ESM-P,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MRI-CGCM3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MRI-ESM1,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: NorESM1-M,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: NorESM1-ME,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: GPCP-SG, project: obs4mips, level: L3, version: v2.2, start_year: 2000, end_year: 2002, tier: 1}
+    scripts:
+      grading:
+        <<: *grading_settings
+        metric: [RMSD]                   # Metric ('RMSD', 'BIAS', taylor')
+        normalization: [centered_median] # Normalization ('mean', 'median', 'centered_median', 'none')
+
 
 ### clt: TOTAL CLOUD COVER ###########################################################################################################################
 
+  clt:
+    description: Total cloud cover
+    variables:
+      clt:
+        preprocessor: ppNOLEVclt
+        reference_model: ESACCI-CLOUD
+        alternative_model: PATMOS
+        mip: Amon
+        field: T2Ms
+    additional_models:
+      - {model: ACCESS1-0,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: ACCESS1-3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: bcc-csm1-1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: bcc-csm1-1-m,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: BNU-ESM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CanESM2,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CCSM4,            project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CESM1-BGC,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CESM1-CAM5,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CESM1-CAM5-1-FV2, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CMCC-CM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CMCC-CMS,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CNRM-CM5,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: CSIRO-Mk3-6-0,    project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: EC-EARTH,         project: CMIP5, exp: historical, ensemble: r6i1p1, start_year: 2000, end_year: 2002}
+      - {model: FGOALS-g2,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: FIO-ESM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: GFDL-CM3,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: GFDL-ESM2G,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: GFDL-ESM2M,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: GISS-E2-H,        project: CMIP5, exp: historical, ensemble: r1i1p2, start_year: 2000, end_year: 2002}
+      - {model: GISS-E2-H-CC,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: GISS-E2-R,        project: CMIP5, exp: historical, ensemble: r1i1p2, start_year: 2000, end_year: 2002}
+      - {model: GISS-E2-R-CC,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: HadCM3,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: HadGEM2-AO,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: HadGEM2-CC,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: HadGEM2-ES,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: inmcm4,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: IPSL-CM5A-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: IPSL-CM5A-MR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: IPSL-CM5B-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MIROC4h,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MIROC5,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MIROC-ESM,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MIROC-ESM-CHEM,   project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MPI-ESM-LR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MPI-ESM-MR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: MRI-CGCM3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: NorESM1-M,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: NorESM1-ME,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+      - {model: ESACCI-CLOUD,     project: OBS, type: sat, version: AVHRR-fv2.0, start_year: 2000, end_year: 2002, tier: 2}
+      - {model: PATMOS,           project: OBS, type: sat, version: 1,           start_year: 2000, end_year: 2002, tier: 2}
+    scripts:
+      latlon:
+        <<: *latlon_settings
+        show_global_avg: true
+        abs_levs: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]             # Contour levels for absolute plot
+        diff_levs: [-30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30] # Contour levels for difference plot
+      grading:
+        <<: *grading_settings
+        metric: [RMSD]                   # Metric ('RMSD', 'BIAS', taylor')
+        normalization: [centered_median] # Normalization ('mean', 'median', 'centered_median', 'none')
+
+
 ### rlut: ALL-SKY LONGWAVE RADIATION #################################################################################################################
 
+  rlut:
+    description: All-sky longwave radiation
+    variables:
+      rlut:
+        preprocessor: ppNOLEVrad
+        reference_model: CERES-EBAF
+        mip: Amon
+        field: T2Ms
+    additional_models:
+      - {model: ACCESS1-0,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: ACCESS1-3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: bcc-csm1-1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: bcc-csm1-1-m,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: BNU-ESM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CanCM4,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CanESM2,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CCSM4,            project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CESM1-BGC,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CESM1-CAM5,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CESM1-CAM5-1-FV2, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CMCC-CM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CMCC-CMS,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CNRM-CM5,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CSIRO-Mk3-6-0,    project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: EC-EARTH,         project: CMIP5, exp: historical, ensemble: r6i1p1, start_year: 2001, end_year: 2003}
+      - {model: FGOALS-g2,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: FGOALS-s2,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: FIO-ESM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: GFDL-CM2p1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: GFDL-CM3,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: GFDL-ESM2G,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: GFDL-ESM2M,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: GISS-E2-H,        project: CMIP5, exp: historical, ensemble: r1i1p2, start_year: 2001, end_year: 2003}
+      - {model: GISS-E2-R,        project: CMIP5, exp: historical, ensemble: r1i1p2, start_year: 2001, end_year: 2003}
+      - {model: HadCM3,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: HadGEM2-AO,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: HadGEM2-CC,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: HadGEM2-ES,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: inmcm4,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: IPSL-CM5A-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: IPSL-CM5A-MR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: IPSL-CM5B-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: MIROC4h,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: MIROC5,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: MIROC-ESM,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: MIROC-ESM-CHEM,   project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: MPI-ESM-LR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: MPI-ESM-MR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: MRI-CGCM3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: NorESM1-M,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: NorESM1-ME,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CERES-EBAF, project: obs4mips, level: L3B, version: Ed2-7, start_year: 2001, end_year: 2003, tier: 1}    
+    scripts:
+      grading:
+        <<: *grading_settings
+        metric: [RMSD]                   # Metric ('RMSD', 'BIAS', taylor')
+        normalization: [centered_median] # Normalization ('mean', 'median', 'centered_median', 'none')
+
+
 ### rsut: ALL-SKY SHORTWAVE RADIATION ################################################################################################################
+
+  rsut:
+    description: All-sky longwave radiation
+    variables:
+      rsut:
+        preprocessor: ppNOLEVrad
+        reference_model: CERES-EBAF
+        mip: Amon
+        field: T2Ms
+    additional_models:
+      - {model: ACCESS1-0,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: ACCESS1-3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: bcc-csm1-1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: bcc-csm1-1-m,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: BNU-ESM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CanESM2,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CCSM4,            project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CESM1-BGC,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CESM1-CAM5,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CESM1-CAM5-1-FV2, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CMCC-CM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CMCC-CMS,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CNRM-CM5,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CSIRO-Mk3-6-0,    project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: FGOALS-s2,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: FIO-ESM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: GFDL-CM2p1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: GFDL-CM3,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: GFDL-ESM2G,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: GFDL-ESM2M,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: GISS-E2-H,        project: CMIP5, exp: historical, ensemble: r1i1p2, start_year: 2001, end_year: 2003}
+      - {model: GISS-E2-R,        project: CMIP5, exp: historical, ensemble: r1i1p2, start_year: 2001, end_year: 2003}
+      - {model: HadCM3,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: HadGEM2-AO,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: HadGEM2-CC,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: HadGEM2-ES,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: inmcm4,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: IPSL-CM5A-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: IPSL-CM5A-MR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: IPSL-CM5B-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: MIROC4h,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: MIROC5,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: MIROC-ESM,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: MIROC-ESM-CHEM,   project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: MPI-ESM-LR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: MPI-ESM-MR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: MRI-CGCM3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: NorESM1-M,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: NorESM1-ME,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+      - {model: CERES-EBAF, project: obs4mips, level: L3B, version: Ed2-7, start_year: 2001, end_year: 2003, tier: 1}
+    scripts:
+      grading:
+        <<: *grading_settings
+        metric: [RMSD]                   # Metric ('RMSD', 'BIAS', taylor')
+        normalization: [centered_median] # Normalization ('mean', 'median', 'centered_median', 'none')
 
 ### lwcre: LONGWAVE CLOUD FORCING ####################################################################################################################
 

--- a/esmvaltool/namelists/namelist_perfmetrics_CMIP5.yml
+++ b/esmvaltool/namelists/namelist_perfmetrics_CMIP5.yml
@@ -1229,126 +1229,128 @@ diagnostics:
 
 
 ### rlut: ALL-SKY LONGWAVE RADIATION #################################################################################################################
-
-  rlut:
-    description: All-sky longwave radiation
-    variables:
-      rlut:
-        preprocessor: ppNOLEVrad
-        reference_model: CERES-EBAF
-        mip: Amon
-        field: T2Ms
-    additional_models:
-      - {model: ACCESS1-0,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: ACCESS1-3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: bcc-csm1-1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: bcc-csm1-1-m,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: BNU-ESM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CanCM4,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CanESM2,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CCSM4,            project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CESM1-BGC,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CESM1-CAM5,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CESM1-CAM5-1-FV2, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CMCC-CM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CMCC-CMS,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CNRM-CM5,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CSIRO-Mk3-6-0,    project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: EC-EARTH,         project: CMIP5, exp: historical, ensemble: r6i1p1, start_year: 2001, end_year: 2003}
-      - {model: FGOALS-g2,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: FGOALS-s2,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: FIO-ESM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: GFDL-CM2p1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: GFDL-CM3,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: GFDL-ESM2G,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: GFDL-ESM2M,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: GISS-E2-H,        project: CMIP5, exp: historical, ensemble: r1i1p2, start_year: 2001, end_year: 2003}
-      - {model: GISS-E2-R,        project: CMIP5, exp: historical, ensemble: r1i1p2, start_year: 2001, end_year: 2003}
-      - {model: HadCM3,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: HadGEM2-AO,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: HadGEM2-CC,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: HadGEM2-ES,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: inmcm4,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: IPSL-CM5A-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: IPSL-CM5A-MR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: IPSL-CM5B-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: MIROC4h,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: MIROC5,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: MIROC-ESM,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: MIROC-ESM-CHEM,   project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: MPI-ESM-LR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: MPI-ESM-MR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: MRI-CGCM3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: NorESM1-M,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: NorESM1-ME,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CERES-EBAF, project: obs4mips, level: L3B, version: Ed2-7, start_year: 2001, end_year: 2003, tier: 1}    
-    scripts:
-      grading:
-        <<: *grading_settings
-        metric: [RMSD]                   # Metric ('RMSD', 'BIAS', taylor')
-        normalization: [centered_median] # Normalization ('mean', 'median', 'centered_median', 'none')
+### FIX-ME: need REFACTORING_cre first
+#   rlut:
+#     description: All-sky longwave radiation
+#     variables:
+#       rlut:
+#         preprocessor: ppNOLEVrad
+#         reference_model: CERES-EBAF
+#         mip: Amon
+#         field: T2Ms
+#     additional_models:
+#       - {model: ACCESS1-0,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: ACCESS1-3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: bcc-csm1-1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: bcc-csm1-1-m,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: BNU-ESM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CanCM4,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CanESM2,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CCSM4,            project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CESM1-BGC,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CESM1-CAM5,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CESM1-CAM5-1-FV2, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CMCC-CM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CMCC-CMS,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CNRM-CM5,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CSIRO-Mk3-6-0,    project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: EC-EARTH,         project: CMIP5, exp: historical, ensemble: r6i1p1, start_year: 2001, end_year: 2003}
+#       - {model: FGOALS-g2,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: FGOALS-s2,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: FIO-ESM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: GFDL-CM2p1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: GFDL-CM3,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: GFDL-ESM2G,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: GFDL-ESM2M,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: GISS-E2-H,        project: CMIP5, exp: historical, ensemble: r1i1p2, start_year: 2001, end_year: 2003}
+#       - {model: GISS-E2-R,        project: CMIP5, exp: historical, ensemble: r1i1p2, start_year: 2001, end_year: 2003}
+#       - {model: HadCM3,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: HadGEM2-AO,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: HadGEM2-CC,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: HadGEM2-ES,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: inmcm4,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: IPSL-CM5A-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: IPSL-CM5A-MR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: IPSL-CM5B-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: MIROC4h,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: MIROC5,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: MIROC-ESM,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: MIROC-ESM-CHEM,   project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: MPI-ESM-LR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: MPI-ESM-MR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: MRI-CGCM3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: NorESM1-M,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: NorESM1-ME,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CERES-EBAF, project: obs4mips, level: L3B, version: Ed2-7, start_year: 2001, end_year: 2003, tier: 1}    
+#     scripts:
+#       grading:
+#         <<: *grading_settings
+#         metric: [RMSD]                   # Metric ('RMSD', 'BIAS', taylor')
+#         normalization: [centered_median] # Normalization ('mean', 'median', 'centered_median', 'none')
 
 
 ### rsut: ALL-SKY SHORTWAVE RADIATION ################################################################################################################
-
-  rsut:
-    description: All-sky longwave radiation
-    variables:
-      rsut:
-        preprocessor: ppNOLEVrad
-        reference_model: CERES-EBAF
-        mip: Amon
-        field: T2Ms
-    additional_models:
-      - {model: ACCESS1-0,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: ACCESS1-3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: bcc-csm1-1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: bcc-csm1-1-m,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: BNU-ESM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CanESM2,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CCSM4,            project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CESM1-BGC,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CESM1-CAM5,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CESM1-CAM5-1-FV2, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CMCC-CM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CMCC-CMS,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CNRM-CM5,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CSIRO-Mk3-6-0,    project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: FGOALS-s2,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: FIO-ESM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: GFDL-CM2p1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: GFDL-CM3,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: GFDL-ESM2G,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: GFDL-ESM2M,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: GISS-E2-H,        project: CMIP5, exp: historical, ensemble: r1i1p2, start_year: 2001, end_year: 2003}
-      - {model: GISS-E2-R,        project: CMIP5, exp: historical, ensemble: r1i1p2, start_year: 2001, end_year: 2003}
-      - {model: HadCM3,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: HadGEM2-AO,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: HadGEM2-CC,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: HadGEM2-ES,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: inmcm4,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: IPSL-CM5A-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: IPSL-CM5A-MR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: IPSL-CM5B-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: MIROC4h,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: MIROC5,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: MIROC-ESM,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: MIROC-ESM-CHEM,   project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: MPI-ESM-LR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: MPI-ESM-MR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: MRI-CGCM3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: NorESM1-M,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: NorESM1-ME,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-      - {model: CERES-EBAF, project: obs4mips, level: L3B, version: Ed2-7, start_year: 2001, end_year: 2003, tier: 1}
-    scripts:
-      grading:
-        <<: *grading_settings
-        metric: [RMSD]                   # Metric ('RMSD', 'BIAS', taylor')
-        normalization: [centered_median] # Normalization ('mean', 'median', 'centered_median', 'none')
+### FIX-ME: need REFACTORING_cre first
+#   rsut:
+#     description: All-sky longwave radiation
+#     variables:
+#       rsut:
+#         preprocessor: ppNOLEVrad
+#         reference_model: CERES-EBAF
+#         mip: Amon
+#         field: T2Ms
+#     additional_models:
+#       - {model: ACCESS1-0,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: ACCESS1-3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: bcc-csm1-1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: bcc-csm1-1-m,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: BNU-ESM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CanESM2,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CCSM4,            project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CESM1-BGC,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CESM1-CAM5,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CESM1-CAM5-1-FV2, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CMCC-CM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CMCC-CMS,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CNRM-CM5,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CSIRO-Mk3-6-0,    project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: FGOALS-s2,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: FIO-ESM,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: GFDL-CM2p1,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: GFDL-CM3,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: GFDL-ESM2G,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: GFDL-ESM2M,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: GISS-E2-H,        project: CMIP5, exp: historical, ensemble: r1i1p2, start_year: 2001, end_year: 2003}
+#       - {model: GISS-E2-R,        project: CMIP5, exp: historical, ensemble: r1i1p2, start_year: 2001, end_year: 2003}
+#       - {model: HadCM3,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: HadGEM2-AO,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: HadGEM2-CC,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: HadGEM2-ES,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: inmcm4,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: IPSL-CM5A-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: IPSL-CM5A-MR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: IPSL-CM5B-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: MIROC4h,          project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: MIROC5,           project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: MIROC-ESM,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: MIROC-ESM-CHEM,   project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: MPI-ESM-LR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: MPI-ESM-MR,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: MRI-CGCM3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: NorESM1-M,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: NorESM1-ME,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
+#       - {model: CERES-EBAF, project: obs4mips, level: L3B, version: Ed2-7, start_year: 2001, end_year: 2003, tier: 1}
+#     scripts:
+#       grading:
+#         <<: *grading_settings
+#         metric: [RMSD]                   # Metric ('RMSD', 'BIAS', taylor')
+#         normalization: [centered_median] # Normalization ('mean', 'median', 'centered_median', 'none')
 
 ### lwcre: LONGWAVE CLOUD FORCING ####################################################################################################################
+### FIX-ME: need REFACTORING_cre first
 
 ### swcre: SHORTWAVE CLOUD FORCING ###################################################################################################################
+### FIX-ME: need REFACTORING_cre first
 
 ### od550aer: AEROSOL OPTICAL DEPTH AT 550 nm ########################################################################################################
 


### PR DESCRIPTION
Further extend namelist_perfmetrics with `hus`, `ts`, `pr`, `clt`.
It also contains an important fix to `namelist_schema.yml`, to allow for Tier=1 in the namelist.