### PR TITLE
Support default preprocessors

### DIFF
--- a/esmvaltool/_recipe.py
+++ b/esmvaltool/_recipe.py
@@ -679,6 +679,8 @@ class Recipe(object):
         self._cfg = config_user
         self._recipe_file = os.path.basename(recipe_file)
         self._preprocessors = raw_recipe['preprocessors']
+        if 'default' not in self._preprocessors:
+            self._preprocessors['default'] = {}
         self._support_ncl = self._need_ncl(raw_recipe['diagnostics'])
         self.diagnostics = self._initialize_diagnostics(
             raw_recipe['diagnostics'], raw_recipe.get('datasets', []))
@@ -773,7 +775,8 @@ class Recipe(object):
             if 'short_name' not in raw_variable:
                 raw_variable['short_name'] = variable_name
             raw_variable['diagnostic'] = diagnostic_name
-            raw_variable['preprocessor'] = str(raw_variable['preprocessor'])
+            raw_variable['preprocessor'] = str(raw_variable.get('preprocessor',
+                                                                'default'))
             preprocessor_output[variable_name] = \
                 self._initialize_variables(raw_variable, raw_datasets)
 

--- a/esmvaltool/recipe_schema.yml
+++ b/esmvaltool/recipe_schema.yml
@@ -4,7 +4,7 @@
 ---
 # Recipe schema
 datasets: list(include('dataset'), required=False)
-preprocessors: map(map(), min=1)
+preprocessors: map(map(), required=False)
 diagnostics: map(include('diagnostic'), required=False)
 
 ---
@@ -24,7 +24,7 @@ dataset:
 
 variable:
   field: str()
-  preprocessor: str()
+  preprocessor: str(required=False)
   reference_dataset: str(required=False)
   alternative_dataset: str(required=False)
   mip: str(required=False)

--- a/esmvaltool/recipes/recipe_example_ncl.yml
+++ b/esmvaltool/recipes/recipe_example_ncl.yml
@@ -15,14 +15,6 @@ preprocessors:
     mask_landocean: false
     multi_model_statistics: false
 
-  preprocessor_2:
-    extract_levels: false
-    regrid:
-      target_grid: ERA-Interim
-      scheme: linear
-    mask_landocean: false
-    multi_model_statistics: false
-
 diagnostics:
   ta_diagnostics:
     description: Air temperature tutorial diagnostics.
@@ -47,7 +39,6 @@ diagnostics:
     description: Precipitation tutorial diagnostic.
     variables:
       pr:
-        preprocessor: preprocessor_2
         field: T2Ms
     additional_datasets: []
     scripts:

--- a/esmvaltool/recipes/recipe_example_py.yml
+++ b/esmvaltool/recipes/recipe_example_py.yml
@@ -19,14 +19,6 @@ preprocessors:
       span: overlap
       statistics: [mean, median]
 
-  preprocessor2:
-    regrid:
-      target_grid: reference_dataset
-      scheme: linear
-    multi_model_statistics:
-      span: overlap
-      statistics: [mean, median]
-
 diagnostics:
 
   diagnostic1:
@@ -39,7 +31,6 @@ diagnostics:
         additional_datasets:
           - {dataset: NCEP,        project: OBS,    tier: 2,    type: reanaly,    version: 1,        start_year: 2000,  end_year: 2002}
       pr:
-        preprocessor: preprocessor2
         field: T2Ms
         reference_dataset: ERA-Interim
     scripts:


### PR DESCRIPTION
Sometimes user do not want to apply any complex prepocessing, just the raw data for the desired time. To simplify namelists in those cases I have added two features:

-  If "default" is not a defined preprocessor, I add an empty one. Thanks to @bouweandela  work, this will execute the minimun tasks required

- If a variable does not have a defined preprocessor, it will use "default" by default

I have updated the python example diagnostic to show this

Be aware that the default preprocessor can now be overriden by the users. If we do not want this behaviour we can just forbid the users to use that name. 