### PR TITLE
Version 2: Add --max-models

### DIFF
--- a/esmvaltool/_main.py
+++ b/esmvaltool/_main.py
@@ -84,6 +84,10 @@ def get_args():
         action='store_true',
         help='Download input data using synda. This requires a working '
         'synda installation.')
+    parser.add_argument(
+        '--max-models',
+        type=int,
+        help='Try to limit the number of models used to MAX_MODELS.')
     args = parser.parse_args()
     return args
 
@@ -119,6 +123,7 @@ def main(args):
     logger.info("Writing program log files to:\n%s", "\n".join(log_files))
 
     cfg['synda_download'] = args.synda_download
+    cfg['max_models'] = args.max_models
 
     resource_log = os.path.join(cfg['run_dir'], 'resource_usage.txt')
     with resource_usage_logger(pid=os.getpid(), filename=resource_log):

--- a/esmvaltool/_namelist.py
+++ b/esmvaltool/_namelist.py
@@ -254,13 +254,27 @@ def _add_cmor_info(variable, override=False):
     check_variable(variable, required_keys=cmor_keys)
 
 
+def _special_name_to_model(variable, special_name):
+    """Convert special names to model names."""
+    if special_name in ('reference_model', 'alternative_model'):
+        if special_name not in variable:
+            raise NamelistError(
+                "Preprocessor {} uses {}, but {} is not defined for "
+                "variable {} of diagnostic {}".format(
+                    variable['preprocessor'], special_name, special_name,
+                    variable['short_name'], variable['diagnostic']))
+        special_name = variable[special_name]
+
+    return special_name
+
+
 def _update_target_levels(variable, variables, settings, config_user):
     """Replace the target levels model name with a filename if needed."""
-    if (not settings.get('extract_levels')
-            or 'levels' not in settings['extract_levels']):
+    levels = settings.get('extract_levels', {}).get('levels')
+    if not levels:
         return
 
-    levels = settings['extract_levels']['levels']
+    levels = _special_name_to_model(variable, levels)
 
     # If levels is a model name, replace it by a dict with a 'model' entry
     if any(levels == v['model'] for v in variables):
@@ -285,10 +299,11 @@ def _update_target_levels(variable, variables, settings, config_user):
 
 def _update_target_grid(variable, variables, settings, config_user):
     """Replace the target grid model name with a filename if needed."""
-    if not settings.get('regrid') or 'target_grid' not in settings['regrid']:
+    grid = settings.get('regrid', {}).get('target_grid')
+    if not grid:
         return
 
-    grid = settings['regrid']['target_grid']
+    grid = _special_name_to_model(variable, grid)
 
     if variable['model'] == grid:
         del settings['regrid']
@@ -309,6 +324,37 @@ def _model_to_file(model, variables, config_user):
 
     raise NamelistError(
         "Unable to find matching file for model {}".format(model))
+
+
+def _limit_models(variables, profile, max_models=None):
+    """Try to limit the number of models to max_models."""
+    if not max_models:
+        return variables
+
+    logger.info("Limiting the number of models to %s", max_models)
+
+    required_models = (
+        profile.get('extract_levels', {}).get('levels'),
+        profile.get('regrid', {}).get('target_grid'),
+        variables[0].get('reference_model'),
+        variables[0].get('alternative_model'),
+    )
+
+    limited = []
+
+    for variable in variables:
+        if variable['model'] in required_models:
+            limited.append(variable)
+
+    for variable in variables[::-1]:
+        if len(limited) >= max_models:
+            break
+        if variable not in limited:
+            limited.append(variable)
+
+    logger.info("Only considering %s", ', '.join(v['model'] for v in limited))
+
+    return limited
 
 
 def _get_default_settings(variable, config_user, derive=False):
@@ -549,6 +595,8 @@ def _get_preprocessor_task(variables,
     profile = copy.deepcopy(profiles[variable['preprocessor']])
     logger.info("Creating preprocessor '%s' task for variable '%s'",
                 variable['preprocessor'], variable['short_name'])
+    variables = _limit_models(variables, profile,
+                              config_user.get('max_models'))
 
     # Create preprocessor task(s)
     derive_tasks = []

--- a/esmvaltool/namelists/namelist_example_py.yml
+++ b/esmvaltool/namelists/namelist_example_py.yml
@@ -13,7 +13,7 @@ preprocessors:
       levels: 85000
       scheme: nearest
     regrid:
-      target_grid: ERA-Interim
+      target_grid: reference_model
       scheme: linear
     multi_model_statistics:
       span: overlap
@@ -21,7 +21,7 @@ preprocessors:
 
   preprocessor2:
     regrid:
-      target_grid: ERA-Interim
+      target_grid: reference_model
       scheme: linear
     multi_model_statistics:
       span: overlap
@@ -35,9 +35,11 @@ diagnostics:
       ta:
         preprocessor: preprocessor1
         field: T3M
+        reference_model: ERA-Interim
       pr:
         preprocessor: preprocessor2
         field: T2Ms
+        reference_model: ERA-Interim
     scripts:
       script1:
         script: examples/diagnostic.py

--- a/esmvaltool/namelists/namelist_perfmetrics_CMIP5.yml
+++ b/esmvaltool/namelists/namelist_perfmetrics_CMIP5.yml
@@ -30,7 +30,7 @@ preprocessors:
       levels: 85000
       scheme: linear
     regrid:
-      target_grid: ERA-Interim
+      target_grid: reference_model
       scheme: linear
     mask_fillvalues:
       threshold_fraction: 0.95
@@ -44,7 +44,7 @@ preprocessors:
       levels: 50000
       scheme: linear
     regrid:
-      target_grid: ERA-Interim
+      target_grid: reference_model
       scheme: linear
     mask_fillvalues:
       threshold_fraction: 0.95
@@ -58,7 +58,7 @@ preprocessors:
       levels: 40000
       scheme: linear
     regrid:
-      target_grid: AIRS
+      target_grid: reference_model
       scheme: linear
     mask_fillvalues:
       threshold_fraction: 0.95
@@ -72,7 +72,7 @@ preprocessors:
       levels: 20000
       scheme: linear
     regrid:
-      target_grid: ERA-Interim
+      target_grid: reference_model
       scheme: linear
     mask_fillvalues:
       threshold_fraction: 0.95
@@ -86,7 +86,7 @@ preprocessors:
       levels: 3000
       scheme: linear
     regrid:
-      target_grid: ERA-Interim
+      target_grid: reference_model
       scheme: linear
     mask_fillvalues:
       threshold_fraction: 0.95
@@ -100,7 +100,7 @@ preprocessors:
       levels: 500
       scheme: linear
     regrid:
-      target_grid: ERA-Interim
+      target_grid: reference_model
       scheme: linear
     mask_fillvalues:
       threshold_fraction: 0.95
@@ -108,10 +108,21 @@ preprocessors:
       span: overlap
       statistics: [mean, median]
       exclude: [reference_model, alternative_model]
-      
-  ppNOLEV:
+
+  ppNOLEV1:
     regrid:
-      target_grid: ERA-Interim
+      target_grid: reference_model
+      scheme: linear
+    mask_fillvalues:
+      threshold_fraction: 0.95
+    multi_model_statistics:
+      span: overlap
+      statistics: [mean, median]
+      exclude: [reference_model]
+      
+  ppNOLEV2:
+    regrid:
+      target_grid: reference_model
       scheme: linear
     mask_fillvalues:
       threshold_fraction: 0.95
@@ -130,46 +141,13 @@ preprocessors:
       span: overlap
       statistics: [mean, median]
       exclude: [reference_model, alternative_model]      
-
-  ppNOLEVpr:
-    regrid:
-      target_grid: GPCP-SG
-      scheme: linear
-    mask_fillvalues:
-      threshold_fraction: 0.95
-    multi_model_statistics:
-      span: overlap
-      statistics: [mean, median]
-      exclude: [reference_model]
-
-  ppNOLEVclt:
-    regrid:
-      target_grid: ESACCI-CLOUD
-      scheme: linear
-    mask_fillvalues:
-      threshold_fraction: 0.95
-    multi_model_statistics:
-      span: overlap
-      statistics: [mean, median]
-      exclude: [reference_model, alternative_model]
-      
-  ppNOLEVrad:
-    regrid:
-      target_grid: CERES-EBAF
-      scheme: linear
-    mask_fillvalues:
-      threshold_fraction: 0.95
-    multi_model_statistics:
-      span: overlap
-      statistics: [mean, median]
-      exclude: [reference_model]      
-      
+         
   ppALL:
     extract_levels:
-      levels: ERA-Interim
+      levels: reference_model
       scheme: linear
     regrid:
-      target_grid: ERA-Interim
+      target_grid: reference_model
       scheme: linear
     mask_fillvalues:
       threshold_fraction: 0.95
@@ -953,7 +931,7 @@ diagnostics:
     description: Near-surface air temperature
     variables:
       tas:
-        preprocessor: ppNOLEV
+        preprocessor: ppNOLEV2
         reference_model: ERA-Interim
         alternative_model: NCEP
         mip: Amon
@@ -1099,7 +1077,7 @@ diagnostics:
     description: Precipitations
     variables:
       pr:
-        preprocessor: ppNOLEVpr
+        preprocessor: ppNOLEV1
         reference_model: GPCP-SG
         mip: Amon
         field: T2Ms
@@ -1167,7 +1145,7 @@ diagnostics:
     description: Total cloud cover
     variables:
       clt:
-        preprocessor: ppNOLEVclt
+        preprocessor: ppNOLEV2
         reference_model: ESACCI-CLOUD
         alternative_model: PATMOS
         mip: Amon
@@ -1234,7 +1212,7 @@ diagnostics:
 #     description: All-sky longwave radiation
 #     variables:
 #       rlut:
-#         preprocessor: ppNOLEVrad
+#         preprocessor: ppNOLEV1
 #         reference_model: CERES-EBAF
 #         mip: Amon
 #         field: T2Ms
@@ -1295,7 +1273,7 @@ diagnostics:
 #     description: All-sky longwave radiation
 #     variables:
 #       rsut:
-#         preprocessor: ppNOLEVrad
+#         preprocessor: ppNOLEV1
 #         reference_model: CERES-EBAF
 #         mip: Amon
 #         field: T2Ms


### PR DESCRIPTION
- Add a --max-models flag
- Allow use of 'reference_model' and 'alternative_model' instead of model name for regrid/extract_levels