### PR TITLE
Added mip 'Oyr' to config-developer.yml for OceanBGC recipe

### DIFF
--- a/esmvaltool/config-developer.yml
+++ b/esmvaltool/config-developer.yml
@@ -113,6 +113,7 @@ CMIP5:
     'NorESM1-M': 'NCC'
     'NorESM1-ME': 'NCC'
   realm_frequency:
+    'Oyr': ['ocnBgchem', 'yr']
     'Amon': ['atmos', 'mon']
     'Omon': ['ocean', 'mon']
     'Lmon': ['land', 'mon']


### PR DESCRIPTION
The [OceanBGC recipe](https://github.com/ESMValGroup/ESMValTool/blob/version2_development/esmvaltool/recipes/recipe_OceanBGC.yml) did not work with the default `config-developer.yml` because of the missing mip `Oyr`.