### PR TITLE
updated documentation of recipe settings for ncl scripts

### DIFF
--- a/doc/sphinx/source/recipes/recipe_clouds.rst
+++ b/doc/sphinx/source/recipes/recipe_clouds.rst
@@ -39,16 +39,16 @@ Diagnostics are stored in diag_scripts/clouds/
     * clouds_taylor.ncl: taylor diagrams
 
 
-User settings
--------------
+User settings in recipe
+-----------------------
 
-#. clouds.ncl
+#. Script clouds.ncl
 
-   *Required diag_script_info attributes*
+   *Required settings (scripts)*
 
    none
 
-   *Optional diag_scipt_info attributes*
+   *Optional settings (scripts)*
 
    * embracesetup: true = 2 plots per line, false = 4 plots per line (default)
    * explicit_cn_levels: explicit contour levels (array)
@@ -71,11 +71,11 @@ User settings
    * treat_var_as_error: treat variable as error when averaging (true, false);
      true:  avg = sqrt(mean(var*var)), false: avg = mean(var)
 
-   *Required variable_info attributes*
+   *Required settings (variables)*
 
    none
 
-   * Optional variable_info attributes (variable specific)
+   * Optional settings (variables)
 
    * long_name: variable description
    * reference_dataset: reference dataset; REQUIRED when calculating
@@ -86,13 +86,13 @@ User settings
 
    * variable "lwp": diag_scripts/shared/plot/rgb/qcm3.rgb
 
-#. clouds_bias.ncl
+#. Script clouds_bias.ncl
 
-   *Required diag_script_info attributes*
+   *Required settings (scripts)*
 
    none
 
-   *Optional diag_scipt_info attributes*
+   *Optional settings (scripts)*
 
    * plot_abs_diff: additionally also plot absolute differences (true, false)
    * plot_rel_diff: additionally also plot relative differences (true, false)
@@ -100,11 +100,11 @@ User settings
    * timemean: time averaging, i.e. "seasonalclim" (DJF, MAM, JJA, SON),
      "annualclim" (annual mean)
 
-   * Required variable_info attributes (variable specific)*
+   * Required settings (variables)*
 
    * reference_dataset: name of reference datatset
 
-   *Optional variable_info attributes (variable specific)*
+   *Optional settings (variables)*
 
    * long_name: description of variable
 
@@ -115,13 +115,13 @@ User settings
    * variable "pr-mmday": diag_scripts/shared/plots/rgb/ipcc-precip.rgb,
      diag_scripts/shared/plot/rgb/ipcc-precip-delta.rgb
 
-#. clouds_interannual.ncl
+#. Script clouds_interannual.ncl
 
-   *Required diag_script_info attributes (diagnostic specific)*
+   *Required settings (scripts)*
 
    none
 
-   *Optional diag_script_info attributes (diagnostic specific)*
+   *Optional settings (scripts)*
 
    * colormap: e.g., WhiteBlueGreenYellowRed, rainbow
    * explicit_cn_levels: use these contour levels for plotting
@@ -129,11 +129,11 @@ User settings
      (true, false)
    * projection: map projection, e.g., Mollweide, Mercator
 
-   *Required variable_info attributes (variable specific)*
+   *Required settings (variables)*
 
    none
 
-   *Optional variable_info attributes (variable specific)*
+   *Optional settings (variables)*
 
    * long_name: description of variable
    * reference_dataset: name of reference datatset
@@ -142,13 +142,13 @@ User settings
 
    * variable "lwp": diag_scripts/shared/plots/rgb/qcm3.rgb
 
-#. clouds_ipcc.ncl
+#. Script clouds_ipcc.ncl
 
-   *Required diag_script_info attributes (diagnostic specific)*
+   *Required settings (scripts)*
 
    none
 
-   *Optional diag_script_info attributes (diagnostic specific)*
+   *Optional settings (scripts)*
 
    * explicit_cn_levels: contour levels
    * mask_ts_sea_ice: true = mask T < 272 K as sea ice (only for variable "ts");
@@ -160,11 +160,11 @@ User settings
    * valid_fraction: used for creating sea ice mask (mask_ts_sea_ice = true):
      fraction of valid time steps required to mask grid cell as valid data
 
-   *Required variable_info attributes (variable specific)*
+   *Required settings (variables)*
 
    * reference_dataset:  name of reference data set
 
-   *Optional variable_info attributes (variable specific)*
+   *Optional settings (variables)*
 
    * long_name: description of variable
    * units: variable units
@@ -173,13 +173,13 @@ User settings
 
    * variables "pr", "pr-mmday": diag_scripts/shared/plot/rgb/ipcc-precip-delta.rgb
 
-#. clouds_taylor.ncl
+#. Script clouds_taylor.ncl
 
-   *Required diag_script_info attributes (diagnostic specific)*
+   *Required settings (scripts)*
 
    none
 
-   *Optional diag_script_info attributes (diagnostic specific)*
+   *Optional settings (scripts)*
 
    * embracelegend: false (default) = include legend in plot, max. 2 columns
      with dataset names in legend; true = write extra file with legend, max. 7
@@ -201,11 +201,11 @@ User settings
    * valid_fraction: used for creating sea ice mask (mask_ts_sea_ice = true):
      fraction of valid time steps required to mask grid cell as valid data
 
-   *Required variable_info attributes (variable specific)*
+   *Required settings (variables)*
 
    * reference_dataset: name of reference data set
 
-   *Optional variable attributes (variable specific)*
+   *Optional settings (variables)*
 
    none
 

--- a/doc/sphinx/source/recipes/recipe_perfmetrics.rst
+++ b/doc/sphinx/source/recipes/recipe_perfmetrics.rst
@@ -24,18 +24,18 @@ Diagnostics are stored in diag_scripts/perfmetrics/
 * cycle_latlon.ncl: precalculates the metrics for a time-lat-lon field, with different options for normalization.
 * collect.ncl: collects and plots the metrics previously calculated by cycle_latlon.ncl.
 
-User settings
--------------
+User settings in recipe
+-----------------------
 
-#. main.ncl
+#. Script main.ncl
 
-   *Required diag_script_info attributes*
+   *Required settings (scripts)*
 
    * plot_type: cycle (time), zonal (plev, lat), latlon (lat, lon), cycle_latlon (time, lat, lon)
    * time_avg: type of time average (opt argument of time_operations in diag_scripts/shared/statistics.ncl)
    * region: selected region (see select_region in diag_scripts/shared/latlon.ncl)
    
-   *Optional diag_script_info attributes*
+   *Optional settings (scripts)*
    
    * styleset: for plot_type cycle only (as in diag_scripts/shared/plot/styles/)
    * plot_stddev: for plot_type cycle only, plots standard deviation as shading
@@ -57,26 +57,26 @@ User settings
    * latlon_cmap: for plot_type latlon only, chosen color table (default: "amwg_blueyellowred")
    * plot_units: plotting units (if different from standard CMOR units)
    
-   *Required variable_info attributes*
+   *Required settings (variables)*
    
    * reference_dataset: reference dataset to compare with (usually the observations).
    
-   *Optional variable_info attributes*
+   *Optional settings (variables)*
 
    * alternative_dataset: a second dataset to compare with.
 
-These settings are passed to the other scripts by main.ncl, depending on the selected plot_type.
+   These settings are passed to the other scripts by main.ncl, depending on the selected plot_type.
 
-#. collect.ncl
+#. Script collect.ncl
 
-   *Required diag_script_info attributes*
+   *Required settings (scripts)*
 
    * metric: selected metric (RMSD, BIAS or taylor)
    * label_bounds: for RMSD and BIAS metrics, min and max of the labelbar
    * label_scale: for RMSD and BIAS metrics, bin width of the labelbar
    * colormap: for RMSD and BIAS metrics, color table of the labelbar
    
-   *Optional diag_script_info attributes*
+   *Optional settings (scripts)*
    
    * label_lo: adds lower triange for values outside range
    * label_hi: adds upper triange for values outside range

--- a/doc/sphinx/source/recipes/recipe_runoff_et.rst
+++ b/doc/sphinx/source/recipes/recipe_runoff_et.rst
@@ -47,17 +47,17 @@ Diagnostics are stored in diag_scripts/runoff_et/
       runoff, evapotranspiration and precipitation
 
 
-User settings
--------------
+User settings in recipe
+-----------------------
 
-runoff_et.yml
+#. Script catchment_analysis.py
 
-   *Required settings for script*
+   *Required settings (scripts)*
 
    * catchmentmask: netCDF file indicating the grid cell for a specific catchment. Modus of
      distribution not yet clearified. ESGF?
 
-   *Optional settings for variables*
+   *Optional settings (variables)*
 
    * reference_dataset: dataset_name
      Datasets can be used as reference instead of defaults provided with the diagnostics.

--- a/doc/sphinx/source/recipes/template.rst
+++ b/doc/sphinx/source/recipes/template.rst
@@ -1,0 +1,71 @@
+Title
+=====
+
+Overview
+--------
+
+Brief description of the diagnostic.
+
+
+Available recipes and diagnostics
+---------------------------------
+
+Recipes are stored in recipes/
+
+    * recipe_<mynewrecipe>.yml
+
+Diagnostics are stored in diag_scripts/<mynewdiag>/
+
+    * <mynewdiag.py/.ncl/.r>: one line scription
+
+
+User settings in recipe
+-----------------------
+
+#. Script <mynewdiag.py/.ncl/.r>
+
+   *Required settings (scripts)*
+
+   * xxx: zzz
+
+   *Optional settings (scripts)*
+
+   *Required settings (variables)*
+
+   * Optional settings (variables)
+
+   *Color tables*
+
+   * list required color tables (if any) here
+
+
+Variables
+---------
+
+* var1 (realm, frequency, dimensions), e.g. pr (atmos, monthly mean, longitude latitude time)
+
+
+Observations and reformat scripts
+---------------------------------
+
+*Note: (1) obs4mips data can be used directly without any preprocessing;
+(2) see headers of reformat scripts for non-obs4mips data for download
+instructions.*
+
+* xxx
+
+  *Reformat script:* <myreformatscript.py>
+
+References
+----------
+
+* xxx
+
+Example plots
+-------------
+
+.. _fig_mynewdiag_1:
+.. figure::  /recipes/figures/<mynewdiagnostic>/awesome1.png
+   :align:   center
+
+   Add figure caption here.

--- a/doc/sphinx/source/recipes/template.rst
+++ b/doc/sphinx/source/recipes/template.rst
@@ -32,7 +32,7 @@ User settings in recipe
 
    *Required settings (variables)*
 
-   * Optional settings (variables)
+   *Optional settings (variables)*
 
    *Color tables*
 


### PR DESCRIPTION
This PR updates the documentation of ncl script settings defined in the recipes:
* renamed "settings diag_script_info" to "settings (scripts)"
* renamed "settings variable_info" to "settings (variables)"

Added .rst template for documenting new recipes/diagnostics to doc/sphinx/source/recipes/template.rst

These changes are up for discussion and could be a possible solution for issue #809.