### PR TITLE
Remove working dir dependency of NCL check test

### DIFF
--- a/tests/unit/test_lint.py
+++ b/tests/unit/test_lint.py
@@ -60,7 +60,8 @@ def test_nclcodestyle():
         ', '.join(check_paths)))
 
     style = nclcodestyle.StyleGuide()
-
+    package_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    check_paths = [os.path.join(package_root, path) for path in check_paths]
     success = style.check_files(check_paths).total_errors == 0
 
     if not success:


### PR DESCRIPTION
It was failing all the time in Pycharm. Now it has the correct paths without worrying about the working dir