### PR TITLE
Allowed recipes with no scripts

### DIFF
--- a/esmvaltool/_recipe.py
+++ b/esmvaltool/_recipe.py
@@ -120,7 +120,10 @@ def check_diagnostics(diagnostics):
             raise RecipeError("Missing scripts section in diagnostic {}"
                               .format(name))
         variable_names = tuple(diagnostic.get('variables', {}))
-        for script_name, script in diagnostic.get('scripts', {}).items():
+        scripts = diagnostic.get('scripts')
+        if scripts is None:
+            scripts = {}
+        for script_name, script in scripts.items():
             if script_name in variable_names:
                 raise RecipeError(
                     "Invalid script name {} encountered in diagnostic {}: "

--- a/esmvaltool/recipes/recipe_preprocessor_test.yml
+++ b/esmvaltool/recipes/recipe_preprocessor_test.yml
@@ -22,7 +22,7 @@ preprocessors:
     multi_model_statistics:
       span: overlap
       statistics: [mean, median]
-      exclude: [NCEP]   
+      exclude: [NCEP]
 
   preprocessor_2:
     custom_order: true
@@ -70,6 +70,7 @@ diagnostics:
       ta:
         preprocessor: preprocessor_2
         field: T3M
+    scripts: null
 
   diagnostic_3_and_4:
     description: Preprocessor test diagnostic.


### PR DESCRIPTION
While testing I noticed that the preprocessor test [recipe](https://github.com/ESMValGroup/ESMValTool/blob/version2_development/esmvaltool/recipes/recipe_preprocessor_test.yml) did not run because no script is used. This should fix it.