### PR TITLE
Use readthedocs theme for local documentation builds

### DIFF
--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -128,7 +128,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ REQUIREMENTS = {
         'pydocstyle',
         'pylint',
         'sphinx',
+        'sphinx_rtd_theme',
         'yamllint',
         'yapf',
     ],


### PR DESCRIPTION
So that when building the documentation locally with `python setup.py build_sphinx` you get the same look as on [readthedocs](https://esmvaltool.readthedocs.io).