### PR TITLE
fix in project_style.ncl

### DIFF
--- a/esmvaltool/diag_scripts/shared/plot/style.ncl
+++ b/esmvaltool/diag_scripts/shared/plot/style.ncl
@@ -73,14 +73,6 @@ begin
   dkeys = (/"dataset", "ensemble", "exp", "mip"/)
   l_dkeys = new(dimsizes(dkeys), logical)
   l_dkeys = True
-  do jj = 0, dimsizes(dkeys) - 1
-    do ii = 0, ListCount(items) - 1
-      if (.not.isatt(items[ii], dkeys(jj))) then
-        l_dkeys(jj) = False
-        break
-      end if
-    end do
-  end do
   ckeys = dkeys(ind(l_dkeys))
 
   ; Style information for this flag available as diag_script_info@$flag$

--- a/esmvaltool/diag_scripts/shared/plot/style.ncl
+++ b/esmvaltool/diag_scripts/shared/plot/style.ncl
@@ -71,9 +71,6 @@ begin
 
   ; Check for the available dictonary keys to be used for the annotations
   dkeys = (/"dataset", "ensemble", "exp", "mip"/)
-  l_dkeys = new(dimsizes(dkeys), logical)
-  l_dkeys = True
-  ckeys = dkeys(ind(l_dkeys))
 
   ; Style information for this flag available as diag_script_info@$flag$
   if (isatt(info, flag)) then
@@ -105,12 +102,12 @@ begin
   if (flag.eq."annots") then
 
     ; Start with highest priority
-    result = metadata_att_as_array(items, ckeys(0))
+    result = metadata_att_as_array(items, dkeys(0))
 
     unique = get_unique_values(result)
     iprio = 1
     do while (dimsizes(unique) .ne. dimsizes(result))
-      if (iprio .eq. dimsizes(l_dkeys)) then
+      if (iprio .eq. dimsizes(dkeys)) then
         error_msg("w", scriptname, funcname, "non-unique labels in dataset" + \
                   "annotations")
         unique := result
@@ -118,7 +115,7 @@ begin
         do i = 0, dimsizes(unique) - 1
           index = ind(result .eq. unique(i))
           if (dimsizes(index) .gt. 1) then  ; More than one occurence
-            append = metadata_att_as_array(items, ckeys(iprio))
+            append = metadata_att_as_array(items, dkeys(iprio))
             result(index) = result(index) + "_" + append(index)
           end if
           delete(index)


### PR DESCRIPTION
Currently, an algorithm selects only those keys from (/"dataset", "ensemble", "exp", "mip"/) that appear in all datasets. This causes an error when certain keys that are needed for disambiguation are not present in all datasets, for example when multiple ensemble members from one model are used together with observations:

- {dataset: ACCESS1-3,  project: CMIP5,  exp: historical,  ensemble: r1i1p1,  ... }
- {dataset: ACCESS1-3,  project: CMIP5,  exp: rcp45,  ensemble: r2i1p1,  ... }
- {dataset: HadISST,  project: OBS,  type: reanaly,  version: 20130524,  ... }

Here, "exp" and/or "ensemble" keys are needed to define the ACCES1-3 styles, but are not passed in project_style.ncl, because these keys do not appear for HadISST.

The fix proposed here is to always pass the full list of keys and remove the selection algorithm.