### PR TITLE
Prepare for version 2.0a1 release

### DIFF
--- a/esmvaltool/_version.py
+++ b/esmvaltool/_version.py
@@ -1,2 +1,2 @@
 """ESMValTool version"""
-__version__ = '2.0a0'
+__version__ = '2.0a1'

--- a/meta.yaml
+++ b/meta.yaml
@@ -5,7 +5,7 @@
 # conda build esmvaltool -c conda-forge -c birdhouse
 
 # Package version number
-{% set version = "2.0a0" %}
+{% set version = "2.0a1" %}
 
 package:
   name: esmvaltool


### PR DESCRIPTION
It's a good moment to have a new release, because we now have several working recipes.

Also, the `version2_master` branch and the corresponding conda package are broken because they are affected by #543, having a new release fixes that too.