### PR TITLE
Set matplotlib non-interactive backend via environment

### DIFF
--- a/esmvaltool/_task.py
+++ b/esmvaltool/_task.py
@@ -434,12 +434,15 @@ class DiagnosticTask(AbstractTask):
 
         cmd = list(self.cmd)
         cwd = None
-        env = None
+        env = dict(os.environ)
 
         settings_file = self.write_settings()
 
-        if not self.script.lower().endswith('.py'):
-            env = dict(os.environ)
+        if self.script.lower().endswith('.py'):
+            # Set non-interactive matplotlib backend
+            env['MPLBACKEND'] = 'Agg'
+        else:
+            # Make diag_scripts path available to diagostics scripts
             env['diag_scripts'] = os.path.join(
                 os.path.dirname(__file__), 'diag_scripts')
 

--- a/esmvaltool/diag_scripts/autoassess/_plot_mo_metrics.py
+++ b/esmvaltool/diag_scripts/autoassess/_plot_mo_metrics.py
@@ -8,13 +8,12 @@ Create normalised assessment criteria plot (NAC plot).
 
 from __future__ import division, print_function
 
-import os
 import csv
 import errno
-import numpy as np
-import matplotlib
-matplotlib.use('Agg')  # noqa
+import os
+
 import matplotlib.pyplot as plt
+import numpy as np
 
 # Define some colours
 BLACK = '#000000'

--- a/esmvaltool/diag_scripts/autoassess/stratosphere/age_of_air.py
+++ b/esmvaltool/diag_scripts/autoassess/stratosphere/age_of_air.py
@@ -1,17 +1,17 @@
 """Stratospheric age-of-air assessment code."""
-import os
-import logging
-import warnings
 import datetime
-import numpy as np
-import matplotlib as mpl
-mpl.use('Agg')  # noqa
-import matplotlib.pyplot as plt
+import logging
+import os
+import warnings
+
 import iris
 import iris.analysis as iai
-from esmvaltool.diag_scripts.autoassess.loaddata import load_run_ss
-from .strat_metrics_1 import weight_lat_ave
+import matplotlib.pyplot as plt
+import numpy as np
 
+from esmvaltool.diag_scripts.autoassess.loaddata import load_run_ss
+
+from .strat_metrics_1 import weight_lat_ave
 
 logger = logging.getLogger(__name__)
 

--- a/esmvaltool/diag_scripts/autoassess/stratosphere/strat_metrics_1.py
+++ b/esmvaltool/diag_scripts/autoassess/stratosphere/strat_metrics_1.py
@@ -1,25 +1,22 @@
 """Stratospheric assessment code; ESMValTool-autoassess version."""
-import os
 import logging
+import os
 
-import matplotlib
-matplotlib.use('Agg')  # noqa
-
-import matplotlib.cm as mpl_cm
-import matplotlib.colors as mcol
-import matplotlib.dates as mdates
-import matplotlib.pyplot as plt
-from matplotlib.patches import Rectangle
-import numpy as np
-
-from cartopy.mpl.gridliner import LATITUDE_FORMATTER
 import iris
 import iris.analysis.cartography as iac
 import iris.coord_categorisation as icc
 import iris.plot as iplt
-from esmvaltool.diag_scripts.autoassess.loaddata import load_run_ss
-from .plotting import segment2list
+import matplotlib.cm as mpl_cm
+import matplotlib.colors as mcol
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+import numpy as np
+from cartopy.mpl.gridliner import LATITUDE_FORMATTER
+from matplotlib.patches import Rectangle
 
+from esmvaltool.diag_scripts.autoassess.loaddata import load_run_ss
+
+from .plotting import segment2list
 
 logger = logging.getLogger(__name__)
 

--- a/esmvaltool/diag_scripts/crem/ww09_esmvaltool.py
+++ b/esmvaltool/diag_scripts/crem/ww09_esmvaltool.py
@@ -42,15 +42,14 @@ Cloud Regime Error Metrics (CREM).
     20150903-A_laue_ax: ESMValTool implementation.
     20150521-A_will_ke: CREM routines written.
 """
-import sys
 import logging
 import os
-import numpy as np
-from scipy.ndimage.interpolation import map_coordinates as interp2d
-from netCDF4 import Dataset
-import matplotlib
-matplotlib.use('Agg')  # noqa
+import sys
+
 import matplotlib.pyplot as plt
+import numpy as np
+from netCDF4 import Dataset
+from scipy.ndimage.interpolation import map_coordinates as interp2d
 
 from esmvaltool.diag_scripts.shared import (group_metadata, run_diagnostic,
                                             select_metadata)

--- a/esmvaltool/diag_scripts/examples/my_little_diagnostic.py
+++ b/esmvaltool/diag_scripts/examples/my_little_diagnostic.py
@@ -19,18 +19,11 @@ and best coding practices.
 # operating system manipulations (e.g. path constructions)
 import os
 
-# for plotting
-import matplotlib
-# use this everytime you import matplotlib
-# modules; some machines dont have graphical interface (X)
-matplotlib.use('Agg')  # noqa
-import matplotlib.pyplot as plt
-
 # to manipulate iris cubes
 import iris
 
 # import internal esmvaltool modules here
-from esmvaltool.diag_scripts.shared import run_diagnostic, group_metadata
+from esmvaltool.diag_scripts.shared import group_metadata, run_diagnostic
 from esmvaltool.preprocessor import average_region
 
 

--- a/esmvaltool/diag_scripts/ocean/diagnostic_maps.py
+++ b/esmvaltool/diag_scripts/ocean/diagnostic_maps.py
@@ -26,12 +26,10 @@ Author: Lee de Mora (PML)
 import logging
 import os
 import sys
-import matplotlib
-matplotlib.use('Agg')  # noqa
-import matplotlib.pyplot as plt
 
 import iris
 import iris.quickplot as qplt
+import matplotlib.pyplot as plt
 
 import diagnostic_tools as diagtools
 from esmvaltool.diag_scripts.shared import run_diagnostic

--- a/esmvaltool/diag_scripts/ocean/diagnostic_maps_quad.py
+++ b/esmvaltool/diag_scripts/ocean/diagnostic_maps_quad.py
@@ -29,13 +29,10 @@ Author: Lee de Mora (PML)
 import logging
 import os
 import sys
-import matplotlib
-matplotlib.use('Agg')  # noqa
-import matplotlib.pyplot as plt
 
 import iris
 import iris.quickplot as qplt
-
+import matplotlib.pyplot as plt
 import numpy as np
 
 import diagnostic_tools as diagtools

--- a/esmvaltool/diag_scripts/ocean/diagnostic_profiles.py
+++ b/esmvaltool/diag_scripts/ocean/diagnostic_profiles.py
@@ -32,12 +32,10 @@ Author: Lee de Mora (PML)
 import logging
 import os
 import sys
-import matplotlib
-matplotlib.use('Agg')  # noqa
-import matplotlib.pyplot as plt
 
 import iris
 import iris.quickplot as qplt
+import matplotlib.pyplot as plt
 
 import diagnostic_tools as diagtools
 from esmvaltool.diag_scripts.shared import run_diagnostic

--- a/esmvaltool/diag_scripts/ocean/diagnostic_seaice.py
+++ b/esmvaltool/diag_scripts/ocean/diagnostic_seaice.py
@@ -26,16 +26,14 @@ Author: Lee de Mora (PML)
 import logging
 import os
 import sys
-import numpy as np
 from itertools import product
 
-import matplotlib
-matplotlib.use('Agg')  # noqa
-import matplotlib.pyplot as plt
+import cartopy
 import iris
 import iris.quickplot as qplt
-
-import cartopy
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
 
 import diagnostic_tools as diagtools
 from esmvaltool.diag_scripts.shared import run_diagnostic

--- a/esmvaltool/diag_scripts/ocean/diagnostic_timeseries.py
+++ b/esmvaltool/diag_scripts/ocean/diagnostic_timeseries.py
@@ -42,12 +42,10 @@ Author: Lee de Mora (PML)
 
 import logging
 import os
-import numpy as np
-import matplotlib
-matplotlib.use('Agg')  # noqa
-import matplotlib.pyplot as plt
 
 import iris
+import matplotlib.pyplot as plt
+import numpy as np
 
 import diagnostic_tools as diagtools
 from esmvaltool.diag_scripts.shared import run_diagnostic

--- a/esmvaltool/diag_scripts/ocean/diagnostic_tools.py
+++ b/esmvaltool/diag_scripts/ocean/diagnostic_tools.py
@@ -13,10 +13,8 @@ Author: Lee de Mora (PML)
 import logging
 import os
 import sys
-import cftime
-import matplotlib
-matplotlib.use('Agg')  # noqa
 
+import cftime
 import matplotlib.pyplot as plt
 
 from esmvaltool.diag_scripts.shared._base import _get_input_data_files

--- a/esmvaltool/diag_scripts/ocean/diagnostic_transects.py
+++ b/esmvaltool/diag_scripts/ocean/diagnostic_transects.py
@@ -26,10 +26,8 @@ Author: Lee de Mora (PML)
 import logging
 import os
 import sys
-import matplotlib
-matplotlib.use('Agg')  # noqa
-import iris
 
+import iris
 import iris.quickplot as qplt
 import matplotlib.pyplot as plt
 

--- a/esmvaltool/diag_scripts/shared/plot/__init__.py
+++ b/esmvaltool/diag_scripts/shared/plot/__init__.py
@@ -1,7 +1,4 @@
 """Module that provides common plot functions."""
-# set matplotlib non-interactive backend
-import matplotlib
-matplotlib.use('Agg')  # noqa
 
 from ._plot import (
     get_path_to_mpl_style,

--- a/esmvaltool/diag_scripts/validation.py
+++ b/esmvaltool/diag_scripts/validation.py
@@ -11,17 +11,15 @@ This diagnostic uses CMIP5 data; to switch to CMIP6 change _CMIP_TYPE
 import logging
 import os
 
-import matplotlib
-matplotlib.use('Agg')  # noqa
-
 import iris
 import iris.analysis.maths as imath
 import iris.quickplot as qplt
 import matplotlib.pyplot as plt
 import numpy as np
 
-from esmvaltool.diag_scripts.shared import (
-    apply_supermeans, get_control_exper_obs, group_metadata, run_diagnostic)
+from esmvaltool.diag_scripts.shared import (apply_supermeans,
+                                            get_control_exper_obs,
+                                            group_metadata, run_diagnostic)
 from esmvaltool.preprocessor import extract_region, extract_season
 
 logger = logging.getLogger(os.path.basename(__file__))

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,8 @@ builder = html
 
 [tool:pytest]
 log_level = DEBUG
+env =
+    MPLBACKEND = Agg
 
 [pydocstyle]
 convention = numpy

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ REQUIREMENTS = {
         'pycodestyle',
         'pytest',
         'pytest-cov',
+        'pytest-env',
         'pytest-html',
         'pytest-metadata>=1.5.1',
     ],


### PR DESCRIPTION
Set matplotlib non-interactive backend via an environmental variable. This removes the need for all the
```python
import matplotlib
matplotlib.use('Agg')
```
code at the top of modules that use matplotlib.