### PR TITLE
Removal of preproc directory upon user option and all diags exited nicely

### DIFF
--- a/esmvaltool/_config.py
+++ b/esmvaltool/_config.py
@@ -23,6 +23,7 @@ def read_config_user_file(config_file, namelist_name):
         'output_file_type': 'ps',
         'output_dir': './output_dir',
         'save_intermediary_cubes': False,
+        'remove_preproc_dir': False,
         'max_parallel_tasks': 1,
         'run_diagnostic': True,
         'drs': {},

--- a/esmvaltool/_main.py
+++ b/esmvaltool/_main.py
@@ -34,7 +34,6 @@ import logging
 import os
 import shutil
 import sys
-import subprocess
 from multiprocessing import cpu_count
 
 from . import __version__
@@ -55,17 +54,6 @@ ______________________________________________________________________
 ______________________________________________________________________
 
 """ + __doc__
-
-
-def remove_preproc(preproc_dir):
-    """Remove the preproc dir if all finished fine"""
-    rm_call = 'rm -r ' + preproc_dir
-    proc = subprocess.Popen(rm_call, stdout=subprocess.PIPE, shell=True)
-    (out, err) = proc.communicate()
-    if int(proc.returncode) == 0:
-        logger.info("Removed preprocessed data...")
-    else:
-        logger.warning("Could not remove preprocessed data...")
 
 
 def get_args():
@@ -205,5 +193,5 @@ def run():
         sys.exit(1)
     else:
         if conf["remove_preproc_dir"]:
-            remove_preproc(conf["preproc_dir"])
+            shutil.rmtree(conf["preproc_dir"])
         logger.info("Run was succesful")

--- a/esmvaltool/_main.py
+++ b/esmvaltool/_main.py
@@ -193,5 +193,8 @@ def run():
         sys.exit(1)
     else:
         if conf["remove_preproc_dir"]:
+            logger.info("Removing preproc containing preprocessed data")
+            logger.info("If this data is further needed, then")
+            logger.info("set remove_preproc_dir to false in config")
             shutil.rmtree(conf["preproc_dir"])
         logger.info("Run was succesful")

--- a/esmvaltool/_main.py
+++ b/esmvaltool/_main.py
@@ -137,6 +137,7 @@ def main(args):
         process_namelist(namelist_file=namelist_file, config_user=cfg)
     return cfg
 
+
 def process_namelist(namelist_file, config_user):
     """Process namelist"""
     if not os.path.isfile(namelist_file):

--- a/esmvaltool/config-user.yml
+++ b/esmvaltool/config-user.yml
@@ -19,6 +19,8 @@ output_file_type: pdf
 output_dir: ./esmvaltool_output
 # Save intermediary cubes in the preprocessor true/[false]
 save_intermediary_cubes: false
+# Remove the preproc dir if all fine
+remove_preproc_dir: false
 # Run at most this many tasks in parallel null/[1]/2/3/4/..
 # Set to null to use the number of available CPUs.
 # Make sure your system has enough memory for the specified number of tasks.

--- a/esmvaltool/config-user.yml
+++ b/esmvaltool/config-user.yml
@@ -20,7 +20,7 @@ output_dir: ./esmvaltool_output
 # Save intermediary cubes in the preprocessor true/[false]
 save_intermediary_cubes: false
 # Remove the preproc dir if all fine
-remove_preproc_dir: false
+remove_preproc_dir: true
 # Run at most this many tasks in parallel null/[1]/2/3/4/..
 # Set to null to use the number of available CPUs.
 # Make sure your system has enough memory for the specified number of tasks.


### PR DESCRIPTION
Rehashed solution for https://github.com/ESMValGroup/ESMValTool/issues/348 -- this is much more straightforward now and it works at all depth levels (tested with a stratosphere diagnostic that now always returns the return code so that the main diagnostic knows if it failed or not).