### PR TITLE
Interactive jump into iPython after preprocessor

### DIFF
--- a/esmvaltool/_task.py
+++ b/esmvaltool/_task.py
@@ -431,6 +431,21 @@ class DiagnosticTask(BaseTask):
             output_files = []
             return output_files
 
+        # interactive scenario
+        if os.path.basename(self.script) == "ipython_diag.py":
+            cmd = list(self.cmd)
+            self.settings['input_files'] = [
+                f for f in input_files
+                if f.endswith('.yml') or os.path.isdir(f)
+            ]
+            settings_file = self.write_settings()
+            env = dict(os.environ)
+            cmd.append(settings_file)
+            logger.info("Running interactive command %s", cmd)
+            process = subprocess.Popen(cmd, env=env)
+            process.communicate()
+            return
+
         is_ncl_script = self.script.lower().endswith('.ncl')
         if is_ncl_script:
             self.settings['input_files'] = [

--- a/esmvaltool/diag_scripts/examples/ipython_diag.py
+++ b/esmvaltool/diag_scripts/examples/ipython_diag.py
@@ -1,0 +1,14 @@
+"""Barebone example of executing an interactive diagnostic."""
+from esmvaltool.diag_scripts.shared import run_diagnostic_interactive
+from IPython import embed
+
+
+def main(cfg):
+    """Function to jump into ipython."""
+    embed()
+
+
+if __name__ == '__main__':
+
+    with run_diagnostic_interactive() as config:
+        main(config)

--- a/esmvaltool/diag_scripts/shared/__init__.py
+++ b/esmvaltool/diag_scripts/shared/__init__.py
@@ -3,13 +3,16 @@ from . import io, iris_helpers, names, plot
 from ._base import (ProvenanceLogger, extract_variables, get_cfg,
                     get_diagnostic_filename, get_plot_filename, group_metadata,
                     run_diagnostic, select_metadata, sorted_group_metadata,
-                    sorted_metadata, variables_available)
+                    sorted_metadata, variables_available,
+                    run_diagnostic_interactive)
 from ._diag import Datasets, Variable, Variables
 from ._validation import apply_supermeans, get_control_exper_obs
 
 __all__ = [
     # Main entry point for diagnostics
     'run_diagnostic',
+    # interactive equivalent
+    'run_diagnostic_interactive',
     # Define output filenames
     'get_diagnostic_filename',
     'get_plot_filename',

--- a/esmvaltool/diag_scripts/shared/_base.py
+++ b/esmvaltool/diag_scripts/shared/_base.py
@@ -476,3 +476,19 @@ def run_diagnostic():
     yield cfg
 
     logger.info("End of diagnostic script run.")
+
+
+@contextlib.contextmanager
+def run_diagnostic_interactive():
+    """Interactive run of diagnostic."""
+    # Implemented as context manager so we can support clean up actions later
+    parser = argparse.ArgumentParser(description="Diagnostic script")
+    parser.add_argument('filename', help="Path to settings.yml")
+    args = parser.parse_args()
+
+    cfg = get_cfg(args.filename)
+
+    # Read input metadata
+    cfg['input_data'] = _get_input_data_files(cfg)
+
+    yield cfg

--- a/meta.yaml
+++ b/meta.yaml
@@ -47,6 +47,7 @@ requirements:
     - cython
     - eofs
     - esmpy
+    - ipython
     - matplotlib<3
     - nc-time-axis
     - netCDF4

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ REQUIREMENTS = {
         'cf_units',
         'cython',
         'scitools-iris',
+        'ipython',
         'matplotlib<3',
         'nc-time-axis',  # needed by iris.plot
         'netCDF4',


### PR DESCRIPTION
This is done at the recommendation of Rob Parker and I also think it's a good idea - @bouweandela and @mattiarighi surely you can add some improvements when you got some time to look - at the moment it dives straight into ipython right after preproc finishes inheriting all the `settings` and `env` inside the console so the user can play around with all the system variables and preproc/recipe settings already in as dicts; what I don't like is the fact that they are still nested dicts and not nicely broken down in separate variables but that sounds like a helluva lot of work to me. Anyways have a look!