### PR TITLE
Fixed bug im landsea masking

### DIFF
--- a/esmvaltool/_recipe.py
+++ b/esmvaltool/_recipe.py
@@ -510,9 +510,9 @@ def _update_fx_settings(settings, variable, config_user):
             drs=config_user['drs'])
 
         # allow both sftlf and sftof
-        if fx_files_dict['sftlf']:
+        if fx_files_dict.get('sftlf'):
             settings['mask_landsea']['fx_files'].append(fx_files_dict['sftlf'])
-        if fx_files_dict['sftof']:
+        if fx_files_dict.get('sftof'):
             settings['mask_landsea']['fx_files'].append(fx_files_dict['sftof'])
 
 

--- a/esmvaltool/preprocessor/_regrid.py
+++ b/esmvaltool/preprocessor/_regrid.py
@@ -194,13 +194,7 @@ def regrid(src_cube, target_grid, scheme):
                 src_cube.remove_coord(coord)
 
     # Perform the horizontal regridding.
-    try:
-        result = src_cube.regrid(target_grid, horizontal_schemes[scheme])
-    except Exception as ex:
-        msg = ('There were errors while regridding the cube '
-               '{}'.format(src_cube),)
-        ex.args = msg + ex.args
-        raise ex
+    result = src_cube.regrid(target_grid, horizontal_schemes[scheme])
 
     return result
 

--- a/esmvaltool/preprocessor/_regrid.py
+++ b/esmvaltool/preprocessor/_regrid.py
@@ -194,7 +194,13 @@ def regrid(src_cube, target_grid, scheme):
                 src_cube.remove_coord(coord)
 
     # Perform the horizontal regridding.
-    result = src_cube.regrid(target_grid, horizontal_schemes[scheme])
+    try:
+        result = src_cube.regrid(target_grid, horizontal_schemes[scheme])
+    except Exception as ex:
+        msg = ('There were errors while regridding the cube '
+               '{}'.format(src_cube),)
+        ex.args = msg + ex.args
+        raise ex
 
     return result
 


### PR DESCRIPTION
Fixed a bug which caused a `KeyError` in preprocessor `mask_landsea` when no `sftlf` or `sftof` data is available (e.g. for `OBS`) and added an error message for regridding. Before, the cube which failed was not printed.