### PR TITLE
Support CDS CMIP5 subset

### DIFF
--- a/esmvaltool/config-developer.yml
+++ b/esmvaltool/config-developer.yml
@@ -28,6 +28,7 @@ CMIP5:
   input_dir:
     default: '/'
     BADC: '[institute]/[dataset]/[exp]/[frequency]/[modeling_realm]/[mip]/[ensemble]/latest/[short_name]'
+    CP4CDS: '[institute]/[dataset]/[exp]/[frequency]/[modeling_realm]/[mip]/[ensemble]/[short_name]/latest/'
     DKRZ: '[institute]/[dataset]/[exp]/[frequency]/[modeling_realm]/[mip]/[ensemble]/[latestversion]/[short_name]'
     ETHZ: '[exp]/[mip]/[short_name]/[dataset]/[ensemble]/'
     SMHI: '[dataset]/[ensemble]/[exp]/[frequency]'

--- a/esmvaltool/recipes/examples/recipe_python.yml
+++ b/esmvaltool/recipes/examples/recipe_python.yml
@@ -1,7 +1,7 @@
 ---
 
 datasets:
-  - {dataset: bcc-csm1-1,  project: CMIP5,  mip: Amon,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
+  - {dataset: CanESM2,  project: CMIP5,  mip: Amon,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
   - {dataset: GFDL-ESM2G,  project: CMIP5,  mip: Amon,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
   - {dataset: MPI-ESM-LR,  project: CMIP5,  mip: Amon,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
 
@@ -26,7 +26,7 @@ diagnostics:
       ta:
         preprocessor: preprocessor1
         field: T3M
-        reference_dataset: bcc-csm1-1
+        reference_dataset: CanESM2
       pr:
         field: T2Ms
         reference_dataset: MPI-ESM-LR


### PR DESCRIPTION
For the CP4CDS CMIP5 subset we use in MAGIC we need a new DRS entry. I'm unsure if it is used outside of CP4CDS, so I've simply called it that.

Example of config-user.yml making use of this: https://github.com/c3s-magic/c3s-magic-cylc-suite/blob/master/config-user.yml

I also changed one of the datasets in the Python example to match the subset available in CDS.

@bjoernbroetz  could you have a look if this also works on the machine you normally run ESMValTool on?