### PR TITLE
Pin matplotlib

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - iris=1.13
   - python-stratify
   # Multi language support:
-  - ncl
+  - ncl>6.5.0
   - ncurses=6.1=hfc679d8_1
   # TODO: add R, julia
 

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - iris=1.13
   - python-stratify
   # Multi language support:
-  - ncl>6.5.0
+  - ncl<6.5.0
   - ncurses=6.1=hfc679d8_1
   # TODO: add R, julia
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - cartopy
     - cf_units
     - cython
-    - matplotlib
+    - matplotlib<3.0.0
     - netCDF4
     - numba
     - numpy
@@ -52,7 +52,7 @@ requirements:
     - six
     - yamale  # in birdhouse channel
     # Multi language support:
-    - ncl
+    - ncl<6.5.0
     - ncurses=6.1=hfc679d8_1
     # TODO: add R, julia
 test:

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ REQUIREMENTS = {
         'cf_units',
         'cython',
         # 'scitools-iris',  # Only iris 2 is on PyPI
-        'matplotlib',
+        'matplotlib<3.0.0',
         'netCDF4',
         'numba',
         'numpy',


### PR DESCRIPTION
As discussed in #637 this keeps the version of matplotlib below 3.0.0 and ncl below 6.5.0.

Merging this will also temporary fix the problems discussed in #610 
