### PR TITLE
Add link to the private repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ To install in development mode, follow these instructions.
   - Update conda: `conda update -y conda`
   - Create a conda environment: `conda create -y -n esmvaltool python=3`
   - Activate the esmvaltool environment: `conda activate esmvaltool`
-  - Clone the ESMValTool github repository: `git clone git@github.com:ESMValGroup/ESMValTool`
+  - Clone the ESMValTool public github repository: `git clone git@github.com:ESMValGroup/ESMValTool`, or one of the private github repositories (e.g. `https://github.com/ESMValGroup/ESMValTool-private`)
   - Go to the esmvaltool directory: `cd ESMValTool`
   - Update the esmvaltool conda environment `conda env update`
   - Install in development mode: `pip install -e '.[develop]'`. If you are installing behind a proxy that does not trust the usual pip-urls you can declare them with the option `--trusted-host`, e.g. `pip install --trusted-host=pypi.python.org --trusted-host=pypi.org --trusted-host=files.pythonhosted.org -e .[develop]`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ To install in development mode, follow these instructions.
   - Update conda: `conda update -y conda`
   - Create a conda environment: `conda create -y -n esmvaltool python=3`
   - Activate the esmvaltool environment: `conda activate esmvaltool`
-  - Clone the ESMValTool public github repository: `git clone git@github.com:ESMValGroup/ESMValTool`, or one of the private github repositories (e.g. `https://github.com/ESMValGroup/ESMValTool-private`)
+  - Clone the ESMValTool public github repository: `git clone git@github.com:ESMValGroup/ESMValTool`, or one of the private github repositories (e.g. `git clone git@github.com:ESMValGroup/ESMValTool-private`)
   - Go to the esmvaltool directory: `cd ESMValTool`
   - Update the esmvaltool conda environment `conda env update`
   - Install in development mode: `pip install -e '.[develop]'`. If you are installing behind a proxy that does not trust the usual pip-urls you can declare them with the option `--trusted-host`, e.g. `pip install --trusted-host=pypi.python.org --trusted-host=pypi.org --trusted-host=files.pythonhosted.org -e .[develop]`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ To install in development mode, follow these instructions.
   - Update conda: `conda update -y conda`
   - Create a conda environment: `conda create -y -n esmvaltool python=3`
   - Activate the esmvaltool environment: `conda activate esmvaltool`
-  - Clone the ESMValTool public github repository: `git clone git@github.com:ESMValGroup/ESMValTool`, or one of the private github repositories (e.g. `git clone git@github.com:ESMValGroup/ESMValTool-private`)
+  - Clone the ESMValTool public github repository: `git clone git@github.com:ESMValGroup/ESMValTool.git`, or one of the private github repositories (e.g. `git clone git@github.com:ESMValGroup/ESMValTool-private.git`)
   - Go to the esmvaltool directory: `cd ESMValTool`
   - Update the esmvaltool conda environment `conda env update`
   - Install in development mode: `pip install -e '.[develop]'`. If you are installing behind a proxy that does not trust the usual pip-urls you can declare them with the option `--trusted-host`, e.g. `pip install --trusted-host=pypi.python.org --trusted-host=pypi.org --trusted-host=files.pythonhosted.org -e .[develop]`

--- a/doc/sphinx/source/user_guide2/install.inc
+++ b/doc/sphinx/source/user_guide2/install.inc
@@ -45,11 +45,17 @@ The ESMValTool source code is available on a public GitHub repository:
 https://github.com/ESMValGroup/ESMValTool
 
 The easiest way to obtain it is to clone the repository using git
-(see https://git-scm.com/):
+(see https://git-scm.com/). To clone the public repository:
 
 .. code-block:: bash
 
     git clone https://github.com/ESMValGroup/ESMValTool.git
+
+It is also possible to work in one of the ESMValTool private repository, e.g.:
+
+.. code-block:: bash
+
+    git clone https://github.com/ESMValGroup/ESMValTool-private.git
 
 By default, this command will create a folder called ESMValTool containing the
 source code of the tool.


### PR DESCRIPTION
Users working in one of the private repository should not clone the public one. This updates the CONTRIBUTING.md file and the user guide.