### PR TITLE
Pin version of matplotlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ REQUIREMENTS = {
         'cf_units',
         'cython',
         # 'scitools-iris',  # Only iris 2 is on PyPI
-        'matplotlib',
+        'matplotlib<3.0.0',
         'netCDF4',
         'numba',
         'numpy',


### PR DESCRIPTION
See https://github.com/ESMValGroup/ESMValTool/issues/610

counters conflict of current releases of Basemap and Matplotlib