### PR TITLE
Remove basemap

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,6 @@ channels:
 dependencies:
   # Python packages that cannot be installed from PyPI:
   # TODO when switching to iris 2.x, switch straight to 2.1+
-  - basemap
   - iris=1.13
   - python-stratify
   # Multi language support:

--- a/meta.yaml
+++ b/meta.yaml
@@ -33,7 +33,6 @@ requirements:
   run:
     # esmvaltool
     - python
-    - basemap
     - iris=1.13
     - python-stratify
     # Normally installed via pip:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@
 # - ncl
 # - iris
 # - python-stratify
-# - basemap
 
 import os
 import re
@@ -28,7 +27,6 @@ REQUIREMENTS = {
     # Installation dependencies
     # Use with pip install . to install from source
     'install': [
-        'basemap',
         'cartopy',
         'cdo',
         'cf_units',


### PR DESCRIPTION
Basemap is
+ [deprecated](https://matplotlib.org/basemap/users/intro.html#cartopy-new-management-and-eol-announcement)
+ starting to give problems during installation, see https://github.com/ESMValGroup/ESMValTool/issues/610
+ currently not used in v2

So lets remove it as a dependency. 

See conversation from withdrawn PR https://github.com/ESMValGroup/ESMValTool/pull/611 and issue https://github.com/ESMValGroup/ESMValTool/issues/610