### PR TITLE
Fix conda build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ REQUIREMENTS = {
     'install': [
         'cartopy',
         'cdo',
-        'cf_units>=2.0.1',
+        'cf_units',
         'cython',
         'matplotlib',
         'netCDF4',


### PR DESCRIPTION
Close #399

@jvegasbsc Can you check that this will still works correctly? Most notably, cf_units < 2 does not simplify the calendar and I removed the calendar simplification code we had in PR #367 because it used different/incompatible defauits from cf_units 2 and is no longer needed when using cf_units => 2.

Note that we could also solve this issue by upgrading to iris 2 instead.