### PR TITLE
Added two calculations to _derive.py : tropospheric ozone column and stratospheric ozone column

### DIFF
--- a/doc/sphinx/source/user_guide2/step_by_step_intro.inc
+++ b/doc/sphinx/source/user_guide2/step_by_step_intro.inc
@@ -9,8 +9,9 @@ basic background with Python would be useful.
 File Structure
 ===============
 
+Here is it just added how looks like the file structure of the tool: 
 
-├── conda_build_config.yaml
+├── conda_build_config.yaml 
 ├── doc
 │   └── sphinx
 │       └── source
@@ -32,12 +33,12 @@ File Structure
 │   ├── config-references.yml
 │   ├── config-user.yml
 │   ├── _data_finder.py
-│   ├── diag_scripts
+│   ├── diag_scripts --------------> here diagnostics (python and others) live.
 │   │   ├── autoassess
 │   │   ├── climate_metrics
 │   │   ├── clouds
 │   │   ├── examples
-│   │   ├── __init__.py
+│   │   ├── __init_../../../../esmvaltool/preprocessor/_.py
 │   │   ├── ipcc_ar5
 │   │   ├── ocean
 │   │   ├── perfmetrics
@@ -53,12 +54,12 @@ File Structure
 │   │   ├── write_header.ncl
 │   │   └── write_references.ncl
 │   ├── _main.py
-│   ├── preprocessor
+│   ├── preprocessor -------------> here preprocessors. Usually users do not have to change
 │   │   ├── _area_pp.py
 │   │   ├── _derive.py
 │   │   ├── _download.py
 │   │   ├── __init__.py
-│   │   ├── _io.py
+│   │   ├── _io.py../../../../esmvaltool/preprocessor/
 │   │   ├── _mask.py
 │   │   ├── _multimodel.py
 │   │   ├── ne_masks
@@ -67,12 +68,12 @@ File Structure
 │   │   ├── _time_area.py
 │   │   └── _volume_pp.py
 │   ├── _recipe.py
-│   ├── recipes
+│   ├── recipes -----------------> here recipes YAML are living.
 │   │   ├── examples
 │   │   ├── recipe_autoassess_landsurface_snow.yml
 │   │   ├── recipe_autoassess_landsurface_surfrad.yml
 │   │   ├── recipe_autoassess_radiation_rms_Amon_all.yml
-│   │   ├── recipe_autoassess_radiation_rms_Amon_obs.yml
+│   │   ├── recipe_autoassess_radiatioseason_yearn_rms_Amon_obs.yml
 │   │   ├── recipe_autoassess_radiation_rms_cfMon_all.yml
 │   │   ├── recipe_autoassess_stratosphere.yml
 │   │   ├── recipe_clouds_bias.yml
@@ -103,7 +104,7 @@ File Structure
 ├── RELEASE_NOTES
 ├── setup.cfg
 ├── setup.py ---------------------------> setup.py for manual installation
-└── tests ------------------------------> testing units to ensure code works
+└── tests ---------../../../../esmvaltool/preprocessor/---------------------> testing units to ensure code works
     ├── __init__.py
     ├── integration
     │   ├── cmor
@@ -142,6 +143,7 @@ def run():
 ```
 
 And removing the exceptions and logs parts of the code it basically:
+
 ```
 def main(args):
     """Define the `esmvaltool` program."""
@@ -199,7 +201,7 @@ but it basically read the recipe file and create a python object (whose class is
 that has a method named run so at some point we have to understand **recipe.run()**
 
 The **recipe object** is something relatively complex with several methods with decorators that
-require carefull reading. My understanding indice that this object has the following components:
+require carefull reading. To my understanding recipe object has the following components:
 
 ```
         """Parse a recipe file into an object."""
@@ -220,7 +222,9 @@ So now we understand better what a recipe, or at least what components it has:
 2. recipe file        [yaml file?]
 3. preprocessors      [a recipe will have a number of pre-processing steps defined here]
 4. support_ncl        [legacy dependence in ncl or to use ncl?]
-5. diagnostics        [derived information using diagnostics on raw-recipe and datasets]
+5. diagnostics        [derived information using diagnostics of raw-recipe and datasets]
 6. tasks              [probably all the other aspects are coded in a number of tasks]
+
+
 
 

--- a/doc/sphinx/source/user_guide2/step_by_step_intro.inc
+++ b/doc/sphinx/source/user_guide2/step_by_step_intro.inc
@@ -1,0 +1,10 @@
+
+Introduction to step by step
+============================
+
+Currently this documentation shows a step by step learning on ESMValTool v2 without any background in v1.
+It is supposed that the user has a installed and working version of the tool in a computer or server, 
+basic background with Python would be useful.
+
+Overview
+========

--- a/doc/sphinx/source/user_guide2/step_by_step_intro.inc
+++ b/doc/sphinx/source/user_guide2/step_by_step_intro.inc
@@ -1,10 +1,226 @@
 
-Introduction to step by step
-============================
+Introduction step by step
+=========================
 
 Currently this documentation shows a step by step learning on ESMValTool v2 without any background in v1.
 It is supposed that the user has a installed and working version of the tool in a computer or server, 
 basic background with Python would be useful.
 
-Overview
-========
+File Structure
+===============
+
+
+├── conda_build_config.yaml
+├── doc
+│   └── sphinx
+│       └── source
+├── docker
+│   ├── Dockerfile
+│   └── docker_guide.md
+├── environment.yml
+├── esmvaltool ---------------------> core folder of the library/tool
+│   ├── cmor
+│   │   ├── check.py
+│   │   ├── _fixes
+│   │   ├── fix.py
+│   │   ├── __init__.py
+│   │   ├── table.py
+│   │   └── tables
+│   ├── config-developer.yml
+│   ├── config-logging.yml
+│   ├── _config.py
+│   ├── config-references.yml
+│   ├── config-user.yml
+│   ├── _data_finder.py
+│   ├── diag_scripts
+│   │   ├── autoassess
+│   │   ├── climate_metrics
+│   │   ├── clouds
+│   │   ├── examples
+│   │   ├── __init__.py
+│   │   ├── ipcc_ar5
+│   │   ├── ocean
+│   │   ├── perfmetrics
+│   │   ├── shared
+│   │   └── validation.py
+│   ├── __init__.py
+│   ├── interface_scripts
+│   │   ├── auxiliary.ncl
+│   │   ├── constants.ncl
+│   │   ├── data_handling.ncl
+│   │   ├── interface.ncl
+│   │   ├── logging.ncl
+│   │   ├── write_header.ncl
+│   │   └── write_references.ncl
+│   ├── _main.py
+│   ├── preprocessor
+│   │   ├── _area_pp.py
+│   │   ├── _derive.py
+│   │   ├── _download.py
+│   │   ├── __init__.py
+│   │   ├── _io.py
+│   │   ├── _mask.py
+│   │   ├── _multimodel.py
+│   │   ├── ne_masks
+│   │   ├── _reformat.py
+│   │   ├── _regrid.py
+│   │   ├── _time_area.py
+│   │   └── _volume_pp.py
+│   ├── _recipe.py
+│   ├── recipes
+│   │   ├── examples
+│   │   ├── recipe_autoassess_landsurface_snow.yml
+│   │   ├── recipe_autoassess_landsurface_surfrad.yml
+│   │   ├── recipe_autoassess_radiation_rms_Amon_all.yml
+│   │   ├── recipe_autoassess_radiation_rms_Amon_obs.yml
+│   │   ├── recipe_autoassess_radiation_rms_cfMon_all.yml
+│   │   ├── recipe_autoassess_stratosphere.yml
+│   │   ├── recipe_clouds_bias.yml
+│   │   ├── recipe_clouds_ipcc.yml
+│   │   ├── recipe_flato13ipcc.yml
+│   │   ├── recipe_lauer13jclim.yml
+│   │   ├── recipe_my_personal_diagnostic.yml
+│   │   ├── recipe_OceanBGC.yml
+│   │   ├── recipe_OceanPhysics.yml
+│   │   ├── recipe_OceanQuadMap.yml
+│   │   ├── recipe_perfmetrics_CMIP5.yml
+│   │   ├── recipe_SeaIceExtent.yml
+│   │   └── recipe_validation.yml
+│   ├── recipe_schema.yml
+│   ├── _task.py
+│   ├── utils
+│   │   ├── batch-jobs
+│   │   ├── editor-enhancements
+│   │   ├── __init__.py
+│   │   ├── nclcodestyle
+│   │   └── xml2yml
+│   └── _version.py
+├── LICENSE
+├── meta.yaml
+├── NOTICE
+├── README.md
+├── readthedocs.yml
+├── RELEASE_NOTES
+├── setup.cfg
+├── setup.py ---------------------------> setup.py for manual installation
+└── tests ------------------------------> testing units to ensure code works
+    ├── __init__.py
+    ├── integration
+    │   ├── cmor
+    │   ├── data_finder.yml
+    │   ├── __init__.py
+    │   ├── preprocessor
+    │   └── test_data_finder.py
+    ├── system
+    │   ├── config-test.yml
+    │   ├── data_simulator.py
+    │   ├── esmvaltool_testlib.py
+    │   ├── __init__.py
+    │   └── test_recipes.py
+    └── unit
+        ├── cmor
+        ├── data_finder
+        ├── __init__.py
+        ├── preprocessor
+        ├── test_lint.py
+        └── test_naming.py
+
+36 directories, 78 files
+
+
+
+**Where to begin** to understand the code? 
+
+By inspecting the setup.py the console entry is done by *esmvaltool._main:run*, so we will explore this
+file to understand how is the step by step from the point of view of the code.
+
+Forgetting the exceptions we get some arguments that are going to main()
+```
+def run():
+    args = get_args()
+    conf = main(args)
+```
+
+And removing the exceptions and logs parts of the code it basically:
+```
+def main(args):
+    """Define the `esmvaltool` program."""
+    recipe = args.recipe
+    if not os.path.exists(recipe):
+        installed_recipe = os.path.join(
+            os.path.dirname(__file__), 'recipes', recipe)
+        if os.path.exists(installed_recipe):
+            recipe = installed_recipe
+    recipe = os.path.abspath(os.path.expandvars(os.path.expanduser(recipe)))
+
+    config_file = os.path.abspath(os.path.expandvars(os.path.expanduser(args.config_file)))
+
+    # Read user config file
+    if not os.path.exists(config_file):
+        print("ERROR: config file {} does not exist".format(config_file))
+
+    recipe_name = os.path.splitext(os.path.basename(recipe))[0]
+    cfg = read_config_user_file(config_file, recipe_name)
+
+    ### Until here we have set up the recipe and read the configuration file
+    ### taking in account that recipe.
+
+    ### Now we begin to process things (logs not mentioned)
+
+    # 1. Create run dir
+    if os.path.exists(cfg['run_dir']):
+        print("ERROR: run_dir {} already exists, aborting to "
+              "prevent data loss".format(cfg['output_dir']))
+    os.makedirs(cfg['run_dir'])
+
+    # 2. Process information related with downloading if necessary
+    cfg['synda_download'] = args.synda_download
+    for limit in ('max_datasets', 'max_years'):
+        value = getattr(args, limit)
+        if value is not None:
+            if value < 1:
+                raise ValueError("--{} should be larger than 0.".format(
+                    limit.replace('_', '-')))
+            cfg[limit] = value
+
+    resource_log = os.path.join(cfg['run_dir'], 'resource_usage.txt')
+
+    # 3. Now it begins the processing of the recipe
+
+    with resource_usage_logger(pid=os.getpid(), filename=resource_log):
+        process_recipe(recipe_file=recipe, config_user=cfg)
+
+    return cfg
+
+```
+
+Nothing heavy has been already done, but now we have to explore the process_recipe function
+but it basically read the recipe file and create a python object (whose class is named recipe)
+that has a method named run so at some point we have to understand **recipe.run()**
+
+The **recipe object** is something relatively complex with several methods with decorators that
+require carefull reading. My understanding indice that this object has the following components:
+
+```
+        """Parse a recipe file into an object."""
+        self._cfg = config_user
+        self._recipe_file = os.path.basename(recipe_file)
+        self._preprocessors = raw_recipe.get('preprocessors', {})
+        if 'default' not in self._preprocessors:
+            self._preprocessors['default'] = {}
+        self._support_ncl = self._need_ncl(raw_recipe['diagnostics'])
+        self.diagnostics = self._initialize_diagnostics(
+            raw_recipe['diagnostics'], raw_recipe.get('datasets', []))
+        self.tasks = self.initialize_tasks() 
+```
+
+So now we understand better what a recipe, or at least what components it has:
+
+1. user configuration [ymal file?]
+2. recipe file        [yaml file?]
+3. preprocessors      [a recipe will have a number of pre-processing steps defined here]
+4. support_ncl        [legacy dependence in ncl or to use ncl?]
+5. diagnostics        [derived information using diagnostics on raw-recipe and datasets]
+6. tasks              [probably all the other aspects are coded in a number of tasks]
+
+

--- a/esmvaltool/_main.py
+++ b/esmvaltool/_main.py
@@ -35,12 +35,18 @@ import logging
 import os
 import shutil
 import sys
+
+if not sys.warnoptions:
+    import warnings
+    warnings.simplefilter("ignore")
+
 from multiprocessing import cpu_count
 
 from . import __version__
 from ._config import configure_logging, read_config_user_file
 from ._recipe import read_recipe_file
 from ._task import resource_usage_logger
+
 
 # set up logging
 logger = logging.getLogger(__name__)

--- a/esmvaltool/_main.py
+++ b/esmvaltool/_main.py
@@ -49,7 +49,14 @@ from ._task import resource_usage_logger
 
 
 # set up logging
+# import coloredlogs -> another option is coloredlogs 
+# which add colors to the logs easily. One it is needed
+# to add a new line:
+# coloredlogs.install(level='DEGUB', logger=logger)
+
 logger = logging.getLogger(__name__)
+
+#coloredlogs.install(level='DEGUB', logger=logger)
 
 HEADER = r"""
 ______________________________________________________________________

--- a/esmvaltool/cmor/tables/custom/CMOR_stratoz.dat
+++ b/esmvaltool/cmor/tables/custom/CMOR_stratoz.dat
@@ -1,0 +1,23 @@
+SOURCE: -----
+!============
+variable_entry:    stratoz 
+!============
+modeling_realm:    atmos
+!----------------------------------
+! Variable attributes:
+!----------------------------------
+standard_name:     equivalent_thickness_at_stp_of_atmosphere_ozone_content
+units:             DU
+cell_methods:      time: mean
+cell_measures:     area: areacella
+long_name:         Total Ozone Column in Stratosphere
+comment:           total ozone column in DU in Stratosphere
+!----------------------------------
+! Additional variable information:
+!----------------------------------
+dimensions:        longitude latitude time
+type:              real
+valid_min:         0.0
+valid_max:         5000.0
+!----------------------------------
+!

--- a/esmvaltool/cmor/tables/custom/CMOR_tropoz.dat
+++ b/esmvaltool/cmor/tables/custom/CMOR_tropoz.dat
@@ -1,0 +1,23 @@
+SOURCE: -----
+!============
+variable_entry:    tropoz 
+!============
+modeling_realm:    atmos
+!----------------------------------
+! Variable attributes:
+!----------------------------------
+standard_name:     equivalent_thickness_at_stp_of_atmosphere_ozone_content
+units:             DU
+cell_methods:      time: mean
+cell_measures:     area: areacella
+long_name:         Total Ozone Column in Troposphere
+comment:           total ozone column in DU in Troposphere
+!----------------------------------
+! Additional variable information:
+!----------------------------------
+dimensions:        longitude latitude time
+type:              real
+valid_min:         0.0
+valid_max:         5000.0
+!----------------------------------
+!

--- a/esmvaltool/diag_scripts/examples/diagnostic.py
+++ b/esmvaltool/diag_scripts/examples/diagnostic.py
@@ -1,4 +1,11 @@
-"""Python example diagnostic."""
+"""Python example diagnostic.
+
+@RCHG: I have added few changes on _plots.py to have additional functionality in
+       this simple recipe. Information is written in recipe_python.xml
+
+"""
+
+
 import logging
 import os
 from pprint import pformat
@@ -33,6 +40,7 @@ def plot_results(cube, filename, cfg):
 
 def main(cfg):
     """Compute the time average for each input dataset."""
+
     # Get a description of the preprocessed data that we will use as input.
     input_data = cfg['input_data'].values()
 

--- a/esmvaltool/diag_scripts/examples/diagnostic.py
+++ b/esmvaltool/diag_scripts/examples/diagnostic.py
@@ -1,7 +1,8 @@
 """Python example diagnostic.
 
-@RCHG: I have added few changes on _plots.py to have additional functionality in
-       this simple recipe. Information is written in recipe_python.xml
+@RCHG: I have added few changes on _plots.py to have additional
+       functionality in this simple recipe. Information is
+       written in recipe_python.xml
 
 """
 

--- a/esmvaltool/diag_scripts/shared/plot/_plot.py
+++ b/esmvaltool/diag_scripts/shared/plot/_plot.py
@@ -118,13 +118,14 @@ def get_dataset_style(dataset, style_file=None):
     return style[dataset]
 
 
-def quickplot(cube, filename, plot_type, **kwargs):
+def quickplot(cube, filename, plot_type, maps=False, **kwargs):
     """Plot a cube using one of the iris.quickplot functions."""
     logger.debug("Creating '%s' plot %s", plot_type, filename)
     plot_function = getattr(iris.quickplot, plot_type)
     fig = plt.figure()
     plot_function(cube, **kwargs)
-    # plt.gca().coastlines()
+    if maps:
+        plt.gca().coastlines() # in general we should be able to tell that it is a map
     fig.savefig(filename)
     plt.close(fig)
 
@@ -282,7 +283,7 @@ def scatterplot(x_data, y_data, filepath, **kwargs):
         if 'markerfacecolor' in plot_kwargs and filepath.endswith('ps'):
             plot_kwargs.pop('markerfacecolor')
 
-        # Plot
+        # Plot 
         axes.plot(x_vals, y_data[idx],
                   **(kwargs.get('plot_kwargs', empty_dict)[idx]))
 

--- a/esmvaltool/diag_scripts/shared/plot/_plot.py
+++ b/esmvaltool/diag_scripts/shared/plot/_plot.py
@@ -125,7 +125,7 @@ def quickplot(cube, filename, plot_type, maps=False, **kwargs):
     fig = plt.figure()
     plot_function(cube, **kwargs)
     if maps:
-        plt.gca().coastlines() # in general we should be able to tell that it is a map
+        plt.gca().coastlines()
     fig.savefig(filename)
     plt.close(fig)
 
@@ -283,7 +283,7 @@ def scatterplot(x_data, y_data, filepath, **kwargs):
         if 'markerfacecolor' in plot_kwargs and filepath.endswith('ps'):
             plot_kwargs.pop('markerfacecolor')
 
-        # Plot 
+        # Plot
         axes.plot(x_vals, y_data[idx],
                   **(kwargs.get('plot_kwargs', empty_dict)[idx]))
 

--- a/esmvaltool/preprocessor/_derive.py
+++ b/esmvaltool/preprocessor/_derive.py
@@ -16,9 +16,9 @@ Avogadro_const = constants.value('Avogadro constant')
 Avogadro_const_unit = constants.unit('Avogadro constant')
 g = 9.81
 g_unit = cf_units.Unit('m s^-2')
-mw_air = 29
+mw_air = 29.0
 mw_air_unit = cf_units.Unit('g mol^-1')
-mw_O3 = 48
+mw_O3 = 48.0
 mw_O3_unit = cf_units.Unit('g mol^-1')
 Dobson_unit = cf_units.Unit('2.69e20 m^-2')
 
@@ -51,7 +51,7 @@ def get_required(short_name, field=None):
         ],
         'tropoz': [
             ('tro3', 'T3' + frequency),
-            ('ps',  'T2' + frequency + 's'),
+            ('ps', 'T2' + frequency + 's'),
             ('ptp', 'T2' + frequency + 's'),
         ],
         'stratoz': [
@@ -260,8 +260,8 @@ def calc_swcre(cubes):
 
 
 def calc_tropoz(cubes):
-    """Compute tropospheric column ozone from ozone mol fraction on
-       pressure levels.
+    """Compute tropospheric column ozone.
+    From ozone mol fraction on pressure levels.
 
     - The surface pressure is used as a lower integration bound.
     - A fixed upper-integration bound of tropopause pressure in Pa is used.
@@ -277,6 +277,7 @@ def calc_tropoz(cubes):
         Cube containing tropospheric column ozone.
 
     """
+
     tro3_cube = cubes.extract_strict(
         Constraint(name='mole_fraction_of_ozone_in_air'))
     ptp_cube = cubes.extract_strict(Constraint(name='tropopause_air_pressure'))
@@ -300,8 +301,8 @@ def calc_tropoz(cubes):
 
 
 def calc_stratoz(cubes):
-    """Compute stratospheric column ozone from ozone mol fraction on 
-       pressure levels.
+    """Compute stratospheric column ozone.
+       From ozone mol fraction on pressure levels.
 
     - The tropopause pressure is used as a lower integration bound.
     - A fixed upper integration bound of 0 Pa is used.
@@ -316,6 +317,7 @@ def calc_stratoz(cubes):
         Cube containing total column ozone.
 
     """
+
     tro3_cube = cubes.extract_strict(
         Constraint(name='mole_fraction_of_ozone_in_air'))
     ptp_cube = cubes.extract_strict(Constraint(name='tropopause_air_pressure'))
@@ -342,10 +344,10 @@ def calc_toz(cubes):
     The surface pressure is used as a lower integration bound. A fixed upper
     integration bound of 0 Pa is used.
 
-    @Ramiro Checa-Garcia: this could be update to calculate also tropospheric
+    @R. Checa-Garcia: this could be update to calculate also tropospheric
     ozone column or stratospheric ozone column. The last one will just took
     the tropopause pressure instead of the surface_air_pressure. I have added
-    two new function named calc_tropoz and calc_straoz, but formally all of them
+    two new function named calc_tropoz and calc_straoz, but formally all
     could be one single function with an extra argument indicating with is the
     desired case.
 
@@ -359,6 +361,7 @@ def calc_toz(cubes):
         Cube containing total column ozone.
 
     """
+
     tro3_cube = cubes.extract_strict(
         Constraint(name='mole_fraction_of_ozone_in_air'))
     ps_cube = cubes.extract_strict(Constraint(name='surface_air_pressure'))

--- a/esmvaltool/preprocessor/_derive.py
+++ b/esmvaltool/preprocessor/_derive.py
@@ -12,6 +12,31 @@ from scipy import constants
 
 logger = logging.getLogger(__name__)
 
+# Possible create object for ctes 
+
+class ctes(object):
+    cname = ''
+    value = ''
+    units = cf_units.Unit('')
+
+    # The class "constructor"
+    def __init__(self, cname, value, units):
+        self.cname = cname
+        self.value = value
+        self.units = units
+
+def make_ctes(cname, value, units):
+    ctes = ctes(cname, value, units)
+    return ctes
+
+# now ---->
+# g_cte = make_ctes('Gravity', 9.81, cf_units.Unit('m s^-2')
+# avo_cte
+# mw_air_cte
+# mw_O3_cte
+# DU_cte = make_ctes('Dobson Unit','1',cf_units.Unit('2.69e20 m^-2')
+
+
 Avogadro_const = constants.value('Avogadro constant')
 Avogadro_const_unit = constants.unit('Avogadro constant')
 g = 9.81
@@ -377,6 +402,10 @@ def calc_toz(cubes):
     toz.units = toz.units / mw_O3_unit * Avogadro_const_unit
     toz.convert_units(Dobson_unit)
     toz.data = np.ma.array(toz.data, dtype=np.dtype('float32'))
+    toz.var_name = 'toz'
+    toz.standard_name= 'equivalent_thickness_at_stp_of_atmosphere_ozone_content'
+    #toz.standard_name='total_ozone_column'
+    toz.long_name='Total Ozone Column'
 
     return toz
 

--- a/esmvaltool/preprocessor/_derive.py
+++ b/esmvaltool/preprocessor/_derive.py
@@ -254,8 +254,12 @@ def calc_toz(cubes):
     The surface pressure is used as a lower integration bound. A fixed upper
     integration bound of 0 Pa is used.
 
+    Ramiro Checa-Garcia: this could be update to calculate also toz or
+    stratospheric ozone column. The last one will just took the tropopause
+    pressure instead of the surface_air_pressure.
+
     Arguments
-    ----
+    ---------
         cubes: cubelist containing tro3_cube (mole_fraction_of_ozone_in_air)
                and ps_cube (surface_air_pressure).
 

--- a/esmvaltool/preprocessor/_derive.py
+++ b/esmvaltool/preprocessor/_derive.py
@@ -51,12 +51,12 @@ def get_required(short_name, field=None):
         ],
         'tropoz': [
             ('tro3', 'T3' + frequency),
-            ('ps',   'T2' + frequency + 's'),
-            ('ptp',  'T2' + frequency + 's'),
+            ('ps',  'T2' + frequency + 's'),
+            ('ptp', 'T2' + frequency + 's'),
         ],
         'stratoz': [
             ('tro3', 'T3' + frequency),
-            ('ptp',  'T2' + frequency + 's'),
+            ('ptp', 'T2' + frequency + 's'),
         ],
         'rtnt': [('rsdt', 'T2' + frequency + 's'),
                  ('rsut', 'T2' + frequency + 's'), ('rlut',
@@ -258,8 +258,10 @@ def calc_swcre(cubes):
 
     return swcre
 
+
 def calc_tropoz(cubes):
-    """Compute tropospheric column ozone from ozone mol fraction on pressure levels.
+    """Compute tropospheric column ozone from ozone mol fraction on
+       pressure levels.
 
     - The surface pressure is used as a lower integration bound.
     - A fixed upper-integration bound of tropopause pressure in Pa is used.
@@ -277,9 +279,9 @@ def calc_tropoz(cubes):
     """
     tro3_cube = cubes.extract_strict(
         Constraint(name='mole_fraction_of_ozone_in_air'))
-    ptp_cube = cubes.extract_strict( Constraint( name='tropopause_air_pressure' ) )
-    ps_cube  = cubes.extract_strict( Constraint( name='surface_air_pressure' ) )
-    p_layer_widths = _pressure_level_widths(tro3_cube, ps_cube, top_limit=ps_cube)
+    ptp_cube = cubes.extract_strict(Constraint(name='tropopause_air_pressure'))
+    ps_cube = cubes.extract_strict(Constraint(name='surface_air_pressure'))
+    p_layer_widths = _pressure_level_widths(tro3_cube, ps_cube, top_limit=ptp_cube)
     # note that here it is needed an update of the function _pressure_level_widths
     tropoz = tro3_cube * p_layer_widths / g * mw_O3 / mw_air
     tropoz = tropoz.collapsed('air_pressure', iris.analysis.SUM)
@@ -296,7 +298,8 @@ def calc_tropoz(cubes):
 
 
 def calc_stratoz(cubes):
-    """Compute stratospheric column ozone from ozone mol fraction on pressure levels.
+    """Compute stratospheric column ozone from ozone mol fraction on 
+       pressure levels.
 
     - The tropopause pressure is used as a lower integration bound.
     - A fixed upper integration bound of 0 Pa is used.

--- a/esmvaltool/preprocessor/_derive.py
+++ b/esmvaltool/preprocessor/_derive.py
@@ -281,11 +281,13 @@ def calc_tropoz(cubes):
         Constraint(name='mole_fraction_of_ozone_in_air'))
     ptp_cube = cubes.extract_strict(Constraint(name='tropopause_air_pressure'))
     ps_cube = cubes.extract_strict(Constraint(name='surface_air_pressure'))
-    p_layer_widths = _pressure_level_widths(tro3_cube, ps_cube, top_limit=ptp_cube)
-    # note that here it is needed an update of the function _pressure_level_widths
+    p_layer_widths = _pressure_level_widths(tro3_cube,
+                                            ps_cube, top_limit=ptp_cube)
+    # note that here it is needed an update of function _pressure_level_widths
     tropoz = tro3_cube * p_layer_widths / g * mw_O3 / mw_air
     tropoz = tropoz.collapsed('air_pressure', iris.analysis.SUM)
-    tropoz.units = (tro3_cube.units * p_layer_widths.units / g_unit * mw_O3_unit /
+    tropoz.units = (tro3_cube.units * p_layer_widths.units /
+                    g_unit * mw_O3_unit /
                     mw_air_unit)
 
     # Convert from kg m^-2 to Dobson unit (2.69e20 m^-2 )
@@ -321,7 +323,8 @@ def calc_stratoz(cubes):
     p_layer_widths = _pressure_level_widths(tro3_cube, ptp_cube, top_limit=0)
     stratoz = tro3_cube * p_layer_widths / g * mw_O3 / mw_air
     stratoz = stratoz.collapsed('air_pressure', iris.analysis.SUM)
-    stratoz.units = (tro3_cube.units * p_layer_widths.units / g_unit * mw_O3_unit /
+    stratoz.units = (tro3_cube.units * p_layer_widths.units /
+                 g_unit * mw_O3_unit /
                  mw_air_unit)
 
     # Convert from kg m^-2 to Dobson unit (2.69e20 m^-2 )
@@ -774,7 +777,7 @@ def _create_pressure_array(tro3_cube, ps_cube, top_limit):
     pressure_4d = np.where((ps_4d_array - p_4d_array) < 0, np.NaN, p_4d_array)
 
     # make top_limit last pressure level
-    # formally using broadcasing top_limit might be a cube like ps_cube, no problem 
+    # formally using broadcasing top_limit might be a cube like ps_cube?
     top_limit_array = np.ones(ps_cube.shape) * top_limit
     data = top_limit_array[:, np.newaxis, :, :]
     pressure_4d = np.concatenate((pressure_4d, data), axis=1)

--- a/esmvaltool/preprocessor/_io.py
+++ b/esmvaltool/preprocessor/_io.py
@@ -60,8 +60,9 @@ def load_cubes(files, filename, metadata, constraints=None, callback=None):
         cube.attributes['metadata'] = yaml.safe_dump(metadata)
         # TODO add block below when using iris 2.0
         # always set fillvalue to 1e+20
-        # if np.ma.is_masked(cube.data):
-        #     np.ma.set_fill_value(cube.data, GLOBAL_FILL_VALUE)
+        if int(iris.__version__.split('.')[0])>=2:
+           if np.ma.is_masked(cube.data):
+              np.ma.set_fill_value(cube.data, GLOBAL_FILL_VALUE)
 
     return cubes
 

--- a/esmvaltool/preprocessor/_io.py
+++ b/esmvaltool/preprocessor/_io.py
@@ -61,7 +61,7 @@ def load_cubes(files, filename, metadata, constraints=None, callback=None):
         cube.attributes['metadata'] = yaml.safe_dump(metadata)
         # TODO add block below when using iris 2.0
         # always set fillvalue to 1e+20
-        if int(iris.__version__.split('.')[0])>=2:
+        if int(iris.__version__.split('.')[0]) >= 2:
            if np.ma.is_masked(cube.data):
               np.ma.set_fill_value(cube.data, GLOBAL_FILL_VALUE)
 

--- a/esmvaltool/preprocessor/_io.py
+++ b/esmvaltool/preprocessor/_io.py
@@ -6,6 +6,7 @@ from itertools import groupby
 
 import iris
 import iris.exceptions
+import numpy as np       # needed by iris v2 in load.cubes
 import yaml
 
 from .._task import write_ncl_settings

--- a/esmvaltool/preprocessor/_mask.py
+++ b/esmvaltool/preprocessor/_mask.py
@@ -2,7 +2,7 @@
 _mask.py
 
 module that performs missing values masking
-and geographical area eslection
+and geographical area selection
 """
 
 from __future__ import print_function

--- a/esmvaltool/preprocessor/_multimodel.py
+++ b/esmvaltool/preprocessor/_multimodel.py
@@ -1,4 +1,4 @@
-"""Multimodel statistics
+"""Multimodel statistics/.
 
 Functions for multi-model operations
 supports a multitude of multimodel statistics
@@ -6,17 +6,17 @@ computations; the only requisite is the ingested
 cubes have (TIME-LAT-LON) or (TIME-PLEV-LAT-LON)
 dimensions; and obviously consistent units.
 
-In general the orginal approach would limit the 
-applicability if any dataset is for example given 
-as zonal mean. An example could be the 
-Meinhaousen et al, 2017 CMIP6 well mixed 
-greenhouse gases forcings. So I tried to refactor 
+@RCHG: In general the original approach would limit the
+applicability if any dataset is for example given
+as zonal mean. An example could be the
+Meinhausen et al, 2017 CMIP6 well mixed
+greenhouse gases forcings. So I will try to refactor
 this module.
 
 Terminology:
 
 cspec -> coordinates specs for cube
-dspec -> 
+dspec -> ?
 
 It operates on different (time) spans:
 - full: computes stats on full dataset time;
@@ -77,6 +77,8 @@ def _compute_statistic(datas, name):
         statistic_function = np.ma.median
     elif name == 'mean':
         statistic_function = np.ma.mean
+
+    # Added other possible statistics useful on comparisons
     elif name == 'range':
         statistic_function = np.ma.ptp
     elif name == 'maximum':
@@ -123,9 +125,14 @@ def _compute_statistic(datas, name):
 
 def _put_in_cube(template_cube, cube_data, stat_name,
                  file_name, time_bounds, t_axis):
-    """Quick cube building and saving. 
-    Currently this limites the possibilies of 
+    """Quick cube building and saving.
+    Currently this limites the possibilies of
     this multimodel methods.
+
+    @RCHG: Own note that it is possible to have cases with
+    cspec = [(times, 0), (lats, 1)]
+    the idea of use len(template_cube.shape)
+    might be fail on those cases??
     """
     # grab coordinates from any cube
     times = template_cube.coord('time')
@@ -152,6 +159,9 @@ def _put_in_cube(template_cube, cube_data, stat_name,
         # might as well have depth here too.
         plev = template_cube.coord('depth')
         cspec = [(times, 0), (plev, 1), ]
+
+
+
 
     # correct dspec if necessary
     fixed_dspec = np.ma.fix_invalid(cube_data, copy=False, fill_value=1e+20)

--- a/esmvaltool/preprocessor/_multimodel.py
+++ b/esmvaltool/preprocessor/_multimodel.py
@@ -77,13 +77,13 @@ def _compute_statistic(datas, name):
         statistic_function = np.ma.median
     elif name == 'mean':
         statistic_function = np.ma.mean
-    elif name == 'range'
+    elif name == 'range':
         statistic_function = np.ma.ptp
-    elif name == 'maximum'
+    elif name == 'maximum':
         statistic_function = np.ma.max
-    elif name == 'minimum'
+    elif name == 'minimum':
         statistic_function = np.ma.min
-    elif name == 'anomalies'
+    elif name == 'anomalies':
         statistic_function = np.ma.anom
     else:
         raise NotImplementedError

--- a/esmvaltool/preprocessor/_multimodel.py
+++ b/esmvaltool/preprocessor/_multimodel.py
@@ -197,7 +197,7 @@ def _datetime_to_int_days(cube):
     # TODO replace the block when using iris 2.0
     # time_cells = [cell.point for cell in cube.coord('time').cells()]
     if int(iris.__version__.split('.')[0]) >= 2:
-       time_cells = [cell.point for cell in cube.coord('time').cells()]
+        time_cells = [cell.point for cell in cube.coord('time').cells()]
     else:
         time_cells = [cube.coord('time').units.num2date(cell.point)
                       for cell in cube.coord('time').cells()]

--- a/esmvaltool/preprocessor/_multimodel.py
+++ b/esmvaltool/preprocessor/_multimodel.py
@@ -78,14 +78,13 @@ def _compute_statistic(datas, name):
     elif name == 'mean':
         statistic_function = np.ma.mean
     elif name == 'range'
-        statistic_function = np.ma.mean    
+        statistic_function = np.ma.ptp  
     elif name == 'maximum'
         statistic_function = np.ma.max
     elif name == 'minimum'
         statistic_function = np.ma.min
-    elif name == 'coef_variation'
-        statistic_function = np.ma.cef
-    
+    elif name == 'anomalies'
+        statistic_function = np.ma.anom
     else:
         raise NotImplementedError
 

--- a/esmvaltool/preprocessor/_multimodel.py
+++ b/esmvaltool/preprocessor/_multimodel.py
@@ -1,10 +1,22 @@
-"""multimodel statistics
+"""Multimodel statistics
 
 Functions for multi-model operations
 supports a multitude of multimodel statistics
 computations; the only requisite is the ingested
 cubes have (TIME-LAT-LON) or (TIME-PLEV-LAT-LON)
 dimensions; and obviously consistent units.
+
+In general the orginal approach would limit the 
+applicability if any dataset is for example given 
+as zonal mean. An example could be the 
+Meinhaousen et al, 2017 CMIP6 well mixed 
+greenhouse gases forcings. So I tried to refactor 
+this module.
+
+Terminology:
+
+cspec -> coordinates specs for cube
+dspec -> 
 
 It operates on different (time) spans:
 - full: computes stats on full dataset time;
@@ -65,6 +77,15 @@ def _compute_statistic(datas, name):
         statistic_function = np.ma.median
     elif name == 'mean':
         statistic_function = np.ma.mean
+    elif name == 'range'
+        statistic_function = np.ma.mean    
+    elif name == 'maximum'
+        statistic_function = np.ma.max
+    elif name == 'minimum'
+        statistic_function = np.ma.min
+    elif name == 'coef_variation'
+        statistic_function = np.ma.cef
+    
     else:
         raise NotImplementedError
 
@@ -103,7 +124,10 @@ def _compute_statistic(datas, name):
 
 def _put_in_cube(template_cube, cube_data, stat_name,
                  file_name, time_bounds, t_axis):
-    """Quick cube building and saving"""
+    """Quick cube building and saving. 
+    Currently this limites the possibilies of 
+    this multimodel methods.
+    """
     # grab coordinates from any cube
     times = template_cube.coord('time')
     # or get the FULL time axis

--- a/esmvaltool/preprocessor/_multimodel.py
+++ b/esmvaltool/preprocessor/_multimodel.py
@@ -78,7 +78,7 @@ def _compute_statistic(datas, name):
     elif name == 'mean':
         statistic_function = np.ma.mean
     elif name == 'range'
-        statistic_function = np.ma.ptp  
+        statistic_function = np.ma.ptp
     elif name == 'maximum'
         statistic_function = np.ma.max
     elif name == 'minimum'

--- a/esmvaltool/preprocessor/_multimodel.py
+++ b/esmvaltool/preprocessor/_multimodel.py
@@ -196,8 +196,11 @@ def _datetime_to_int_days(cube):
     """Return list of int(days) converted from cube datetime cells"""
     # TODO replace the block when using iris 2.0
     # time_cells = [cell.point for cell in cube.coord('time').cells()]
-    time_cells = [cube.coord('time').units.num2date(cell.point)
-                  for cell in cube.coord('time').cells()]
+    if int(iris.__version__.split('.')[0]) >= 2:
+       time_cells = [cell.point for cell in cube.coord('time').cells()]
+    else:
+        time_cells = [cube.coord('time').units.num2date(cell.point)
+                      for cell in cube.coord('time').cells()]
     time_unit = cube.coord('time').units.name
     time_offset = _get_time_offset(time_unit)
 

--- a/esmvaltool/preprocessor/_multimodel.py
+++ b/esmvaltool/preprocessor/_multimodel.py
@@ -85,8 +85,8 @@ def _compute_statistic(datas, name):
         statistic_function = np.ma.max
     elif name == 'minimum':
         statistic_function = np.ma.min
-    elif name == 'anomalies':
-        statistic_function = np.ma.anom
+    #elif name == 'anomalies':
+    #    statistic_function = np.ma.anom
     else:
         raise NotImplementedError
 

--- a/esmvaltool/preprocessor/_time_area.py
+++ b/esmvaltool/preprocessor/_time_area.py
@@ -23,6 +23,7 @@ def time_slice(mycube, start_year, start_month, start_day,
 
     Returns a cube
     """
+    from iris.time import PartialDateTime
     import datetime
     time_units = mycube.coord('time').units
     if time_units.calendar == '360_day':
@@ -39,8 +40,14 @@ def time_slice(mycube, start_year, start_month, start_day,
     # TODO replace the block below for when using iris 2.0
     # my_constraint = iris.Constraint(time=lambda t: (
     #     t_1 < time_units.date2num(t.point) < t_2))
-    my_constraint = iris.Constraint(time=lambda t: (
-        t_1 < t.point < t_2))
+    if int(iris.__version__.split('.')[0])>= 2:
+        my_constraint = iris.Constraint(time=lambda t: (
+        start_date
+        < PartialDateTime(year=t.point.year, month=t.point.month, day=t.point.day) <
+        end_date ))
+    else:
+        my_constraint = iris.Constraint(time=lambda t: (
+                        t_1 < t.point < t_2))
     cube_slice = mycube.extract(my_constraint)
     return cube_slice
 

--- a/esmvaltool/preprocessor/_time_area.py
+++ b/esmvaltool/preprocessor/_time_area.py
@@ -40,11 +40,13 @@ def time_slice(mycube, start_year, start_month, start_day,
     # TODO replace the block below for when using iris 2.0
     # my_constraint = iris.Constraint(time=lambda t: (
     #     t_1 < time_units.date2num(t.point) < t_2))
-    if int(iris.__version__.split('.')[0])>= 2:
+    if int(iris.__version__.split('.')[0]) >= 2:
         my_constraint = iris.Constraint(time=lambda t: (
-        start_date
-        < PartialDateTime(year=t.point.year, month=t.point.month, day=t.point.day) <
-        end_date ))
+          start_date
+          < PartialDateTime(year=t.point.year,
+                            month=t.point.month,
+                            day=t.point.day)
+          < end_date))
     else:
         my_constraint = iris.Constraint(time=lambda t: (
                         t_1 < t.point < t_2))

--- a/esmvaltool/preprocessor/_time_area.py
+++ b/esmvaltool/preprocessor/_time_area.py
@@ -4,6 +4,7 @@ Time operations on cubes
 Allows for selecting data subsets using certain time bounds;
 constructing seasonal and area averages.
 """
+
 import iris
 import iris.coord_categorisation
 import numpy as np
@@ -138,6 +139,8 @@ def seasonal_mean(cube):
     iris.cube.Cube
         Seasonal mean cube
     """
+    import datetime
+    #print(cube)
     if not cube.coords('clim_season'):
         iris.coord_categorisation.add_season(cube, 'time', name='clim_season')
     if not cube.coords('season_year'):
@@ -146,10 +149,17 @@ def seasonal_mean(cube):
     annual_seasonal_mean = cube.aggregated_by(['clim_season', 'season_year'],
                                               iris.analysis.MEAN)
 
+    #print(annual_seasonal_mean)
+
     # TODO: This preprocessor is not calendar independent.
+
+    dt_3months = datetime.timedelta(hours=24*3*28)
+
     def spans_three_months(time):
         """Check for three months"""
-        return (time.bound[1] - time.bound[0]) == 2160
+        return (time.bound[1] - time.bound[0]) > dt_3months
 
     three_months_bound = iris.Constraint(time=spans_three_months)
+    #print(three_months_bound)
+    #print(annual_seasonal_mean.extract(three_months_bound))
     return annual_seasonal_mean.extract(three_months_bound)

--- a/esmvaltool/preprocessor/_time_area.py
+++ b/esmvaltool/preprocessor/_time_area.py
@@ -113,14 +113,6 @@ def time_average(cube):
                           weights=time_weights)
 
 
-# get the seasonal mean
-def seasonal_data(cube):
-    '''
-    In this case the idea would be return a dataset where the time-coord is season.
-    '''
-    
-    return season_cube
-
 def seasonal_mean(cube):
     """
     Function to compute seasonal means with MEAN

--- a/esmvaltool/preprocessor/_time_area.py
+++ b/esmvaltool/preprocessor/_time_area.py
@@ -76,8 +76,8 @@ def extract_month(mycube, month):
     month: int
         Month to extract as a number from 1 to 12
     """
-    season_cube = mycube.extract(iris.Constraint(month_number=month))
-    return season_cube
+    month_cube = mycube.extract(iris.Constraint(month_number=month))
+    return month_cube
 
 
 # get the time average
@@ -114,6 +114,13 @@ def time_average(cube):
 
 
 # get the seasonal mean
+def seasonal_data(cube):
+    '''
+    In this case the idea would be return a dataset where the time-coord is season.
+    '''
+    
+    return season_cube
+
 def seasonal_mean(cube):
     """
     Function to compute seasonal means with MEAN

--- a/esmvaltool/preprocessor/_volume_pp.py
+++ b/esmvaltool/preprocessor/_volume_pp.py
@@ -84,9 +84,6 @@ def _create_cube_time(src_cube, data, times):
         scalar vertical coordinate will be added.
 
     """
-    print(src_cube.coords)
-    print(len(data))
-    print(times)
     # Get the source cube vertical coordinate and associated dimension.
     src_times = src_cube.coord('time')
     t_dim, = src_cube.coord_dims(src_times)

--- a/esmvaltool/recipes/examples/recipe_preprocessor_derive_test.yml
+++ b/esmvaltool/recipes/examples/recipe_preprocessor_derive_test.yml
@@ -3,26 +3,88 @@
 datasets:
 #  - {dataset: CESM1-WACCM,    project: CMIP5, mip: Amon, exp: historical, ensemble: r2i1p1, start_year: 1997, end_year: 2005}
 #  - {dataset: CNRM-CM5,       project: CMIP5, mip: Amon, exp: historical, ensemble: r1i1p1, start_year: 1997, end_year: 2005}
-  - {dataset: GFDL-CM3,       project: CMIP5, mip: Amon, exp: historical, ensemble: r1i1p1, start_year: 1997, end_year: 2005}
-  - {dataset: GISS-E2-H,      project: CMIP5, mip: Amon, exp: historical, ensemble: r1i1p2, start_year: 1997, end_year: 2005}
-  - {dataset: GISS-E2-R,      project: CMIP5, mip: Amon, exp: historical, ensemble: r1i1p2, start_year: 1997, end_year: 2005}
+  - {dataset: GFDL-CM3,       project: CMIP5, mip: Amon, exp: historical, ensemble: r1i1p1, start_year: 1955, end_year: 1959}
+#  - {dataset: GISS-E2-H,      project: CMIP5, mip: Amon, exp: historical, ensemble: r1i1p2, start_year: 1997, end_year: 2005}
+#  - {dataset: GISS-E2-R,      project: CMIP5, mip: Amon, exp: historical, ensemble: r1i1p2, start_year: 1997, end_year: 2005}
 #   - {dataset: MIROC-ESM-CHEM, project: CMIP5, mip: Amon, exp: historical, ensemble: r1i1p1, start_year: 1997, end_year: 2005}
-  - {dataset: ESACCI-OZONE,   project: OBS,   tier: 2,   type: sat,       version: L3,      start_year: 1997, end_year: 2005}
-#   - {dataset: NIWA,           project: OBS,   tier: 3,   type: reanaly,   version: 1,       start_year: 1997, end_year: 2005}
+#  - {dataset: ESACCI-OZONE,   project: OBS,   tier: 2,   type: sat,       version: L3,      start_year: 1997, end_year: 2005}
 
 preprocessors:
 
-  preprocessor: {}
- 
+   # preprocessor: {} -- 'if not preprocessor is used'
+   prep_season_DJF:
+     extract_season: 
+       season: DJF
+   prep_season_MAM:
+     extract_season: 
+       season: MAM 
+   prep_season_JJA:
+     extract_season: 
+       season: JJA 
+   prep_season_SON:
+     extract_season: 
+       season: SON 
+
 diagnostics:
 
-  derive_diagnostic:
+  derive_diagnostic_DJF:
     description: Test variable derivation
     variables:
       toz:
-        preprocessor: preprocessor
+        preprocessor: prep_season_DJF
         field: T2Ms
         derive: true
         force_derivation: false
     additional_datasets: []
-    scripts: null
+    scripts:
+    # scripts: null -- 'if no scripts is used'
+      script1: &test_plot
+        script: examples/diagnostic.py
+        quickplot:
+          plot_type: contourf
+          maps: True
+          cmap: Spectral
+
+  derive_diagnostic_MAM:
+    description: Test variable derivation
+    variables:
+      toz:
+        preprocessor: prep_season_MAM
+        field: T2Ms
+        derive: true
+        force_derivation: false
+    additional_datasets: []
+    scripts:
+      script1:
+        <<: *test_plot
+
+  derive_diagnostic_JJA:
+    description: Test variable derivation season JJA
+    variables:
+      toz:
+        preprocessor: prep_season_JJA
+        field: T2Ms
+        derive: true
+        force_derivation: false
+    additional_datasets: []
+    scripts:
+      script1:
+        <<: *test_plot
+
+  derive_diagnostic_SON:
+    description: Test variable derivation
+    variables:
+      toz:
+        preprocessor: prep_season_SON
+        field: T2Ms
+        derive: true
+        force_derivation: false
+    additional_datasets: []
+    scripts:
+      script1:
+        <<: *test_plot
+
+
+
+
+

--- a/esmvaltool/recipes/examples/recipe_preprocessor_derive_test_seasons.yml
+++ b/esmvaltool/recipes/examples/recipe_preprocessor_derive_test_seasons.yml
@@ -1,0 +1,42 @@
+---
+
+datasets:
+#  - {dataset: CESM1-WACCM,    project: CMIP5, mip: Amon, exp: historical, ensemble: r2i1p1, start_year: 1997, end_year: 2005}
+#  - {dataset: CNRM-CM5,       project: CMIP5, mip: Amon, exp: historical, ensemble: r1i1p1, start_year: 1997, end_year: 2005}
+  - {dataset: GFDL-CM3,       project: CMIP5, mip: Amon, exp: historical, ensemble: r1i1p1, start_year: 1955, end_year: 1959}
+#  - {dataset: GISS-E2-H,      project: CMIP5, mip: Amon, exp: historical, ensemble: r1i1p2, start_year: 1997, end_year: 2005}
+#  - {dataset: GISS-E2-R,      project: CMIP5, mip: Amon, exp: historical, ensemble: r1i1p2, start_year: 1997, end_year: 2005}
+#   - {dataset: MIROC-ESM-CHEM, project: CMIP5, mip: Amon, exp: historical, ensemble: r1i1p1, start_year: 1997, end_year: 2005}
+#  - {dataset: ESACCI-OZONE,   project: OBS,   tier: 2,   type: sat,       version: L3,      start_year: 1997, end_year: 2005}
+#   - {dataset: NIWA,           project: OBS,   tier: 3,   type: reanaly,   version: 1,       start_year: 1997, end_year: 2005}
+
+preprocessors:
+
+   # preprocessor: {} -- 'if not preprocessor is used'
+   prep_season_mean:
+     seasonal_mean: 
+diagnostics:
+
+  derive_diagnostic_seasons:
+    description: Test variable derivation
+    variables:
+      toz:
+        preprocessor: prep_season_mean
+        field: T2Ms
+        derive: true
+        force_derivation: false
+    additional_datasets: []
+    scripts:
+    # scripts: null -- 'if no scripts is used'
+      script1: &test_plot
+        script: examples/diagnostic.py
+        quickplot:
+          plot_type: contourf
+          maps: True
+          cmap: Spectral
+
+
+
+
+
+

--- a/esmvaltool/recipes/examples/recipe_python.yml
+++ b/esmvaltool/recipes/examples/recipe_python.yml
@@ -3,20 +3,26 @@
 # @RCHG: Example modified to show more properties and made it more flexible. This means to change quickplot on shared
 #        for example.
 #        *Datasets* can be downloaded on CEDA for example. Loading of files is working fine but this recipe needed
-#        changes on the main code to be able to work with Iris v2. I have added a if on preprocessors to detect which
+#        changes on the main code to be able to work with Iris v2. I have added an if on preprocessors to detect which
 #        Iris version is installed.
 #
 #        It has been added also a new keyword to quickplot in esmvaltool/diag_scripts/shared/plot/_plot.py
 #        def quickplot(cube, filename, plot_type, maps=False, **kwargs):
-#        now bydefault is maps=True it will plot the coastlines. Also the example now shows how to add kwargs to 
-#        the iris quickplot by including them explicitaly the example. 
+#        now by default is maps=True it will plot the coastlines. Also the example now shows how to add kwargs to 
+#        the iris quickplot by including them explicitly the example. 
 #
 #        (Ramiro Checa-Garcia LSCE-IPSL rcheca@lsce.ipsl.fr)
 
+#datasets:
+#  - {dataset: bcc-csm1-1,  project: CMIP5,  mip: Amon,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
+#  - {dataset: GFDL-ESM2G,  project: CMIP5,  mip: Amon,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
+#  - {dataset: MPI-ESM-LR,  project: CMIP5,  mip: Amon,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
+
+# An alternative equivalent specification of the datasets less verbose will be:
 datasets:
-  - {dataset: bcc-csm1-1,  project: CMIP5,  mip: Amon,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
-  - {dataset: GFDL-ESM2G,  project: CMIP5,  mip: Amon,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
-  - {dataset: MPI-ESM-LR,  project: CMIP5,  mip: Amon,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
+  - &default {dataset: bcc-csm1-1,  project: CMIP5,  mip: Amon,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
+  - {<<: *default , dataset: GFDL-ESM2G}
+  - {<<: *default , dataset: MPI-ESM-LR}
 
 
 preprocessors:
@@ -30,10 +36,10 @@ preprocessors:
       scheme: linear
     multi_model_statistics:
       span: overlap
-      statistics: [mean, median]
-
+      statistics: [mean, median, maximum, minimum, range]
+      # in this case new multimodel preprocesors has been added that could be useful: maximum, minimun, range all tested
 diagnostics:
-
+  # note that here we defined one diagnostic 
   diagnostic1:
     description: Air temperature and precipitation Python tutorial diagnostic.
     variables:
@@ -51,5 +57,4 @@ diagnostics:
           plot_type: contourf
           maps: True
           cmap: Spectral
-
 

--- a/esmvaltool/recipes/examples/recipe_python.yml
+++ b/esmvaltool/recipes/examples/recipe_python.yml
@@ -1,9 +1,23 @@
 ---
 
+# @RCHG: Example modified to show more properties and made it more flexible. This means to change quickplot on shared
+#        for example.
+#        *Datasets* can be downloaded on CEDA for example. Loading of files is working fine but this recipe needed
+#        changes on the main code to be able to work with Iris v2. I have added a if on preprocessors to detect which
+#        Iris version is installed.
+#
+#        It has been added also a new keyword to quickplot in esmvaltool/diag_scripts/shared/plot/_plot.py
+#        def quickplot(cube, filename, plot_type, maps=False, **kwargs):
+#        now bydefault is maps=True it will plot the coastlines. Also the example now shows how to add kwargs to 
+#        the iris quickplot by including them explicitaly the example. 
+#
+#        (Ramiro Checa-Garcia LSCE-IPSL rcheca@lsce.ipsl.fr)
+
 datasets:
   - {dataset: bcc-csm1-1,  project: CMIP5,  mip: Amon,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
   - {dataset: GFDL-ESM2G,  project: CMIP5,  mip: Amon,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
   - {dataset: MPI-ESM-LR,  project: CMIP5,  mip: Amon,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
+
 
 preprocessors:
 
@@ -34,4 +48,8 @@ diagnostics:
       script1:
         script: examples/diagnostic.py
         quickplot:
-          plot_type: pcolormesh
+          plot_type: contourf
+          maps: True
+          cmap: Spectral
+
+

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,13 @@ REQUIREMENTS = {
         'stratify',
         'vmprof',
         'yamale',
+        # options added by RCHG, it is possible that some of these dependencies are 
+        # included as derived of the previous ones
+        'xarray',
+        'seaborn',
+        'pandas',
+        'regionmask',
+        'scipy',
     ],
     # Test dependencies
     # Execute 'python setup.py test' to run tests

--- a/setup.py
+++ b/setup.py
@@ -46,13 +46,6 @@ REQUIREMENTS = {
         'stratify',
         'vmprof',
         'yamale',
-        # options added by RCHG, it is possible that some of these dependencies are 
-        # included as derived of the previous ones
-        'xarray',
-        'seaborn',
-        'pandas',
-        'regionmask',
-        'scipy',
     ],
     # Test dependencies
     # Execute 'python setup.py test' to run tests


### PR DESCRIPTION
Hi all,

This is my first commit ever, so I don't know if I have done it correctly. My aim is just to pull a request about _derive.py (although other commits are in the pull and I don't know how to remove them. Sorry about it).

So, I have added two calculations to _derive.py that might be useful:

- **calc_stratoz(cubes)**: needs ptp (pressure_air_tropopause) rather than ps (surface_air_pressure) but formally it is identical.
                                     
- **calc_tropoz(cubes)**: needs both ptp and ps but again formally it is very similar. Just instead of top_limit it needs the ptp cube.

_Note 1_: that the functions **calc_tropoz(cubes)**, **calc_stratoz(cubes)**, and **calc_toz** can be unified in one function if an extra argument if added.

_Note 2_: that **_create_pressure_array** could be extended to include not top_limit as a single value but also a cube equivalent to ps.  The same applies to **_pressure_level_widths**, which also I think formally is not necessary attached to tro3_cube but any cube that is given in pressure levels.

_Note 3_: I did not test these new functions, and errors are runtime are expected. But the new functions seems to be quite straight forward to implement. 


Beyond that I added an if to test if Iris is version 1 or version 2 on 
**_multimodel.py**
**_time_area.py**
otherwise the user has to change the code to run a diagnostic with Iris 2 installed.

Kind regards,
Ramiro Checa-Garcia (LSCE-IPSL).
