### PR TITLE
Allowing empty preprocessor

### DIFF
--- a/esmvaltool/_recipe.py
+++ b/esmvaltool/_recipe.py
@@ -77,7 +77,7 @@ def check_recipe(filename):
         raw_recipe = yaml.safe_load(file)
 
     # TODO: add more checks?
-    check_preprocessors(raw_recipe['preprocessors'])
+    check_preprocessors(raw_recipe.get('preprocessors', {}))
     check_diagnostics(raw_recipe['diagnostics'])
     return raw_recipe
 
@@ -679,7 +679,7 @@ class Recipe(object):
         """Parse a recipe file into an object."""
         self._cfg = config_user
         self._recipe_file = os.path.basename(recipe_file)
-        self._preprocessors = raw_recipe['preprocessors']
+        self._preprocessors = raw_recipe.get('preprocessors', {})
         if 'default' not in self._preprocessors:
             self._preprocessors['default'] = {}
         self._support_ncl = self._need_ncl(raw_recipe['diagnostics'])


### PR DESCRIPTION
After #469, preprocessors should no longer be necessary to run a recipe. However, if there is no `preprocessors` key in the recipe, I get the following error:

```
2018-07-04 11:06:41,909 UTC [24306] ERROR   Program terminated abnormally, see stack trace below for more information
Traceback (most recent call last):
  File "~/ESMValTool/esmvaltool/_main.py", line 204, in run
    conf = main(args)
  File "~/ESMValTool/esmvaltool/_main.py", line 133, in main
    process_recipe(recipe_file=recipe, config_user=cfg)
  File "~/ESMValTool/esmvaltool/_main.py", line 179, in process_recipe
    recipe = read_recipe_file(recipe_file, config_user)
  File "~/ESMValTool/esmvaltool/_recipe.py", line 34, in read_recipe_file
    raw_recipe = check_recipe(filename)
  File "~/ESMValTool/esmvaltool/_recipe.py", line 80, in check_recipe
    check_preprocessors(raw_recipe['preprocessors'])
KeyError: 'preprocessors'
```

If the recipe contains another preprocessor and some of the variables do not use one, the tool works just fine (as done in `esmvaltool/recipes/recipe_example_py.yml`).