### PR TITLE
Deal with scalar z coordinates in irregular regridding.

### DIFF
--- a/esmvaltool/preprocessor/_regrid_esmpy.py
+++ b/esmvaltool/preprocessor/_regrid_esmpy.py
@@ -262,14 +262,21 @@ def build_regridder(src_rep, dst_rep, method, mask_threshold=.99):
 def get_grid_representant(cube, horizontal_only=False):
     """Extract the spatial grid from a cube."""
     horizontal_slice = ['latitude', 'longitude']
-    if horizontal_only:
-        ref_to_slice = horizontal_slice
-    else:
+    ref_to_slice = horizontal_slice
+    if not horizontal_only:
         try:
             cube_z_coord = cube.coord(axis='Z')
-            ref_to_slice = [cube_z_coord] + horizontal_slice
+            n_zdims = len(cube.coord_dims(cube_z_coord))
+            if n_zdims == 0:
+                # scalar z coordinate, go on with 2d regridding
+                pass
+            elif n_zdims == 1:
+                ref_to_slice = [cube_z_coord] + horizontal_slice
+            else:
+                raise ValueError("Cube has multidimensional Z coordinate.")
         except iris.exceptions.CoordinateNotFoundError:
-            ref_to_slice = horizontal_slice
+            # no z coordinate, go on with 2d regridding
+            pass
     return get_representant(cube, ref_to_slice)
 
 

--- a/tests/unit/preprocessor/_regrid_esmpy/test_regrid_esmpy.py
+++ b/tests/unit/preprocessor/_regrid_esmpy/test_regrid_esmpy.py
@@ -292,7 +292,7 @@ class TestHelpers(tests.Test):
             shape=self.data_3d.shape,
             data=self.data_3d,
             coord=coord_3d,
-            coord_dims=lambda name: self.coord_dims[name],
+            coord_dims=lambda name: self.coord_dims_3d[name],
         )
         self.cube.__getitem__ = mock.Mock(return_value=self.cube)
 


### PR DESCRIPTION
This adds handling of scalar z coordinates to irregular regridding.

Fixes #865

Signed-off-by: Klaus Zimmermann <klaus.zimmermann@smhi.se>