### PR TITLE
Added fix for inmcm4's nbp variable

### DIFF
--- a/esmvaltool/cmor/_fixes/CMIP5/inmcm4.py
+++ b/esmvaltool/cmor/_fixes/CMIP5/inmcm4.py
@@ -1,4 +1,6 @@
 """Fixes for inmcm4 model"""
+import iris
+
 from ..fix import Fix
 
 
@@ -48,3 +50,39 @@ class lai(Fix):
         cube *= 0.01
         cube.metadata = metadata
         return cube
+
+
+class nbp(Fix):
+    """Fixes for nbp"""
+
+    def fix_file(self, filepath, output_dir):
+        """
+        Apply fixes to the files prior to creating the cube.
+
+        Should be used only to fix errors that prevent loading or can
+        not be fixed in the cube (i.e. those related with missing_value
+        and _FillValue or missing standard_name).
+
+        Parameters
+        ----------
+        filepath: basestring
+            file to fix.
+        output_dir: basestring
+            path to the folder to store the fix files, if required.
+
+        Returns
+        -------
+        basestring
+            Path to the corrected file. It can be different from the original
+            filepath if a fix has been applied, but if not it should be the
+            original filepath.
+
+        """
+        new_path = Fix.get_fixed_filepath(output_dir, filepath)
+        cube = iris.load_cube(filepath)
+        cube.standard_name = 'surface_net_downward_mass_flux_of_carbon_' \
+                             'dioxide_expressed_as_carbon_due_to_all_land_' \
+                             'processes'
+        iris.save(cube, new_path)
+        return new_path
+

--- a/tests/integration/cmor/_fixes/CMIP5/test_inmcm4.py
+++ b/tests/integration/cmor/_fixes/CMIP5/test_inmcm4.py
@@ -1,9 +1,13 @@
+import os
+import shutil
+import tempfile
 import unittest
 
 from cf_units import Unit
+import iris
 from iris.cube import Cube
 
-from esmvaltool.cmor._fixes.CMIP5.inmcm4 import gpp, lai
+from esmvaltool.cmor._fixes.CMIP5.inmcm4 import gpp, lai, nbp
 
 
 class TestGpp(unittest.TestCase):
@@ -26,3 +30,28 @@ class TestLai(unittest.TestCase):
         cube = self.fix.fix_data(self.cube)
         self.assertEqual(cube.data[0], 1.0 / 100.0)
         self.assertEqual(cube.units, Unit('J'))
+
+
+class TestNbp(unittest.TestCase):
+    def setUp(self):
+        """Prepare temp folder for test"""
+        self.cube = Cube([1], var_name='nbp')
+        self.fix = nbp()
+        self.temp_folder = tempfile.mkdtemp()
+
+    def tearDown(self):
+        """Delete temp folder"""
+        shutil.rmtree(self.temp_folder)
+
+    def test_fix_file(self):
+        """Test fix on nbp files to set standard_name"""
+        temp_handler, temp_path = tempfile.mkstemp('.nc', dir=self.temp_folder)
+        os.close(temp_handler)
+        output_dir = os.path.join(self.temp_folder, 'fixed')
+
+        iris.save(self.cube, temp_path)
+        new_path = self.fix.fix_file(temp_path, output_dir)
+        new_cube = iris.load_cube(new_path)
+        self.assertEqual(new_cube.standard_name,
+                         'surface_net_downward_mass_flux_of_carbon_dioxide_'
+                         'expressed_as_carbon_due_to_all_land_processes')


### PR DESCRIPTION
The original dataset does not contain the attribute `standard_name`, which is needed by iris to load the cubes.