### PR TITLE
Update _data_finder.py

### DIFF
--- a/esmvaltool/_data_finder.py
+++ b/esmvaltool/_data_finder.py
@@ -59,7 +59,6 @@ def get_start_end_year(filename):
         if ind != 0:
             pos_ydates_l[ind] = (pos_ydates_l[ind - 1] and pos_ydates_l[ind])
     
-    
     for ind, _ in enumerate(pos_ydates_r):
         if ind != 0:
             pos_ydates_r[- ind - 1] = (pos_ydates_r[- ind] and
@@ -67,7 +66,7 @@ def get_start_end_year(filename):
     
     dates = [filename_list[ind] for ind, _ in enumerate(pos_ydates)
              if pos_ydates_r[ind] or pos_ydates_l[ind]]
-
+    
     if len(dates) == 1:
         start_year = int(dates[0][:4])
         end_year = start_year

--- a/esmvaltool/_data_finder.py
+++ b/esmvaltool/_data_finder.py
@@ -52,8 +52,8 @@ def get_start_end_year(filename):
     filename_list = [elem for sublist in filename_list for elem in sublist]
 
     pos_ydates = [elem.isdigit() and len(elem) >= 4 for elem in filename_list]
-    pos_ydates_l = pos_ydates.copy()
-    pos_ydates_r = pos_ydates.copy()
+    pos_ydates_l = list(pos_ydates)
+    pos_ydates_r = list(pos_ydates)
 
     for ind, _ in enumerate(pos_ydates_l):
         if ind != 0:

--- a/esmvaltool/_data_finder.py
+++ b/esmvaltool/_data_finder.py
@@ -33,10 +33,40 @@ def find_files(dirname, filename):
 def get_start_end_year(filename):
     """Get the start and end year from a file name.
 
-    This works for filenames matching *_YYYY*-YYYY*.* or *_YYYY*.*
+    This works for filenames matching 
+    
+    *[-,_]YYYY*[-,_]YYYY*.* 
+      or 
+    *[-,_]YYYY*.* 
+      or 
+    YYYY*[-,_]*.*
+      or 
+    YYYY*[-,_]YYYY*[-,_]*.*
+      or
+    YYYY*[-,_]*[-,_]YYYY*.* (Does this make sense? Is this worth catching?)
     """
     name = os.path.splitext(filename)[0]
-    dates = name.split('_')[-1].split('-')
+    
+    filename = name.split(os.sep)[-1]
+    filename_list = [elem.split('-') for elem in filename.split('_')]
+    filename_list = [elem for sublist in filename_list for elem in sublist]
+    
+    pos_ydates = [elem.isdigit() and len(elem)>=4 for elem in filename_list]
+    pos_ydates_l = pos_ydates.copy(); pos_ydates_r = pos_ydates.copy() 
+    
+    for ind,_ in enumerate(pos_ydates_l):
+        if ind != 0:
+            pos_ydates_l[ind] = (pos_ydates_l[ind-1] and pos_ydates_l[ind])
+    
+    
+    for ind,_ in enumerate(pos_ydates_r):
+        if ind != 0:
+            pos_ydates_r[-ind-1] = (pos_ydates_r[-ind] and 
+                                    pos_ydates_r[-ind-1])
+    
+    dates = [filename_list[ind] for ind,_ in enumerate(pos_ydates) 
+             if pos_ydates_r[ind] or pos_ydates_l[ind]]
+
     if len(dates) == 1:
         start_year = int(dates[0][:4])
         end_year = start_year
@@ -45,6 +75,7 @@ def get_start_end_year(filename):
     else:
         raise ValueError('Name {0} dates do not match a recognized '
                          'pattern'.format(name))
+    
     return start_year, end_year
 
 

--- a/esmvaltool/_data_finder.py
+++ b/esmvaltool/_data_finder.py
@@ -34,7 +34,7 @@ def get_start_end_year(filename):
     """Get the start and end year from a file name.
 
     This works for filenames matching
-    
+
     *[-,_]YYYY*[-,_]YYYY*.*
       or
     *[-,_]YYYY*.*
@@ -46,27 +46,27 @@ def get_start_end_year(filename):
     YYYY*[-,_]*[-,_]YYYY*.* (Does this make sense? Is this worth catching?)
     """
     name = os.path.splitext(filename)[0]
-    
+
     filename = name.split(os.sep)[-1]
     filename_list = [elem.split('-') for elem in filename.split('_')]
     filename_list = [elem for sublist in filename_list for elem in sublist]
-    
+
     pos_ydates = [elem.isdigit() and len(elem) >= 4 for elem in filename_list]
     pos_ydates_l = pos_ydates.copy()
     pos_ydates_r = pos_ydates.copy()
-    
+
     for ind, _ in enumerate(pos_ydates_l):
         if ind != 0:
             pos_ydates_l[ind] = (pos_ydates_l[ind - 1] and pos_ydates_l[ind])
-    
+
     for ind, _ in enumerate(pos_ydates_r):
         if ind != 0:
             pos_ydates_r[- ind - 1] = (pos_ydates_r[- ind] and
-                                    pos_ydates_r[- ind - 1])
-    
+                                       pos_ydates_r[- ind - 1])
+
     dates = [filename_list[ind] for ind, _ in enumerate(pos_ydates)
              if pos_ydates_r[ind] or pos_ydates_l[ind]]
-    
+
     if len(dates) == 1:
         start_year = int(dates[0][:4])
         end_year = start_year
@@ -75,7 +75,7 @@ def get_start_end_year(filename):
     else:
         raise ValueError('Name {0} dates do not match a recognized '
                          'pattern'.format(name))
-    
+
     return start_year, end_year
 
 

--- a/esmvaltool/_data_finder.py
+++ b/esmvaltool/_data_finder.py
@@ -35,12 +35,12 @@ def get_start_end_year(filename):
 
     This works for filenames matching 
     
-    *[-,_]YYYY*[-,_]YYYY*.* 
-      or 
-    *[-,_]YYYY*.* 
-      or 
+    *[-,_]YYYY*[-,_]YYYY*.*
+      or
+    *[-,_]YYYY*.*
+      or
     YYYY*[-,_]*.*
-      or 
+      or
     YYYY*[-,_]YYYY*[-,_]*.*
       or
     YYYY*[-,_]*[-,_]YYYY*.* (Does this make sense? Is this worth catching?)
@@ -51,20 +51,21 @@ def get_start_end_year(filename):
     filename_list = [elem.split('-') for elem in filename.split('_')]
     filename_list = [elem for sublist in filename_list for elem in sublist]
     
-    pos_ydates = [elem.isdigit() and len(elem)>=4 for elem in filename_list]
-    pos_ydates_l = pos_ydates.copy(); pos_ydates_r = pos_ydates.copy() 
+    pos_ydates = [elem.isdigit() and len(elem) >= 4 for elem in filename_list]
+    pos_ydates_l = pos_ydates.copy()
+    pos_ydates_r = pos_ydates.copy()
     
-    for ind,_ in enumerate(pos_ydates_l):
+    for ind, _ in enumerate(pos_ydates_l):
         if ind != 0:
             pos_ydates_l[ind] = (pos_ydates_l[ind-1] and pos_ydates_l[ind])
     
     
-    for ind,_ in enumerate(pos_ydates_r):
+    for ind, _ in enumerate(pos_ydates_r):
         if ind != 0:
-            pos_ydates_r[-ind-1] = (pos_ydates_r[-ind] and 
+            pos_ydates_r[-ind-1] = (pos_ydates_r[-ind] and
                                     pos_ydates_r[-ind-1])
     
-    dates = [filename_list[ind] for ind,_ in enumerate(pos_ydates) 
+    dates = [filename_list[ind] for ind, _ in enumerate(pos_ydates)
              if pos_ydates_r[ind] or pos_ydates_l[ind]]
 
     if len(dates) == 1:

--- a/esmvaltool/_data_finder.py
+++ b/esmvaltool/_data_finder.py
@@ -33,7 +33,7 @@ def find_files(dirname, filename):
 def get_start_end_year(filename):
     """Get the start and end year from a file name.
 
-    This works for filenames matching 
+    This works for filenames matching
     
     *[-,_]YYYY*[-,_]YYYY*.*
       or
@@ -57,13 +57,13 @@ def get_start_end_year(filename):
     
     for ind, _ in enumerate(pos_ydates_l):
         if ind != 0:
-            pos_ydates_l[ind] = (pos_ydates_l[ind-1] and pos_ydates_l[ind])
+            pos_ydates_l[ind] = (pos_ydates_l[ind - 1] and pos_ydates_l[ind])
     
     
     for ind, _ in enumerate(pos_ydates_r):
         if ind != 0:
-            pos_ydates_r[-ind-1] = (pos_ydates_r[-ind] and
-                                    pos_ydates_r[-ind-1])
+            pos_ydates_r[- ind - 1] = (pos_ydates_r[- ind] and
+                                    pos_ydates_r[- ind - 1])
     
     dates = [filename_list[ind] for ind, _ in enumerate(pos_ydates)
              if pos_ydates_r[ind] or pos_ydates_l[ind]]

--- a/tests/unit/data_finder/test_get_start_end_year.py
+++ b/tests/unit/data_finder/test_get_start_end_year.py
@@ -1,0 +1,76 @@
+"""Unit tests for :func:`esmvaltool._data_finder.regrid._stock_cube`"""
+
+import unittest
+
+from esmvaltool._data_finder import get_start_end_year
+
+
+class TestGetStartEndYear(unittest.TestCase):
+    """Tests for get_start_end_year function"""
+
+    def test_years_at_the_end(self):
+        """Test parse files with two years at the end"""
+        start, end = get_start_end_year('var_whatever_1980-1981')
+        self.assertEqual(1980, start)
+        self.assertEqual(1981, end)
+
+    def test_one_year_at_the_end(self):
+        """Test parse files with one year at the end"""
+        start, end = get_start_end_year('var_whatever_1980.nc')
+        self.assertEqual(1980, start)
+        self.assertEqual(1980, end)
+
+    def test_full_dates_at_the_end(self):
+        """Test parse files with two dates at the end"""
+        start, end = get_start_end_year('var_whatever_19800101-19811231.nc')
+        self.assertEqual(1980, start)
+        self.assertEqual(1981, end)
+
+    def test_one_fulldate_at_the_end(self):
+        """Test parse files with one date at the end"""
+        start, end = get_start_end_year('var_whatever_19800101.nc')
+        self.assertEqual(1980, start)
+        self.assertEqual(1980, end)
+
+    def test_years_at_the_start(self):
+        """Test parse files with two years at the start"""
+        start, end = get_start_end_year('1980-1981_var_whatever.nc')
+        self.assertEqual(1980, start)
+        self.assertEqual(1981, end)
+
+    def test_one_year_at_the_start(self):
+        """Test parse files with one year at the start"""
+        start, end = get_start_end_year('1980_var_whatever.nc')
+        self.assertEqual(1980, start)
+        self.assertEqual(1980, end)
+
+    def test_full_dates_at_the_start(self):
+        """Test parse files with two dates at the start"""
+        start, end = get_start_end_year('19800101-19811231_var_whatever.nc')
+        self.assertEqual(1980, start)
+        self.assertEqual(1981, end)
+
+    def test_one_fulldate_at_the_start(self):
+        """Test parse files with one date at the start"""
+        start, end = get_start_end_year('19800101_var_whatever.nc')
+        self.assertEqual(1980, start)
+        self.assertEqual(1980, end)
+
+    def test_start_with_dates_in_other_parts(self):
+        """Test parse one date at the start and one in experiment's name"""
+        start, end = get_start_end_year(
+            '19800101_var_control-1950_whatever.nc')
+        self.assertEqual(1980, start)
+        self.assertEqual(1980, end)
+
+    def test_end_with_dates_in_other_parts(self):
+        """Test parse one date at the end and one in experiment's name"""
+        start, end = get_start_end_year(
+            'var_control-1950_whatever_19800101.nc')
+        self.assertEqual(1980, start)
+        self.assertEqual(1980, end)
+
+    def test_fails_if_no_date_present(self):
+        """Test raises if no date is present"""
+        with self.assertRaises(ValueError):
+            start, end = get_start_end_year('var_whatever')

--- a/tests/unit/data_finder/test_get_start_end_year.py
+++ b/tests/unit/data_finder/test_get_start_end_year.py
@@ -56,14 +56,14 @@ class TestGetStartEndYear(unittest.TestCase):
         self.assertEqual(1980, start)
         self.assertEqual(1980, end)
 
-    def test_start_with_dates_in_other_parts(self):
+    def test_start_and_date_in_name(self):
         """Test parse one date at the start and one in experiment's name"""
         start, end = get_start_end_year(
             '19800101_var_control-1950_whatever.nc')
         self.assertEqual(1980, start)
         self.assertEqual(1980, end)
 
-    def test_end_with_dates_in_other_parts(self):
+    def test_end_and_date_in_name(self):
         """Test parse one date at the end and one in experiment's name"""
         start, end = get_start_end_year(
             'var_control-1950_whatever_19800101.nc')
@@ -73,4 +73,4 @@ class TestGetStartEndYear(unittest.TestCase):
     def test_fails_if_no_date_present(self):
         """Test raises if no date is present"""
         with self.assertRaises(ValueError):
-            start, end = get_start_end_year('var_whatever')
+            get_start_end_year('var_whatever')


### PR DESCRIPTION
get_start_end_year can now also handle dates at the beginning of the filenames:

````
"""Get the start and end year from a file name.

    This works for filenames matching 
    
    *[-,_]YYYY*[-,_]YYYY*.* 
      or 
    *[-,_]YYYY*.* 
      or 
    YYYY*[-,_]*.*
      or 
    YYYY*[-,_]YYYY*[-,_]*.*
      or
    YYYY*[-,_]*[-,_]YYYY*.* (Does this make sense? Is this worth catching?)
    """
````