### PR TITLE
Allow more complex variable derivation

### DIFF
--- a/esmvaltool/_recipe.py
+++ b/esmvaltool/_recipe.py
@@ -376,8 +376,8 @@ def _dataset_to_file(variable, config_user):
         drs=config_user['drs'])
     if not files and variable.get('derive'):
         variable = copy.deepcopy(variable)
-        variable['short_name'], variable['field'] = get_required(
-            variable['short_name'], variable['field'])['vars'][0]
+        required_var = get_required(variable['short_name'], variable['field'])
+        variable.update(required_var['vars'][0])
         files = get_input_filelist(
             variable=variable,
             rootpath=config_user['rootpath'],
@@ -768,13 +768,13 @@ def _get_preprocessor_task(variables,
                 derive_input[short_name].append(variable)
             else:
                 # Process input data needed to derive variable
-                for short_name, field in get_required(
+                for new_variable in get_required(
                         variable['short_name'], variable['field'])['vars']:
+                    short_name = new_variable['short_name']
                     if short_name not in derive_input:
                         derive_input[short_name] = []
                     variable = copy.deepcopy(variable)
-                    variable['short_name'] = short_name
-                    variable['field'] = field
+                    variable.update(new_variable)
                     variable['filename'] = get_output_file(
                         variable, config_user['preproc_dir'])
                     _add_cmor_info(variable, override=True)

--- a/esmvaltool/preprocessor/_derive/__init__.py
+++ b/esmvaltool/preprocessor/_derive/__init__.py
@@ -18,8 +18,8 @@ ALL_DERIVED_VARIABLES = {}
 def get_required(short_name, field=None):
     """Return all required variables for derivation.
 
-    Get variable `short_name` and `field` pairs required for derivation
-    and optionally a list of needed fx files.
+    Get all information (at least `short_name`) required for derivation and
+    optionally a list of needed fx files.
 
     Parameters
     ----------
@@ -31,8 +31,9 @@ def get_required(short_name, field=None):
     Returns
     -------
     dict
-        Dictionary containing a list of tuples `(short_name, field)` with the
-        `vars` key and optionally a list of fx files with the key `fx_files`.
+        Dictionary containing a :obj:`list` of dictionaries (including at least
+        the key `short_name`) with the key `vars` and optionally a :obj:`list`
+        of fx variables with the key `fx_files`.
 
     """
     frequency = field[2] if field else 'M'

--- a/esmvaltool/preprocessor/_derive/_derived_variable_base.py
+++ b/esmvaltool/preprocessor/_derive/_derived_variable_base.py
@@ -1,6 +1,7 @@
 """Contains the base class for derived variables."""
 
 
+import copy
 import importlib
 import logging
 
@@ -21,8 +22,8 @@ class DerivedVariableBase(object):
     def get_required(self, frequency):
         """Return all required variables for derivation.
 
-        Get variable `short_name` and `field` pairs required for derivation
-        and optionally a list of needed fx files from the static class member
+        Get all information (at least `short_name`) required for derivation and
+        optionally a list of needed fx files from the static class member
         _required_variables (may include '{frequency}' keyword in the `field`
         string for dynamic frequency adaption).
 
@@ -34,9 +35,9 @@ class DerivedVariableBase(object):
         Returns
         -------
         dict
-            Dictionary containing a list of tuples `(short_name, field)` with
-            the `vars` key and optionally a list of fx files with the key
-            `fx_files`.
+            Dictionary containing a :obj:`list` of dictionaries (including at
+            least the key `short_name`) with the key `vars` and optionally a
+            :obj:`list` of fx variables with the key `fx_files`.
 
         Raises
         ------
@@ -45,20 +46,24 @@ class DerivedVariableBase(object):
             required variables are declared.
 
         """
-        required_variables = dict(self.__class__._required_variables)
+        required_variables = copy.deepcopy(self.__class__._required_variables)
         if not required_variables:
             raise NotImplementedError("Don't know how to derive variable "
                                       "'{}'".format(self.short_name))
         if 'vars' not in required_variables:
             raise NotImplementedError(
-                "Don't know how to derive variable '{}', all required "
+                "Don't know how to derive variable '{}': all required "
                 "variables have to be specified in the 'vars' key of the "
                 "_required_variables dictionary (derivation from fx files "
                 "only is not supported yet)".format(self.short_name))
-        new_vars = []
-        for (short_name, field) in required_variables['vars']:
-            new_vars.append((short_name, field.format(frequency=frequency)))
-        required_variables['vars'] = new_vars
+        for (idx, var) in enumerate(required_variables['vars']):
+            if 'short_name' not in var:
+                raise NotImplementedError(
+                    "Don't know how to derive variable '{}': 'short_name' is "
+                    "not given for at least one required variable")
+            if 'field' in var:
+                required_variables['vars'][idx]['field'] = var['field'].format(
+                    frequency=frequency)
 
         return required_variables
 

--- a/esmvaltool/preprocessor/_derive/clhmtisccp.py
+++ b/esmvaltool/preprocessor/_derive/clhmtisccp.py
@@ -11,7 +11,8 @@ class DerivedVariable(DerivedVariableBase):
     """Derivation of variable `clhmtisccp`."""
 
     # Required variables
-    _required_variables = {'vars': [('clisccp', 'T4{frequency}')]}
+    _required_variables = {'vars': [{'short_name': 'clisccp',
+                                     'field': 'T4{frequency}'}]}
 
     def calculate(self, cubes):
         """Compute ISCCP high level medium-thickness cloud area fraction."""

--- a/esmvaltool/preprocessor/_derive/clhtkisccp.py
+++ b/esmvaltool/preprocessor/_derive/clhtkisccp.py
@@ -11,7 +11,8 @@ class DerivedVariable(DerivedVariableBase):
     """Derivation of variable `clhtkisccp`."""
 
     # Required variables
-    _required_variables = {'vars': [('clisccp', 'T4{frequency}')]}
+    _required_variables = {'vars': [{'short_name': 'clisccp',
+                                     'field': 'T4{frequency}'}]}
 
     def calculate(self, cubes):
         """Compute ISCCP high level thick cloud area fraction."""

--- a/esmvaltool/preprocessor/_derive/cllmtisccp.py
+++ b/esmvaltool/preprocessor/_derive/cllmtisccp.py
@@ -11,7 +11,8 @@ class DerivedVariable(DerivedVariableBase):
     """Derivation of variable `cllmtisccp`."""
 
     # Required variables
-    _required_variables = {'vars': [('clisccp', 'T4{frequency}')]}
+    _required_variables = {'vars': [{'short_name': 'clisccp',
+                                     'field': 'T4{frequency}'}]}
 
     def calculate(self, cubes):
         """Compute ISCCP low level medium-thickness cloud area fraction."""

--- a/esmvaltool/preprocessor/_derive/clltkisccp.py
+++ b/esmvaltool/preprocessor/_derive/clltkisccp.py
@@ -11,7 +11,8 @@ class DerivedVariable(DerivedVariableBase):
     """Derivation of variable `clltkisccp`."""
 
     # Required variables
-    _required_variables = {'vars': [('clisccp', 'T4{frequency}')]}
+    _required_variables = {'vars': [{'short_name': 'clisccp',
+                                     'field': 'T4{frequency}'}]}
 
     def calculate(self, cubes):
         """Compute ISCCP low level thick cloud area fraction."""

--- a/esmvaltool/preprocessor/_derive/clmmtisccp.py
+++ b/esmvaltool/preprocessor/_derive/clmmtisccp.py
@@ -11,7 +11,8 @@ class DerivedVariable(DerivedVariableBase):
     """Derivation of variable `clmmtisccp`."""
 
     # Required variables
-    _required_variables = {'vars': [('clisccp', 'T4{frequency}')]}
+    _required_variables = {'vars': [{'short_name': 'clisccp',
+                                     'field': 'T4{frequency}'}]}
 
     def calculate(self, cubes):
         """Compute ISCCP middle level medium-thickness cloud area fraction."""

--- a/esmvaltool/preprocessor/_derive/clmtkisccp.py
+++ b/esmvaltool/preprocessor/_derive/clmtkisccp.py
@@ -11,7 +11,8 @@ class DerivedVariable(DerivedVariableBase):
     """Derivation of variable `clmtkisccp`."""
 
     # Required variables
-    _required_variables = {'vars': [('clisccp', 'T4{frequency}')]}
+    _required_variables = {'vars': [{'short_name': 'clisccp',
+                                     'field': 'T4{frequency}'}]}
 
     def calculate(self, cubes):
         """Compute ISCCP middle level thick cloud area fraction."""

--- a/esmvaltool/preprocessor/_derive/lwcre.py
+++ b/esmvaltool/preprocessor/_derive/lwcre.py
@@ -10,8 +10,10 @@ class DerivedVariable(DerivedVariableBase):
     """Derivation of variable `lwcre`."""
 
     # Required variables
-    _required_variables = {'vars': [('rlut', 'T2{frequency}s'),
-                                    ('rlutcs', 'T2{frequency}s')]}
+    _required_variables = {'vars': [{'short_name': 'rlut',
+                                     'field': 'T2{frequency}s'},
+                                    {'short_name': 'rlutcs',
+                                     'field': 'T2{frequency}s'}]}
 
     def calculate(self, cubes):
         """Compute longwave cloud radiative effect."""

--- a/esmvaltool/preprocessor/_derive/lwp.py
+++ b/esmvaltool/preprocessor/_derive/lwp.py
@@ -14,8 +14,10 @@ class DerivedVariable(DerivedVariableBase):
     """Derivation of variable `lwp`."""
 
     # Required variables
-    _required_variables = {'vars': [('clwvi', 'T2{frequency}s'),
-                                    ('clivi', 'T2{frequency}s')]}
+    _required_variables = {'vars': [{'short_name': 'clwvi',
+                                     'field': 'T2{frequency}s'},
+                                    {'short_name': 'clivi',
+                                     'field': 'T2{frequency}s'}]}
 
     def calculate(self, cubes):
         """Compute liquid water path.

--- a/esmvaltool/preprocessor/_derive/nbp_grid.py
+++ b/esmvaltool/preprocessor/_derive/nbp_grid.py
@@ -11,7 +11,8 @@ class DerivedVariable(DerivedVariableBase):
     """Derivation of variable `nbp_grid`."""
 
     # Required variables
-    _required_variables = {'vars': [('nbp', 'T2{frequency}s')],
+    _required_variables = {'vars': [{'short_name': 'nbp',
+                                     'field': 'T2{frequency}s'}],
                            'fx_files': ['sftlf']}
 
     def calculate(self, cubes):

--- a/esmvaltool/preprocessor/_derive/netcre.py
+++ b/esmvaltool/preprocessor/_derive/netcre.py
@@ -10,10 +10,14 @@ class DerivedVariable(DerivedVariableBase):
     """Derivation of variable `netcre`."""
 
     # Required variables
-    _required_variables = {'vars': [('rlut', 'T2{frequency}s'),
-                                    ('rlutcs', 'T2{frequency}s'),
-                                    ('rsut', 'T2{frequency}s'),
-                                    ('rsutcs', 'T2{frequency}s')]}
+    _required_variables = {'vars': [{'short_name': 'rlut',
+                                     'field': 'T2{frequency}s'},
+                                    {'short_name': 'rlutcs',
+                                     'field': 'T2{frequency}s'},
+                                    {'short_name': 'rsut',
+                                     'field': 'T2{frequency}s'},
+                                    {'short_name': 'rsutcs',
+                                     'field': 'T2{frequency}s'}]}
 
     def calculate(self, cubes):
         """Compute net cloud radiative effect.

--- a/esmvaltool/preprocessor/_derive/rlns.py
+++ b/esmvaltool/preprocessor/_derive/rlns.py
@@ -10,8 +10,10 @@ class DerivedVariable(DerivedVariableBase):
     """Derivation of variable `rlns`."""
 
     # Required variables
-    _required_variables = {'vars': [('rlds', 'T2{frequency}s'),
-                                    ('rlus', 'T2{frequency}s')]}
+    _required_variables = {'vars': [{'short_name': 'rlds',
+                                     'field': 'T2{frequency}s'},
+                                    {'short_name': 'rlus',
+                                     'field': 'T2{frequency}s'}]}
 
     def calculate(self, cubes):
         """Compute surface net downward longwave radiation."""

--- a/esmvaltool/preprocessor/_derive/rsns.py
+++ b/esmvaltool/preprocessor/_derive/rsns.py
@@ -10,8 +10,10 @@ class DerivedVariable(DerivedVariableBase):
     """Derivation of variable `rsns`."""
 
     # Required variables
-    _required_variables = {'vars': [('rsds', 'T2{frequency}s'),
-                                    ('rsus', 'T2{frequency}s')]}
+    _required_variables = {'vars': [{'short_name': 'rsds',
+                                     'field': 'T2{frequency}s'},
+                                    {'short_name': 'rsus',
+                                     'field': 'T2{frequency}s'}]}
 
     def calculate(self, cubes):
         """Compute surface net downward shortwave radiation."""

--- a/esmvaltool/preprocessor/_derive/rsnt.py
+++ b/esmvaltool/preprocessor/_derive/rsnt.py
@@ -10,8 +10,10 @@ class DerivedVariable(DerivedVariableBase):
     """Derivation of variable `rsnt`."""
 
     # Required variables
-    _required_variables = {'vars': [('rsdt', 'T2{frequency}s'),
-                                    ('rsut', 'T2{frequency}s')]}
+    _required_variables = {'vars': [{'short_name': 'rsdt',
+                                     'field': 'T2{frequency}s'},
+                                    {'short_name': 'rsut',
+                                     'field': 'T2{frequency}s'}]}
 
     def calculate(self, cubes):
         """Compute toa net downward shortwave radiation."""

--- a/esmvaltool/preprocessor/_derive/rtnt.py
+++ b/esmvaltool/preprocessor/_derive/rtnt.py
@@ -10,9 +10,12 @@ class DerivedVariable(DerivedVariableBase):
     """Derivation of variable `rtnt`."""
 
     # Required variables
-    _required_variables = {'vars': [('rsdt', 'T2{frequency}s'),
-                                    ('rsut', 'T2{frequency}s'),
-                                    ('rlut', 'T2{frequency}s')]}
+    _required_variables = {'vars': [{'short_name': 'rsdt',
+                                     'field': 'T2{frequency}s'},
+                                    {'short_name': 'rsut',
+                                     'field': 'T2{frequency}s'},
+                                    {'short_name': 'rlut',
+                                     'field': 'T2{frequency}s'}]}
 
     def calculate(self, cubes):
         """Compute toa net downward total radiation."""

--- a/esmvaltool/preprocessor/_derive/swcre.py
+++ b/esmvaltool/preprocessor/_derive/swcre.py
@@ -10,8 +10,10 @@ class DerivedVariable(DerivedVariableBase):
     """Derivation of variable `swcre`."""
 
     # Required variables
-    _required_variables = {'vars': [('rsut', 'T2{frequency}s'),
-                                    ('rsutcs', 'T2{frequency}s')]}
+    _required_variables = {'vars': [{'short_name': 'rsut',
+                                     'field': 'T2{frequency}s'},
+                                    {'short_name': 'rsutcs',
+                                     'field': 'T2{frequency}s'}]}
 
     def calculate(self, cubes):
         """Compute shortwave cloud radiative effect."""

--- a/esmvaltool/preprocessor/_derive/toz.py
+++ b/esmvaltool/preprocessor/_derive/toz.py
@@ -27,8 +27,10 @@ class DerivedVariable(DerivedVariableBase):
     """Derivation of variable `toz`."""
 
     # Required variables
-    _required_variables = {'vars': [('tro3', 'T3{frequency}'),
-                                    ('ps', 'T2{frequency}s')]}
+    _required_variables = {'vars': [{'short_name': 'tro3',
+                                     'field': 'T3{frequency}'},
+                                    {'short_name': 'ps',
+                                     'field': 'T2{frequency}s'}]}
 
     def calculate(self, cubes):
         """Compute total column ozone.

--- a/esmvaltool/recipes/examples/recipe_preprocessor_derive_test.yml
+++ b/esmvaltool/recipes/examples/recipe_preprocessor_derive_test.yml
@@ -2,6 +2,14 @@
 # variables use the same basic variables, which leads to PermissionDenied
 # errors.
 ---
+preprocessors:
+
+  regrid:
+    regrid:
+      target_grid: CanESM2
+      scheme: linear
+
+
 diagnostics:
 
   diag1:
@@ -37,6 +45,7 @@ diagnostics:
         additional_datasets:
           - {dataset: HadGEM2-A}
       nbp_grid:
+        # preprocessor: regrid
         project: CMIP5
         mip: Lmon
         exp: historical

--- a/esmvaltool/recipes/examples/recipe_preprocessor_derive_test.yml
+++ b/esmvaltool/recipes/examples/recipe_preprocessor_derive_test.yml
@@ -45,7 +45,7 @@ diagnostics:
         additional_datasets:
           - {dataset: HadGEM2-A}
       nbp_grid:
-        # preprocessor: regrid
+        preprocessor: regrid
         project: CMIP5
         mip: Lmon
         exp: historical

--- a/esmvaltool/recipes/recipe_autoassess_radiation_rms_cfMon_all.yml
+++ b/esmvaltool/recipes/recipe_autoassess_radiation_rms_cfMon_all.yml
@@ -38,7 +38,7 @@ preprocessors:
 
 diagnostics:
   radiation_cfMon_all_ISCCP:
-    description: "CMIP5 vs ISCCP Clouds" 
+    description: "CMIP5 vs ISCCP Clouds"
     variables:
       cllmtisccp: # Low-intermediate Cloud
         preprocessor: pp_rad_derive_var


### PR DESCRIPTION
Closes #685.

This PR allows more complex variable derivation by adding arbitrary entries to the requested variables, e.g.

```python
    _required_variables = {'vars': [{'short_name': 'rlds',
                                     'field': 'T2{frequency}s'},
                                    {'short_name': 'rlus',
                                     'field': 'T2{frequency}s'}]}
```

Only the key `short_name` is required, all others are optional (when the `field` of the derived variable is equal to the required one it can be omitted, too).