### PR TITLE
Change maintainer for ocean recipes

### DIFF
--- a/esmvaltool/recipes/recipe_ocean_amoc.yml
+++ b/esmvaltool/recipes/recipe_ocean_amoc.yml
@@ -12,7 +12,7 @@ documentation:
     - demo_le
 
   maintainer:
-    - schl_ma
+    - demo_le
 
   references:
     - demora2018gmd

--- a/esmvaltool/recipes/recipe_ocean_bgc.yml
+++ b/esmvaltool/recipes/recipe_ocean_bgc.yml
@@ -11,6 +11,9 @@ documentation:
 
   authors:
     - demo_le
+  
+  maintainer:
+    - demo_le
 
   references:
     - demora2018gmd

--- a/esmvaltool/recipes/recipe_ocean_example.yml
+++ b/esmvaltool/recipes/recipe_ocean_example.yml
@@ -11,7 +11,7 @@ documentation:
     - demo_le
 
   maintainer:
-    - schl_ma
+    - demo_le
 
   references:
     - demora2018gmd

--- a/esmvaltool/recipes/recipe_ocean_ice_extent.yml
+++ b/esmvaltool/recipes/recipe_ocean_ice_extent.yml
@@ -9,7 +9,7 @@ documentation:
     - demo_le
 
   maintainer:
-    - schl_ma
+    - demo_le
 
   references:
     - demora2018gmd

--- a/esmvaltool/recipes/recipe_ocean_quadmap.yml
+++ b/esmvaltool/recipes/recipe_ocean_quadmap.yml
@@ -10,7 +10,7 @@ documentation:
     - demo_le
 
   maintainer:
-    - schl_ma
+    - demo_le
 
   references:
     - demora2018gmd

--- a/esmvaltool/recipes/recipe_ocean_scalar_fields.yml
+++ b/esmvaltool/recipes/recipe_ocean_scalar_fields.yml
@@ -12,7 +12,7 @@ documentation:
     - demo_le
 
   maintainer:
-    - schl_ma
+    - demo_le
 
   references:
     - demora2018gmd


### PR DESCRIPTION
@ledm since you are now in the core development team, it would make sense that you are the maintainer of the ocean recipes (so far this was done by @schlunma).

The task of the maintainers is to test their recipes whenever a significant change to the preprocessor or other core functionalities is to be merged. This means running the recipes and making sure there are no errors and, in some cases, also check the results (e.g., compare with a "reference-run" from `version2_development`).

See #774 for more details.

If you agree with this just approve the PR. Thanks! :beer: 