### PR TITLE
Fix cube attributes

### DIFF
--- a/esmvaltool/preprocessor/_io.py
+++ b/esmvaltool/preprocessor/_io.py
@@ -50,14 +50,18 @@ def concatenate_callback(raw_cube, field, _):
             if units is not None:
                 coord.units = units
 
+
 def _adjust_cube_attributes(cubes):
-    """Fixes attribute mismatch in cubes causing problems during `concatenate_cube` operations."""
+    """
+    Fixes attribute mismatch in cubes causing problems during
+    `concatenate_cube` operations.
+    """
     from iris.experimental.equalise_cubes import equalise_attributes
 
     equalise_attributes(cubes)
     for idx in range(len(cubes)):
         try:
-            cubes[idx].coord('time').attributes={}
+            cubes[idx].coord('time').attributes = {}
         except iris.exceptions.CoordinateNotFoundError as ex:
             continue
     return cubes

--- a/esmvaltool/preprocessor/_io.py
+++ b/esmvaltool/preprocessor/_io.py
@@ -50,12 +50,22 @@ def concatenate_callback(raw_cube, field, _):
             if units is not None:
                 coord.units = units
 
+def _adjust_cube_attributes(cubes):
+    """Fixes attribute mismatch in cubes causing problems during `concatenate_cube` operations."""
+    from iris.experimental.equalise_cubes import equalise_attributes
+
+    equalise_attributes(cubes)
+    for idx in range(len(cubes)):
+        cubes[idx].coord('time').attributes={}
+    return cubes
+
 
 def load(files, constraints=None, callback=None):
     """Load iris cubes from files."""
     logger.debug("Loading:\n%s", "\n".join(files))
     cubes = iris.load_raw(files, constraints=constraints, callback=callback)
     iris.util.unify_time_units(cubes)
+    _adjust_cube_attributes(cubes)
     if not cubes:
         raise Exception('Can not load cubes from {0}'.format(files))
 

--- a/esmvaltool/preprocessor/_io.py
+++ b/esmvaltool/preprocessor/_io.py
@@ -56,7 +56,10 @@ def _adjust_cube_attributes(cubes):
 
     equalise_attributes(cubes)
     for idx in range(len(cubes)):
-        cubes[idx].coord('time').attributes={}
+        try:
+            cubes[idx].coord('time').attributes={}
+        except iris.exceptions.CoordinateNotFoundError as ex:
+            continue
     return cubes
 
 

--- a/esmvaltool/preprocessor/_io.py
+++ b/esmvaltool/preprocessor/_io.py
@@ -56,9 +56,6 @@ def _adjust_cube_attributes(cubes):
     Fixes attribute mismatch in cubes causing problems during
     `concatenate_cube` operations.
     """
-    from iris.experimental.equalise_cubes import equalise_attributes
-
-    equalise_attributes(cubes)
     for idx in range(len(cubes)):
         try:
             cubes[idx].coord('time').attributes = {}


### PR DESCRIPTION
Fixes attribute mismatch in cubes causing problems during   `concatenate_cube` operations.

My cubes spanned a time interval with each cube (of cause) starting at a different time. This information was given in the attributes of the coordinate of each of the cubes. During `concatenate_cubes` iris complained about an attribute mismatch due to this changing `start_time` attribute in the coordinate attributes. 