### PR TITLE
Areacello files are now available for seaIce realm

### DIFF
--- a/esmvaltool/_data_finder.py
+++ b/esmvaltool/_data_finder.py
@@ -206,6 +206,11 @@ def get_input_fx_dirname_template(variable, rootpath, drs):
                 'drs {} for {} project not specified in config-developer file'
                 .format(_drs, project))
 
+        # Replace seaIce realm by ocean realm
+        path_elements = dir2.split(os.path.sep)
+        if "seaIce" in path_elements:
+            dir2 = dir2.replace("seaIce", "ocean")
+
         dirname_template = os.path.join(dir1, dir2)
         dirs.append(dirname_template)
 


### PR DESCRIPTION
The `areacello` files are stored in the `ocean` directories of the `fx` files. When used with seaice variables having the mip `OImon`, the tool couldn't find the files. This fixes it.