### PR TITLE
removed the fill value setting at load point and no more realising data

### DIFF
--- a/esmvaltool/preprocessor/_io.py
+++ b/esmvaltool/preprocessor/_io.py
@@ -60,10 +60,6 @@ def load_cubes(files, filename, metadata, constraints=None, callback=None):
     for cube in cubes:
         cube.attributes['_filename'] = filename
         cube.attributes['metadata'] = yaml.safe_dump(metadata)
-        if not use_legacy_iris():
-            # always set fillvalue to 1e+20
-            if np.ma.is_masked(cube.data):
-                np.ma.set_fill_value(cube.data, GLOBAL_FILL_VALUE)
 
     return cubes
 


### PR DESCRIPTION
The latest iris 2.2.0 documentation says this: https://scitools.org.uk/iris/docs/latest/whitepapers/missing_data_handling.html so this means that if we load a file with a set fill_value = 1e+20 (like is the case of all normal CMOR-compliant netCDF data files) iris will not go about and change that on its own at load point, it will preserve it; a possible alteration of fill_value can only occur at save point (when not specifying the fill_value=1e20 **arg) but that is handled correctly at line 180 in `_io.py` (I have tested with iris 2.1 and 2.2 and saved intermediary cubes to file, all good, and the final preproc'd file has 1e20 for fill_value). The only problem would occuer when we use some crazy file that has a fill_value = some banana shit, but isn't that part of the CMOR check @jvegasbsc ?