### PR TITLE
Add support for lower and upper tags

### DIFF
--- a/esmvaltool/_data_finder.py
+++ b/esmvaltool/_data_finder.py
@@ -69,14 +69,7 @@ def replace_tags(path, variable, j=None, i=None):
 
     for tag in tlist:
         original_tag = tag
-        lower = False
-        upper = False
-        if tag.endswith('.lower'):
-            lower = True
-            tag = tag[0:-6]
-        elif tag.endswith('.upper'):
-            upper = True
-            tag = tag[0:-6]
+        tag, lower, upper = _get_caps_options(tag)
 
         if tag == 'var':
             replacewith = variable['short_name']
@@ -110,17 +103,30 @@ def replace_tags(path, variable, j=None, i=None):
 
         if not isinstance(replacewith, list):
             path = path.replace('[' + original_tag + ']',
-                                _apply_lower(replacewith, lower, upper))
+                                _apply_caps(replacewith, lower, upper))
         else:
             path = [
                 path.replace('[' + original_tag + ']',
-                             _apply_lower(dkrz_place, lower, upper))
+                             _apply_caps(dkrz_place, lower, upper))
                 for dkrz_place in replacewith
             ][j]
     return path
 
 
-def _apply_lower(original, lower, upper):
+def _get_caps_options(tag):
+    original_tag = tag
+    lower = False
+    upper = False
+    if tag.endswith('.lower'):
+        lower = True
+        tag = tag[0:-6]
+    elif tag.endswith('.upper'):
+        upper = True
+        tag = tag[0:-6]
+    return tag, lower, upper
+
+
+def _apply_caps(original, lower, upper):
     if lower:
         return original.lower()
     elif upper:

--- a/esmvaltool/_data_finder.py
+++ b/esmvaltool/_data_finder.py
@@ -114,7 +114,6 @@ def replace_tags(path, variable, j=None, i=None):
 
 
 def _get_caps_options(tag):
-    original_tag = tag
     lower = False
     upper = False
     if tag.endswith('.lower'):

--- a/esmvaltool/_data_finder.py
+++ b/esmvaltool/_data_finder.py
@@ -68,6 +68,15 @@ def replace_tags(path, variable, j=None, i=None):
     tlist = re.findall(r'\[([^]]*)\]', path)
 
     for tag in tlist:
+        original_tag = tag
+        lower = False
+        upper = False
+        if tag.endswith('.lower'):
+            lower = True
+            tag = tag[0:-6]
+        elif tag.endswith('.upper'):
+            upper = True
+            tag = tag[0:-6]
 
         if tag == 'var':
             replacewith = variable['short_name']
@@ -100,13 +109,23 @@ def replace_tags(path, variable, j=None, i=None):
                     "your recipe entry".format(tag, variable['project']))
 
         if not isinstance(replacewith, list):
-            path = path.replace('[' + tag + ']', replacewith)
+            path = path.replace('[' + original_tag + ']',
+                                _apply_lower(replacewith, lower, upper))
         else:
             path = [
-                path.replace('[' + tag + ']', dkrz_place)
+                path.replace('[' + original_tag + ']',
+                             _apply_lower(dkrz_place, lower, upper))
                 for dkrz_place in replacewith
             ][j]
     return path
+
+
+def _apply_lower(original, lower, upper):
+    if lower:
+        return original.lower()
+    elif upper:
+        return original.upper()
+    return original
 
 
 def get_input_dirname_template(variable, rootpath, drs):

--- a/esmvaltool/config-developer.yml
+++ b/esmvaltool/config-developer.yml
@@ -29,7 +29,7 @@ CMIP5:
     DKRZ: '[institute]/[dataset]/[exp]/[freq]/[realm]/[mip]/[ensemble]/[latestversion]/[var]'
     ETHZ: '[exp]/[mip]/[var]/[dataset]/[ensemble]/'
     SMHI: '[dataset]/[ensemble]/[exp]/[freq]'
-    BSC: '[project]/[exp]/[dataset]'
+    BSC: '[project]/[exp]/[dataset.lower]'
   input_file: '[var]_[mip]_[dataset]_[exp]_[ensemble]_*'
   fx_dir:
     default: '/'
@@ -116,7 +116,7 @@ CMIP5:
 OBS:
   input_dir:
     default: '[tier]/[dataset]'
-    BSC: '[type]/[institute]/[dataset]/[freq_folder]/[var][freq_base]'
+    BSC: '[type]/[institute.lower]/[dataset.upperlower]/[freq_folder]/[var][freq_base]'
   input_file:
     default: '[project]_[dataset]_[type]_[version]_[field]_[var]_*'
     BSC: '[var]_*.nc'

--- a/esmvaltool/config-developer.yml
+++ b/esmvaltool/config-developer.yml
@@ -116,7 +116,7 @@ CMIP5:
 OBS:
   input_dir:
     default: '[tier]/[dataset]'
-    BSC: '[type]/[institute.lower]/[dataset.upperlower]/[freq_folder]/[var][freq_base]'
+    BSC: '[type]/[institute.lower]/[dataset.lower]/[freq_folder]/[var][freq_base]'
   input_file:
     default: '[project]_[dataset]_[type]_[version]_[field]_[var]_*'
     BSC: '[var]_*.nc'


### PR DESCRIPTION
In our storage, we have the convention of using all lowercase for dataset and institute folder names.

To support this, I have added the option to specifiy capitalization in tag substitution. An example:

If tag=Tag, the configuration
```
[tag]_[tag.lower]_ [tag.upper]
```
will be converted to
```
Tag_tag_TAG
```
