### PR TITLE
Version 2: allow defining models at namelist/diagnostic/variable level

### DIFF
--- a/esmvaltool/_namelist.py
+++ b/esmvaltool/_namelist.py
@@ -617,13 +617,9 @@ class Namelist(object):
         self._cfg = config_user
         self._namelist_file = os.path.basename(namelist_file)
         self._preprocessors = raw_namelist['preprocessors']
-        if raw_namelist.get('models'):
-            self.models = raw_namelist['models']
-        else:
-            self.models = []
         self._support_ncl = self._need_ncl(raw_namelist['diagnostics'])
         self.diagnostics = self._initialize_diagnostics(
-            raw_namelist['diagnostics'])
+            raw_namelist['diagnostics'], raw_namelist.get('models', []))
         self.tasks = self.initialize_tasks() if initialize_tasks else None
 
     @staticmethod
@@ -640,7 +636,7 @@ class Namelist(object):
                     return True
         return False
 
-    def _initialize_diagnostics(self, raw_diagnostics):
+    def _initialize_diagnostics(self, raw_diagnostics, raw_models):
         """Define diagnostics in namelist"""
         logger.debug("Retrieving diagnostics from namelist")
 
@@ -649,26 +645,21 @@ class Namelist(object):
         for name, raw_diagnostic in raw_diagnostics.items():
             diagnostic = {}
             diagnostic['name'] = name
-            models = self._initialize_models(
-                name, raw_diagnostic.get('additional_models'))
-            diagnostic['models'] = models
             diagnostic['preprocessor_output'] = \
                 self._initialize_preprocessor_output(
-                    name, raw_diagnostic.get('variables'), models)
+                    name,
+                    raw_diagnostic.get('variables', {}),
+                    raw_models + raw_diagnostic.get('additional_models', []))
             diagnostic['scripts'] = self._initialize_scripts(
                 name, raw_diagnostic.get('scripts'))
             diagnostics[name] = diagnostic
 
         return diagnostics
 
-    def _initialize_models(self, diagnostic_name, raw_additional_models):
-        """Define models in diagnostic"""
-        logger.debug("Setting models for diagnostic %s", diagnostic_name)
-
-        models = list(self.models)
-
-        if raw_additional_models:
-            models += raw_additional_models
+    @staticmethod
+    def _initialize_models(raw_models):
+        """Define models used by variable"""
+        models = copy.deepcopy(raw_models)
 
         for model in models:
             for key in model:
@@ -677,11 +668,14 @@ class Namelist(object):
         check_duplicate_models(models)
         return models
 
-    def _initialize_variables(self, raw_variable, models):
+    def _initialize_variables(self, raw_variable, raw_models):
         """Define variables for all models."""
         # TODO: rename `variables` to `attributes` and store in dict
         # using filenames as keys?
         variables = []
+
+        models = self._initialize_models(
+            raw_models + raw_variable.pop('additional_models', []))
 
         for model in models:
             variable = copy.deepcopy(raw_variable)
@@ -705,11 +699,8 @@ class Namelist(object):
         return variables
 
     def _initialize_preprocessor_output(self, diagnostic_name, raw_variables,
-                                        models):
+                                        raw_models):
         """Define variables in diagnostic"""
-        if not raw_variables:
-            return {}
-
         logger.debug("Populating list of variables for diagnostic %s",
                      diagnostic_name)
 
@@ -721,7 +712,7 @@ class Namelist(object):
             raw_variable['diagnostic'] = diagnostic_name
             raw_variable['preprocessor'] = str(raw_variable['preprocessor'])
             preprocessor_output[variable_name] = \
-                self._initialize_variables(raw_variable, models)
+                self._initialize_variables(raw_variable, raw_models)
 
         return preprocessor_output
 

--- a/esmvaltool/namelists/namelist_example_py.yml
+++ b/esmvaltool/namelists/namelist_example_py.yml
@@ -35,6 +35,8 @@ diagnostics:
       ta:
         preprocessor: preprocessor1
         field: T3M
+        additional_models:
+          - {model: NCEP,        project: OBS,    tier: 2,    type: reanaly,    version: 1,        start_year: 2000,  end_year: 2002}
       pr:
         preprocessor: preprocessor2
         field: T2Ms

--- a/esmvaltool/namelists/namelist_perfmetrics_CMIP5.yml
+++ b/esmvaltool/namelists/namelist_perfmetrics_CMIP5.yml
@@ -21,9 +21,6 @@
 # This namelist is part of the ESMValTool
 ###############################################################################
 ---
-
-models:
-
 preprocessors:
   pp850:
     extract_levels:
@@ -65,8 +62,8 @@ preprocessors:
     multi_model_statistics:
       span: overlap
       statistics: [mean, median]
-      exclude: [reference_model, alternative_model]      
-      
+      exclude: [reference_model, alternative_model]
+
   pp200:
     extract_levels:
       levels: 20000
@@ -79,7 +76,7 @@ preprocessors:
     multi_model_statistics:
       span: overlap
       statistics: [mean, median]
-      exclude: [reference_model, alternative_model]      
+      exclude: [reference_model, alternative_model]
 
   pp30:
     extract_levels:
@@ -119,7 +116,7 @@ preprocessors:
       span: overlap
       statistics: [mean, median]
       exclude: [reference_model]
-      
+
   ppNOLEV2:
     regrid:
       target_grid: reference_model
@@ -140,8 +137,8 @@ preprocessors:
     multi_model_statistics:
       span: overlap
       statistics: [mean, median]
-      exclude: [reference_model, alternative_model]      
-         
+      exclude: [reference_model, alternative_model]
+
   ppALL:
     extract_levels:
       levels: reference_model
@@ -159,8 +156,8 @@ preprocessors:
 
 diagnostics:
 
-### ta: AIR TEMPERATURE ##############################################################################################################################
-  
+  ### ta: AIR TEMPERATURE ##############################################################################################################################
+
   ta850:
     description: Air temperature at 850 hPa global.
     variables:
@@ -454,7 +451,7 @@ diagnostics:
         reference_model: ERA-Interim
         alternative_model: NCEP
         mip: Amon
-        field: T3M    
+        field: T3M
     additional_models:
       - {model: ACCESS1-0,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
       - {model: ACCESS1-3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
@@ -522,7 +519,7 @@ diagnostics:
         diff_levs: [-10, -8, -6, -4, -2, 0, 2, 4, 6, 8, 10]               # Contour levels for difference plot
 
 
-### ua: EASTWARD WIND ################################################################################################################################
+  ### ua: EASTWARD WIND ################################################################################################################################
 
   ua850:
     description: Eastward wind at 850 hPa global.
@@ -660,7 +657,7 @@ diagnostics:
         normalization: [centered_median] # Normalization ('mean', 'median', 'centered_median', 'none')
 
 
-### va: NORTHWARD WIND ###############################################################################################################################
+  ### va: NORTHWARD WIND ###############################################################################################################################
 
   va850:
     description: Northward wind at 850 hPa global.
@@ -796,7 +793,7 @@ diagnostics:
         normalization: [centered_median] # Normalization ('mean', 'median', 'centered_median', 'none')
 
 
-### zg: GEOPOTENTIAL HEIGHT ##########################################################################################################################
+  ### zg: GEOPOTENTIAL HEIGHT ##########################################################################################################################
 
   zg500:
     description: Geopotential height 500 hPa global.
@@ -854,7 +851,7 @@ diagnostics:
       - {model: MPI-ESM-P,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
       - {model: MRI-CGCM3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
       - {model: NorESM1-M,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
-      - {model: NorESM1-ME,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}     
+      - {model: NorESM1-ME,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
       - {model: ERA-Interim,  project: OBS,  type: reanaly,  version: 1,  start_year: 2000,  end_year: 2002,  tier: 3}
       - {model: NCEP,         project: OBS,  type: reanaly,  version: 1,  start_year: 2000,  end_year: 2002,  tier: 2}
     scripts:
@@ -864,7 +861,7 @@ diagnostics:
         normalization: [centered_median] # Normalization ('mean', 'median', 'centered_median', 'none')
 
 
-### hus: SPECIFIC HUMIDITY ###########################################################################################################################
+  ### hus: SPECIFIC HUMIDITY ###########################################################################################################################
 
   hus400:
     description: Specific humidity at 400 hPa global.
@@ -917,7 +914,7 @@ diagnostics:
       - {model: NorESM1-M,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
       - {model: NorESM1-ME,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2003, end_year: 2004}
       - {model: AIRS, project: obs4mips, level: L3, version: RetStd-v5, start_year: 2003, end_year: 2004, tier: 1}
-      - {model: ERA-Interim,  project: OBS,  type: reanaly,  version: 1,  start_year: 2003,  end_year: 2004,  tier: 3}     
+      - {model: ERA-Interim,  project: OBS,  type: reanaly,  version: 1,  start_year: 2003,  end_year: 2004,  tier: 3}
     scripts:
       grading:
         <<: *grading_settings
@@ -925,7 +922,7 @@ diagnostics:
         normalization: [centered_median] # Normalization ('mean', 'median', 'centered_median', 'none')
 
 
-### tas: NEAR-SURFACE TEMPERATURE ####################################################################################################################
+  ### tas: NEAR-SURFACE TEMPERATURE ####################################################################################################################
 
   tas:
     description: Near-surface air temperature
@@ -986,7 +983,7 @@ diagnostics:
       - {model: MRI-CGCM3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
       - {model: MRI-ESM1,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
       - {model: NorESM1-M,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
-      - {model: NorESM1-ME,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}    
+      - {model: NorESM1-ME,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
       - {model: ERA-Interim,  project: OBS,  type: reanaly,  version: 1,  start_year: 2000,  end_year: 2002,  tier: 3}
       - {model: NCEP,         project: OBS,  type: reanaly,  version: 1,  start_year: 2000,  end_year: 2002,  tier: 2}
     scripts:
@@ -995,8 +992,8 @@ diagnostics:
         plot_type: latlon        # Plot type ('cycle' [time], 'zonal' [plev, lat], 'latlon' [lat, lon], 'cycle_latlon' [time, lat, lon])
         time_avg: annualclim     # Time average ('opt' argument of time_operations.ncl)
         region: Global           # Selected region ('Global', 'Tropics', 'NH extratropics', 'SH extratropics')
-        plot_diff: True          # Draw difference plots
-        t_test: True             # Calculate t-test in difference plots
+        plot_diff: true          # Draw difference plots
+        t_test: true             # Calculate t-test in difference plots
         conf_level: 0.95         # Confidence level for the t-test
         abs_levs: [240, 243, 246, 249, 252, 255, 258,
                    261, 264, 267, 270, 273, 276, 279,
@@ -1006,9 +1003,9 @@ diagnostics:
         <<: *grading_settings
         metric: [RMSD]                   # Metric ('RMSD', 'BIAS', taylor')
         normalization: [centered_median] # Normalization ('mean', 'median', 'centered_median', 'none')
-       
 
-### ts: SEA-SURFACE (SKIN) TEMPERATURE ###############################################################################################################
+
+  ### ts: SEA-SURFACE (SKIN) TEMPERATURE ###############################################################################################################
 
   ts:
     description: Sea-surface (skin) temperature
@@ -1071,7 +1068,7 @@ diagnostics:
         normalization: [centered_median] # Normalization ('mean', 'median', 'centered_median', 'none')
 
 
-### pr: PRECIPITATIONS ###############################################################################################################################
+  ### pr: PRECIPITATIONS ###############################################################################################################################
 
   pr:
     description: Precipitations
@@ -1139,7 +1136,7 @@ diagnostics:
         normalization: [centered_median] # Normalization ('mean', 'median', 'centered_median', 'none')
 
 
-### clt: TOTAL CLOUD COVER ###########################################################################################################################
+  ### clt: TOTAL CLOUD COVER ###########################################################################################################################
 
   clt:
     description: Total cloud cover
@@ -1259,7 +1256,7 @@ diagnostics:
 #       - {model: MRI-CGCM3,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
 #       - {model: NorESM1-M,        project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
 #       - {model: NorESM1-ME,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2003}
-#       - {model: CERES-EBAF, project: obs4mips, level: L3B, version: Ed2-7, start_year: 2001, end_year: 2003, tier: 1}    
+#       - {model: CERES-EBAF, project: obs4mips, level: L3B, version: Ed2-7, start_year: 2001, end_year: 2003, tier: 1}
 #     scripts:
 #       grading:
 #         <<: *grading_settings


### PR DESCRIPTION
Allow defining models at 3 different levels:
- at namelist level in the `models` section
- at diagnostic level in an `additional_models` section
- at variable level in an `additional_models` section

This closes #288.