### PR TITLE
Version2 clouds provenance

### DIFF
--- a/esmvaltool/diag_scripts/clouds/clouds.ncl
+++ b/esmvaltool/diag_scripts/clouds/clouds.ncl
@@ -1046,8 +1046,8 @@ begin
     do is = 0, numseas - 1
       caption = "Mean values for variable " + var0 \
                 + " (" + allseas + ")."
-      log_provenance(nc_outfile_mean, outfile(is), caption, statistics, domain, \
-                     plottype, "", "", climofiles)
+      log_provenance(nc_outfile_mean, outfile(is), caption, statistics, \
+                     domain, plottype, "", "", climofiles)
     end do
 
     ; ========================================================================
@@ -1193,9 +1193,9 @@ begin
       do is = 0, numseas - 1
         log_info(" Wrote " + outfile(is))
 
-        ; ------------------------------------------------------------------------
+        ; --------------------------------------------------------------------
         ; write provenance to netcdf output and plot file(s) (bias)
-        ; ------------------------------------------------------------------------
+        ; --------------------------------------------------------------------
 
         statistics = (/"clim", "diff"/)
         if (isatt(diag_script_info, "region")) then

--- a/esmvaltool/diag_scripts/clouds/clouds.ncl
+++ b/esmvaltool/diag_scripts/clouds/clouds.ncl
@@ -46,10 +46,10 @@
 ;   units:             variable units (for labeling plot only)
 ;
 ; Caveats
-;   TO DO (ESMValTool v2.0.0)
-;     1) get tags from namelist and write meta data to plots
+;   none
 ;
 ; Modification history
+;   20190220-A_laue_ax: added output of provenance (v2.0)
 ;   20181119-A_laue_ax: adapted code to multi-variable capable framework
 ;   20180923-A_laue_ax: added writing of results to netcdf
 ;   20180518-A_laue_ax: code rewritten for ESMValTool v2.0
@@ -67,8 +67,6 @@ load "$diag_scripts/shared/statistics.ncl"
 load "$diag_scripts/shared/plot/style.ncl"
 load "$diag_scripts/shared/plot/contour_maps.ncl"
 
-; load "$diag_scripts/shared/meta_data.ncl"
-
 begin
 
   enter_msg(DIAG_SCRIPT, "")
@@ -85,17 +83,6 @@ begin
   log_info("++++++++++++++++++++++++++++++++++++++++++")
   log_info(DIAG_SCRIPT + " (var: " + var0 + ")")
   log_info("++++++++++++++++++++++++++++++++++++++++++")
-
-  ; ###########################################
-  ; # references                    #
-  ; ###########################################
-  ; FIX-ME: to be replaced by new method
-  ; write_references(DIAG_SCRIPT,      \  ; script name
-  ;                  "A_laue_ax",      \  ; authors
-  ;                  "",               \  ; contributors
-  ;                  "D_lauer13jclim", \  ; diag_references
-  ;                  "",               \  ; obs_references
-  ;                  (/"P_embrace"/))     ; proj_references
 
   ; Set default values for non-required diag_script_info attributes
 
@@ -153,16 +140,11 @@ begin
 
   extralegend = diag_script_info@extralegend
 
-  ; make sure path for (optional) netcdf output exists
+  ; make sure path for (mandatory) netcdf output exists
 
-  if (config_user_info@write_netcdf.eq."True") then
-    write_nc = True
-    work_dir = config_user_info@work_dir + "/"
-    ; Create work dir
-    system("mkdir -p " + work_dir)
-  else
-    write_nc = False
-  end if
+  work_dir = config_user_info@work_dir + "/"
+  ; Create work dir
+  system("mkdir -p " + work_dir)
 
   if (config_user_info@write_plots.eq."True") then
     write_plots = True
@@ -184,18 +166,12 @@ begin
 
   climofiles = metadata_att_as_array(info0, "filename")
 
-;  if (isatt(diag_script_info, "region")) then
-;    alltags = array_append_record(tags, (/"PT_geo", "ST_clim", "DM_reg"/), 0)
-;  else
-;    alltags = array_append_record(tags, (/"PT_geo", "ST_clim", \
-;                                  "DM_global"/), 0)
-;  end if
-
   outfile = new(numseas, string)
+  outfile(:) = ""
 
   if (flag_diff) then
     outfile_d = new(numseas, string)
-;    difftags = array_append_record(alltags, (/"ST_diff"/), 0)
+    outfile_d(:) = ""
 
     ; check for reference model definition
     if (.not.isvar("refname")) then
@@ -216,7 +192,7 @@ end
 
 begin
   ; ###########################################
-  ; # get data and average time          #
+  ; # get data and average time               #
   ; ###########################################
 
   maps = new((/dim_MOD, 4/), graphic)
@@ -234,6 +210,13 @@ begin
   gavg = new((/numseas/), float)
   rmsd = new((/numseas/), float)
   bias = new((/numseas/), float)
+
+  ; filenames for netcdf output
+
+  nc_filename_bias = work_dir + "clouds_" + var0 + "_bias.nc"
+  nc_filename_bias@existing = "append"
+  nc_filename_mean = work_dir + "clouds_" + var0 + "_mean.nc"
+  nc_filename_mean@existing = "append"
 
   do ii = 0, dim_MOD - 1
 
@@ -400,7 +383,7 @@ begin
 
     ; specified in namelist
 
-    data1@res_mpProjection       = diag_script_info@projection
+    data1@res_mpProjection       = projection
 
     ; set explicit contour levels
 
@@ -429,10 +412,11 @@ begin
       data1@diag_script = (/DIAG_SCRIPT/)
     end if
 
-    data1@var = var0  ; Overwrite existing entry
     if (isatt(variable_info[0], "long_name")) then
       data1@var_long_name = variable_info[0]@long_name
     end if
+
+    data1@var = var0
 
     if (isatt(variable_info[0], "units")) then
       data1@var_units = variable_info[0]@units
@@ -510,7 +494,7 @@ begin
       ; difference plots will be saved to a different file
       if (flag_diff) then
         wks0d = get_wks("dummy_for_wks", DIAG_SCRIPT, "clouds_" + var0 + \
-                        "_diff_" + season(0) + filename_add)
+                        "_bias_" + season(0) + filename_add)
       end if
       if (numseas.gt.1) then
         wks1 = get_wks("dummy_for_wks", DIAG_SCRIPT, "clouds_" + var0 + \
@@ -522,11 +506,11 @@ begin
         ; difference plots will be saved to a different files
         if (flag_diff) then
           wks1d = get_wks("dummy_for_wks", DIAG_SCRIPT, "clouds_" + var0 + \
-                          "_diff_" + season(1) + filename_add)
+                          "_bias_" + season(1) + filename_add)
           wks2d = get_wks("dummy_for_wks", DIAG_SCRIPT, "clouds_" + var0 + \
-                          "_diff_" + season(2) + filename_add)
+                          "_bias_" + season(2) + filename_add)
           wks3d = get_wks("dummy_for_wks", DIAG_SCRIPT, "clouds_" + var0 + \
-                          "_diff_" + season(3) + filename_add)
+                          "_bias_" + season(3) + filename_add)
         end if
       end if
     end if
@@ -580,13 +564,10 @@ begin
       maps(imod, 0) = contour_map(wks0, data1, var0)
     end if
 
-    ; optional netcdf output
+    ; mandatory netcdf output
 
-    if (write_nc) then
-      nc_filename = work_dir + "clouds_" + var0 + "_" \
-                    + names(imod) + ".nc"
-      nc_outfile = ncdf_write(data1, nc_filename)
-    end if
+    data1@var = var0 + "_mean_" + names(imod)
+    nc_outfile_mean = ncdf_write(data1, nc_filename_mean)
 
     ; =======================================================================
     ; Create difference plots (if requested)
@@ -796,7 +777,7 @@ begin
 
       ; specified in namelist
 
-      diff@res_mpProjection       = diag_script_info@projection
+      diff@res_mpProjection       = projection
 
       ; set explicit contour levels
 
@@ -813,7 +794,6 @@ begin
       ; ###########################################
       ; add to diff as attributes without prefix
 
-      diff@var = var0  ; Overwrite existing entry
       if (isatt(variable_info, "long_name")) then
         diff@var_long_name = variable_info@long_name
       end if
@@ -872,13 +852,10 @@ begin
         maps_d(imod, 0) = contour_map(wks0d, diff, var0)
       end if
 
-      ; optional netcdf output
+      ; mandatory netcdf output
 
-      if (write_nc) then
-        nc_filename = work_dir + "clouds_" + var0 + "_bias_" \
-                      + names(imod) + ".nc"
-        nc_outfile = ncdf_write(diff, nc_filename)
-      end if
+      diff@var = var0 + "_bias_" + names(imod)
+      nc_outfile_bias = ncdf_write(diff, nc_filename_bias)
 
     end if  ; if flag_diff
 
@@ -1045,18 +1022,25 @@ begin
 
     do is = 0, numseas - 1
       log_info("Wrote " + outfile(is))
+    end do
 
-      ; add meta data to plot (for reporting)
+    ; ------------------------------------------------------------------------
+    ; write provenance to netcdf output and plot file(s) (mean)
+    ; ------------------------------------------------------------------------
 
+    statistics = (/"clim", "mean"/)
+    if (isatt(diag_script_info, "region")) then
+      domain = ("reg")
+    else
+      domain = ("glob")
+    end if
+    plottype = ("geo")
+
+    do is = 0, numseas - 1
       caption = "Mean values for variable " + var0 \
                 + " (" + season(is) + ")."
-      id = DIAG_SCRIPT + "_" + var0 + "_" + season(is)
-
-      contrib_authors = "A_laue_ax"
-
-;      ESMValMD(outfile(is), alltags, caption, id, var0, \
-;               names, climofiles, DIAG_SCRIPT, \
-;               contrib_authors)
+      log_provenance(nc_outfile_mean, outfile(is), caption, statistics, domain, \
+                     plottype, "", "", climofiles)
     end do
 
     ; ========================================================================
@@ -1202,18 +1186,23 @@ begin
       do is = 0, numseas - 1
         log_info(" Wrote " + outfile(is))
 
-        ; add meta data to plot (for reporting)
+        ; ------------------------------------------------------------------------
+        ; write provenance to netcdf output and plot file(s) (bias)
+        ; ------------------------------------------------------------------------
+
+        statistics = (/"clim", "diff"/)
+        if (isatt(diag_script_info, "region")) then
+          domain = ("reg")
+        else
+          domain = ("glob")
+        end if
+        plottype = ("geo")
 
         caption = "Differences for variable " + var0 \
                   + " (" + season(is) + "), reference = " \
                   + refname + "."
-        id = DIAG_SCRIPT + "_" + var0 + "_diff_" + season(is)
-
-        contrib_authors = "A_laue_ax"
-
-;        ESMValMD(outfile_d(is), difftags, caption, id, var0, \
-;                 names, climofiles, DIAG_SCRIPT, \
-;                 contrib_authors)
+        log_provenance(nc_outfile_bias, outfile_d(is), caption, statistics, \
+                       domain, plottype, "", "", climofiles)
       end do
 
     end if  ; if flag_diff

--- a/esmvaltool/diag_scripts/clouds/clouds.ncl
+++ b/esmvaltool/diag_scripts/clouds/clouds.ncl
@@ -134,6 +134,13 @@ begin
     season = (/"DJF", "MAM", "JJA", "SON"/)
   end if
 
+  ; create string for caption (netcdf provenance)
+
+  allseas = season(0)
+  do is = 1, numseas - 1
+    allseas = allseas + "/" + season(i)
+  end do
+
   panel_labels = diag_script_info@panel_labels
 
   treat_var_as_error = diag_script_info@treat_var_as_error
@@ -1038,7 +1045,7 @@ begin
 
     do is = 0, numseas - 1
       caption = "Mean values for variable " + var0 \
-                + " (" + season(is) + ")."
+                + " (" + allseas + ")."
       log_provenance(nc_outfile_mean, outfile(is), caption, statistics, domain, \
                      plottype, "", "", climofiles)
     end do
@@ -1198,9 +1205,13 @@ begin
         end if
         plottype = ("geo")
 
+        ; note: because function log_provenance does not yet support to attach
+        ;       different captions to netcdf (contains all seasons) and plots
+        ;       (contain one season each), the caption cannot specifiy the
+        ;       season plotted; using "annual" or "DJF/MAM/JJA/SON" instead.
+
         caption = "Differences for variable " + var0 \
-                  + " (" + season(is) + "), reference = " \
-                  + refname + "."
+                  + " (" + allseas + "), reference = " + refname + "."
         log_provenance(nc_outfile_bias, outfile_d(is), caption, statistics, \
                        domain, plottype, "", "", climofiles)
       end do

--- a/esmvaltool/diag_scripts/clouds/clouds_bias.ncl
+++ b/esmvaltool/diag_scripts/clouds/clouds_bias.ncl
@@ -438,11 +438,11 @@ begin
   domain = ("glob")
   plottype = ("geo")
   prov_caption = caption + " for variable " + var0 \
-                 + " (" + allseas + "), reference = " + names(ref_ind) + "."
+    + " (" + allseas + "), reference = " + names(ref_ind) + "."
 
   do is = 0, numseas - 1
-    log_provenance(nc_outfile, plotfile(is), prov_caption, statistics, domain, \
-                   plottype, "", "", climofiles)
+    log_provenance(nc_outfile, plotfile(is), prov_caption, statistics, \
+                   domain, plottype, "", "", climofiles)
   end do
 
   leave_msg(DIAG_SCRIPT, "")

--- a/esmvaltool/diag_scripts/clouds/clouds_bias.ncl
+++ b/esmvaltool/diag_scripts/clouds/clouds_bias.ncl
@@ -437,11 +437,11 @@ begin
   statistics = (/"clim", "diff"/)
   domain = ("glob")
   plottype = ("geo")
+  prov_caption = caption + " for variable " + var0 \
+                 + " (" + allseas + "), reference = " + names(ref_ind) + "."
 
   do is = 0, numseas - 1
-    prov_caption = caption + " for variable " + var0 \
-      + " (" + allseas + "), reference = " + names(ref_ind) + "."
-    log_provenance(nc_outfile, plotfile(is), caption, statistics, domain, \
+    log_provenance(nc_outfile, plotfile(is), prov_caption, statistics, domain, \
                    plottype, "", "", climofiles)
   end do
 

--- a/esmvaltool/diag_scripts/clouds/clouds_bias.ncl
+++ b/esmvaltool/diag_scripts/clouds/clouds_bias.ncl
@@ -25,10 +25,10 @@
 ;   long_name: description of variable
 ;
 ; Caveats
-;   TO DO (ESMValTool v2.0.0)
-;   1) get tags from namelist and write meta data to plots
+;   none
 ;
 ; Modification history
+;   20190222-A_laue_ax: added output of provenance (v2.0)
 ;   20181119-A_laue_ax: adapted code to multi-variable capable framework
 ;   20180923-A_laue_ax: added writing of results to netcdf
 ;   20180914-A_laue_ax: code rewritten for ESMValTool v2.0
@@ -47,8 +47,6 @@ load "$diag_scripts/shared/statistics.ncl"
 load "$diag_scripts/shared/plot/style.ncl"
 load "$diag_scripts/shared/plot/contour_maps.ncl"
 
-; load "$diag_scripts/shared/meta_data.ncl"
-
 begin
 
   enter_msg(DIAG_SCRIPT, "")
@@ -65,17 +63,6 @@ begin
   log_info("++++++++++++++++++++++++++++++++++++++++++")
   log_info(DIAG_SCRIPT + " (var: " + var0 + ")")
   log_info("++++++++++++++++++++++++++++++++++++++++++")
-
-  ; ========================================================================
-  ; ========================= write references =============================
-  ; ========================================================================
-  ; FIX-ME: to be replaced by new method
-  ; write_references(DIAG_SCRIPT,  \   ; script name
-  ;                  "A_laue_ax",  \   ; authors
-  ;                  "",  \            ; contributors
-  ;                  "",  \            ; diag_references
-  ;                  "",  \            ; obs_references
-  ;                  (/"P_embrace"/))  ; proj_references
 
   ; time averaging: at the moment, only "annualclim" and "seasonalclim"
   ; are supported
@@ -96,16 +83,18 @@ begin
     season = (/"annual"/)
   end if
 
-  ; make sure path for (optional) netcdf output exists
+  ; create string for caption (netcdf provenance)
 
-  if (config_user_info@write_netcdf.eq."True") then
-    write_nc = True
-    work_dir = config_user_info@work_dir + "/"
-    ; Create work dir
-    system("mkdir -p " + work_dir)
-  else
-    write_nc = False
-  end if
+  allseas = season(0)
+  do is = 1, numseas - 1
+    allseas = allseas + "/" + season(i)
+  end do
+
+  ; make sure path for (mandatory) netcdf output exists
+
+  work_dir = config_user_info@work_dir + "/"
+  ; Create work dir
+  system("mkdir -p " + work_dir)
 
   if (config_user_info@write_plots.eq."True") then
     write_plots = True
@@ -197,9 +186,6 @@ begin
   climofiles = new(2, string)
   climofiles(0) = infiles(mm_ind)
   climofiles(1) = infiles(ref_ind)
-
-;  alltags = array_append_record(tags, (/"PT_geo", "ST_clim", "ST_diff", \
-;                                        "DM_global"/), 0)
 
   diff@res_gsnMaximize  = True  ; use full page for the plot
   diff@res_cnFillOn  = True  ; color plot desired
@@ -362,6 +348,9 @@ begin
   pres@gsnPanelYWhiteSpacePercent = 5
   pres@gsnPanelXWhiteSpacePercent = 5
 
+  plotfile = new(numseas, string)
+  plotfile(:) = ""
+
   if (write_plots) then
     do is = 0, numseas - 1
       ; --------------------------------------------------------------------
@@ -373,6 +362,8 @@ begin
 
       wks = get_wks("dummy_for_wks", DIAG_SCRIPT, "clouds_bias_" + var0 \
                     + "_" + season(is))
+
+      plotfile(is) = wks@fullname
 
       if (numseas.gt.1) then
         pres@txString = season(is)
@@ -407,37 +398,52 @@ begin
       if (plot_rel_diff) then
         caption = caption + ", relative error"
       end if
-      caption = caption + " for variable " + var0 \
-        + " (" + season(is) + "), reference = " + names(ref_ind) + "."
-      id = DIAG_SCRIPT + "_" + var0 + "_" + season(is)
-
-      contrib_authors = "A_laue_ax"
-
-;      ESMValMD(wks@fullname, alltags, caption, id, var0, \
-;               names, climofiles, DIAG_SCRIPT, \
-;               contrib_authors)
 
     end do  ; is-loop (seasons)
   end if  ; if write_plots
 
   ; ###########################################
-  ; # Optional output to netCDF  #
+  ; # output to netCDF                        #
   ; ###########################################
 
-  if (write_nc) then
-    nc_filename = work_dir + "clouds_bias_mmm_" + var0 + ".nc"
-    nc_outfile = ncdf_write(mmdata, nc_filename)
-    nc_filename = work_dir + "clouds_bias_diff_" + var0 + ".nc"
-    nc_outfile = ncdf_write(diff, nc_filename)
-    if (isvar("absdiff")) then
-      nc_filename = work_dir + "clouds_bias_abs_diff_" + var0 + ".nc"
-      nc_outfile = ncdf_write(absdiff, nc_filename)
-    end if
-    if (isvar("reldiff")) then
-      nc_filename = work_dir + "clouds_bias_rel_diff_" + var0 + ".nc"
-      nc_outfile = ncdf_write(reldiff, nc_filename)
-    end if
+  nc_filename = work_dir + "clouds_bias_" + var0 + ".nc"
+  nc_filename@existing = "append"
+
+  mmdata@var = var0 + "_mean"
+  mmdata@long_name = var0 + " (multi-model mean)"
+  nc_outfile = ncdf_write(mmdata, nc_filename)
+
+  diff@var = var0 + "_bias"
+  diff@long_name = var0 + " (multi-model bias)"
+  nc_outfile = ncdf_write(diff, nc_filename)
+
+  if (isvar("absdiff")) then
+    absdiff@var = var0 + "_abs_bias"
+    absdiff@long_name = var0 + " (multi-model absolute bias)"
+    nc_outfile = ncdf_write(absdiff, nc_filename)
   end if
+
+  if (isvar("reldiff")) then
+    reldiff@var = var0 + "_rel_bias"
+    reldiff@long_name = var0 + " (multi-model relative bias)"
+    reldiff@units = reldiff@units
+    nc_outfile = ncdf_write(reldiff, nc_filename)
+  end if
+
+  ; ------------------------------------------------------------------------
+  ; write provenance to netcdf output and plot file(s) (mean)
+  ; ------------------------------------------------------------------------
+
+  statistics = (/"clim", "diff"/)
+  domain = ("glob")
+  plottype = ("geo")
+
+  do is = 0, numseas - 1
+    prov_caption = caption + " for variable " + var0 \
+      + " (" + allseas + "), reference = " + names(ref_ind) + "."
+    log_provenance(nc_outfile, plotfile(is), caption, statistics, domain, \
+                   plottype, "", "", climofiles)
+  end do
 
   leave_msg(DIAG_SCRIPT, "")
 

--- a/esmvaltool/diag_scripts/clouds/clouds_interannual.ncl
+++ b/esmvaltool/diag_scripts/clouds/clouds_interannual.ncl
@@ -153,6 +153,12 @@ begin
       error_msg("f", DIAG_SCRIPT, "", "no lon dimension")
     end if
 
+    if (var0.eq."pr") then
+      ; convert from kg m-2 s-1 to mm day-1
+      A0 = A0 * 86400.0
+      A0@units = "mm day-1"
+    end if
+
     ; subtract climatological seasonal cycle from time series
 
     if (isvar("timeseries")) then
@@ -230,12 +236,6 @@ begin
       data1@res_mpLandFillColor    = "Black"
 ;      delete(pal)
 ;      pal = read_colormap_file("$diag_scripts/shared/plot/rgb/qcm3.rgb")
-    end if
-
-    if (var0.eq."pr") then
-      ; convert from kg m-2 s-1 to mm day-1
-      data1 = data1 * 86400.0
-      data1@units = "mm day-1"
     end if
 
     nboxes = dimsizes(data1@res_cnLevels)

--- a/esmvaltool/diag_scripts/clouds/clouds_interannual.ncl
+++ b/esmvaltool/diag_scripts/clouds/clouds_interannual.ncl
@@ -26,10 +26,10 @@
 ;   reference_dataset: name of reference datatset
 ;
 ; Caveats
-;   TO DO (ESMValTool v2.0.0)
-;     1) get tags from namelist and write meta data to plots
+;   none
 ;
 ; Modification history
+;   20190220-A_laue_ax: added provenance to output (v2.0)
 ;   20181120-A_laue_ax: adapted code to multi-variable capable framework
 ;   20180923-A_laue_ax: added writing of results to netcdf
 ;   20180611-A_laue_ax: code rewritten for ESMValTool v2.0
@@ -55,8 +55,6 @@ load "$diag_scripts/shared/statistics.ncl"
 load "$diag_scripts/shared/plot/style.ncl"
 load "$diag_scripts/shared/plot/contour_maps.ncl"
 
-; load "$diag_scripts/lib/ncl/meta_data.ncl"
-
 begin
   enter_msg(DIAG_SCRIPT, "")
 
@@ -73,39 +71,17 @@ begin
   log_info(DIAG_SCRIPT + " (var: " + var0 + ")")
   log_info("++++++++++++++++++++++++++++++++++++++++++")
 
-  ; ###############################
-  ; define diagnostic specific tags
-  ; ###############################
-
-  diag_tags = (/"PT_geo", "DM_global", "ST_clim", "ST_var"/)
-
-  ; ###########################################
-  ; # references                              #
-  ; ###########################################
-  ; FIX-ME: to be replaced by new method
-  ; write_references(DIAG_SCRIPT,      \  ; script name
-  ;                  "A_laue_ax",      \  ; authors
-  ;                  "",               \  ; contributors
-  ;                  "D_lauer13jclim", \  ; diag_references
-  ;                  "",               \  ; obs_references
-  ;                  (/"P_embrace"/))     ; proj_references
-
   set_default_att(diag_script_info, "colormap", "WhiteBlueGreenYellowRed")
   set_default_att(diag_script_info, "extrafiles", False)
   set_default_att(diag_script_info, "projection", "CylindricalEquidistant")
 
   extrafiles = diag_script_info@extrafiles
 
-  ; make sure path for (optional) netcdf output exists
+  ; make sure path for (mandatory) netcdf output exists
 
-  if (config_user_info@write_netcdf.eq."True") then
-    write_nc = True
-    work_dir = config_user_info@work_dir + "/"
-    ; Create work dir
-    system("mkdir -p " + work_dir)
-  else
-    write_nc = False
-  end if
+  work_dir = config_user_info@work_dir + "/"
+  ; Create work dir
+  system("mkdir -p " + work_dir)
 
   if (config_user_info@write_plots.eq."True") then
     write_plots = True
@@ -139,11 +115,11 @@ begin
     ind_all_sorted(1:dim_MOD - 1) = ind_wo_ref
   end if
 
+  maps = new(dim_MOD, graphic)  ; collect individual maps in a graphic array
+
   ; ###########################################
   ; # get data and average time               #
   ; ###########################################
-
-  maps = new(dim_MOD, graphic)  ; collect individual maps in a graphic array
 
   do ii = 0, dim_MOD - 1
 
@@ -305,10 +281,17 @@ begin
       data1@diag_script = (/DIAG_SCRIPT/)
     end if
     data1@var = var0  ; Overwrite existing entry
-    if (isatt(variable_info, "long_name")) then
-      data1@var_long_name = variable_info@long_name
+    if (isatt(variable_info[0], "long_name")) then
+      data1@var_long_name = variable_info[0]@long_name
+    else
+      data1@var_long_name = var0
     end if
     data1@var_units    = "%"
+
+    ; copy attributes for netCDF output
+
+    data1@long_name = "interannual variability " + data1@var_long_name
+    data1@units = data1@var_units
 
     ; ###########################################
     ; # create the plot                         #
@@ -337,42 +320,55 @@ begin
 
     maps(ii) = contour_map(wks, data1, var0)
 
-    ; ###########################################
-    ; # optional output to netCDF               #
-    ; ###########################################
+    if (extrafiles) then
+      if (write_plots) then  ; add labels
+        txres = True
+        txres@txFontHeightF = 0.03
+        txres@txJust = "BottomRight"
+        txres@txPerimOn = True
+        txres@txBackgroundFillColor = "white"
+        text = gsn_add_text(wks, maps(ii), annots(imod), 170, -80, txres)
+        draw(maps(ii))
+        frame(wks)
+        plotfile = maps@outfile
+      else
+        plotfile = ""
+      end if
 
-    if (write_nc) then
+      ; ##########################################
+      ; # output each dataset to separate netCDF #
+      ; ##########################################
+
       nc_filename = work_dir + "clouds_interannual_" + var0 + "_" \
-                    + names(imod) + ".nc"
+                    + annots(imod) + ".nc"
       nc_outfile = ncdf_write(data1, nc_filename)
-    end if
 
-    if (write_plots .and. extrafiles) then  ; add labels
-      txres = True
-      txres@txFontHeightF = 0.03
-      txres@txJust = "BottomRight"
-      txres@txPerimOn = True
-      txres@txBackgroundFillColor = "white"
-      text = gsn_add_text(wks, maps(ii), annots(imod), 170, -80, txres)
-      draw(maps(ii))
-      frame(wks)
+      ; -------------------------------------------------------------------
+      ; write provenance info
+      ; -------------------------------------------------------------------
 
-      ; *** add meta data for reporting to plots ***
-
-;      alltags = array_append_record(tags, diag_tags, 0)
-      caption = "Interannual variability of variable " + var0 + \
-        " from dataset " + names(imod) + "."
-      id = DIAG_SCRIPT + "_" + names(imod)
+      statistics = (/"clim", "var"/)
+      domain = ("glob")
+      plottype = ("geo")
       climofile = infiles(imod)
-      contrib_authors = "A_laue_ax"
+      caption = "Interannual variability of variable " + var0 + \
+                " from dataset " + annots(imod) + "."
 
-;      ESMValMD(maps@outfile, alltags, caption, id, var0, \
-;               name(imod), climofile, DIAG_SCRIPT, \
-;               contrib_authors)
+      log_provenance(nc_outfile, plotfile, caption, statistics, domain, \
+                     plottype, "", "", climofile)
 
-;      delete([/alltags, caption, id, climofile/])
+    else  ; extrafiles .eq. false
 
-    end if
+      ; #########################################
+      ; # output all datasets to common netCDF  #
+      ; #########################################
+
+      nc_filename = work_dir + "clouds_interannual_" + var0 + ".nc"
+      nc_filename@existing = "append"
+      data1@var = var0 + "_var_" + annots(imod)
+      nc_outfile = ncdf_write(data1, nc_filename)
+
+    end if  ; if extrafiles
   end do  ; ii-loop (datasets)
 
   if (write_plots) then
@@ -416,23 +412,24 @@ begin
     else
       outfile = panelling(wks, maps, (dim_MOD + 3) / 4, 4, pres)
       log_info(" Wrote " + outfile)
-
-;      alltags = array_append_record(tags, diag_tags, 0)
-        caption = "Interannual variability of variable " + var0 + "."
-        id = DIAG_SCRIPT + "_" + var0 + "_all_models"
-
-        climofiles = new(dim_MOD, string)
-        climofiles = infiles
-        contrib_authors = "A_laue_ax"
-
-;        ESMValMD(outfile, alltags, caption, id, var0, \
-;                 names, climofiles, DIAG_SCRIPT, \
-;                 contrib_authors)
-;
-;        delete([/alltags, caption, id, climofiles/])
-
     end if
+  else
+    outfile = ""
   end if  ; if write_plots
+
+  ; ------------------------------------------------------------------------
+  ; write provenance to common netcdf and plot file
+  ; ------------------------------------------------------------------------
+
+  if (.not. extrafiles) then
+    statistics = (/"clim", "var"/)
+    domain = ("glob")
+    plottype = ("geo")
+    caption = "Interannual variability of variable " + var0 + "."
+
+    log_provenance(nc_outfile, outfile, caption, statistics, domain, \
+                   plottype, "", "", infiles)
+  end if
 
   leave_msg(DIAG_SCRIPT, "")
 

--- a/esmvaltool/diag_scripts/clouds/clouds_interannual.ncl
+++ b/esmvaltool/diag_scripts/clouds/clouds_interannual.ncl
@@ -346,7 +346,7 @@ begin
       ; ##########################################
 
       nc_filename = work_dir + "clouds_interannual_" + var0 + "_" \
-                    + annots(imod) + ".nc"
+        + annots(imod) + ".nc"
       nc_outfile = ncdf_write(data1, nc_filename)
 
       ; -------------------------------------------------------------------

--- a/esmvaltool/diag_scripts/clouds/clouds_interannual.ncl
+++ b/esmvaltool/diag_scripts/clouds/clouds_interannual.ncl
@@ -232,6 +232,12 @@ begin
 ;      pal = read_colormap_file("$diag_scripts/shared/plot/rgb/qcm3.rgb")
     end if
 
+    if (var0.eq."pr") then
+      ; convert from kg m-2 s-1 to mm day-1
+      data1 = data1 * 86400.0
+      data1@units = "mm day-1"
+    end if
+
     nboxes = dimsizes(data1@res_cnLevels)
     clen = dimsizes(pal)
     stride = max((/1, ((clen(0)-1) - 2) / nboxes /))

--- a/esmvaltool/diag_scripts/clouds/clouds_ipcc.ncl
+++ b/esmvaltool/diag_scripts/clouds/clouds_ipcc.ncl
@@ -37,13 +37,20 @@
 ;   units:              variable units
 ;
 ; Caveats
-;   TO DO (ESMValTool v2.0.0)
-;     1) get tags from namelist and write meta data to plots
 ;   KNOWN ISSUES
 ;     1) specifying more than one data set for the observational uncertainties
-;       my lead to unexpected or undefined results
+;        may lead to unexpected or undefined results
+;     2) Bias and zonal means cannot be written to the same netCDF because
+;        function ncdf_write does not support writing variables with different
+;        dimensions to the same output file yet. As the Python function for
+;        writing the provenance information called by function log_provenance
+;        does not support different captions for netCDF and (associated)
+;        plotfile, the caption does not represent the contents of the netCDF
+;        exactly but rather those of the plot. The data used for creating the
+;        plot is written to 2 separate netCDFs.
 ;
 ; Modification history
+;   20190222-A_laue_ax: added output of provenance (v2.0)
 ;   20181119-A_laue_ax: adapted code to multi-variable capable framework
 ;   20180923-A_laue_ax: added writing of results to netcdf
 ;   20180529-A_laue_ax: code rewritten for ESMValTool v2.0
@@ -62,8 +69,6 @@ load "$diag_scripts/../interface_scripts/interface.ncl"
 load "$diag_scripts/shared/statistics.ncl"
 load "$diag_scripts/shared/plot/style.ncl"
 load "$diag_scripts/shared/plot/contour_maps.ncl"
-
-; load "$diag_scripts/lib/ncl/meta_data.ncl"
 
 begin
 
@@ -120,17 +125,6 @@ begin
   log_info(DIAG_SCRIPT + " (var: " + var0 + ")")
   log_info("++++++++++++++++++++++++++++++++++++++++++")
 
-  ; ========================================================================
-  ; ========================= write references =============================
-  ; ========================================================================
-  ; FIX-ME: to be replaced by new method
-  ; write_references(DIAG_SCRIPT,    \   ; script name
-  ;                  "A_laue_ax",    \   ; authors
-  ;                  "",             \   ; contributors
-  ;                  "",             \   ; diag_references
-  ;                  "",             \   ; obs_references
-  ;                  (/"P_embrace"/))    ; proj_references
-
   ; Set default values for non-required diag_script_info attributes
   set_default_att(diag_script_info, "mask_ts_sea_ice", False)
   set_default_att(diag_script_info, "projection", "CylindricalEquidistant")
@@ -151,16 +145,19 @@ begin
     season = (/"DJF", "MAM", "JJA", "SON"/)
   end if
 
-  ; make sure path for (optional) netcdf output exists
+  ; create string for caption (netcdf provenance)
 
-  if (config_user_info@write_netcdf.eq."True") then
-    write_nc = True
-    work_dir = config_user_info@work_dir + "/"
-    ; Create work dir
-    system("mkdir -p " + work_dir)
-  else
-    write_nc = False
-  end if
+  allseas = season(0)
+  do is = 1, numseas - 1
+    allseas = allseas + "/" + season(i)
+  end do
+
+  ; make sure path for (mandatory) netcdf output exists
+
+  write_nc = True
+  work_dir = config_user_info@work_dir + "/"
+  ; Create work dir
+  system("mkdir -p " + work_dir)
 
   if (config_user_info@write_plots.eq."True") then
     write_plots = True
@@ -484,9 +481,6 @@ begin
     cnLevels = fspan(min(diff), max(diff), 20)
   end if
 
-;  alltags = array_append_record(tags, (/"PT_geo", "PT_zonal", "ST_clim", \
-;                                        "DM_global"/), 0)
-
   diff@diag_script = DIAG_SCRIPT
   diff@res = True
 
@@ -565,6 +559,8 @@ begin
   end if
 
   plots = new((/2, numseas/), graphic)
+  plotfile = new(numseas, string)
+  plotfile(:) = ""
 
   do is = 0, numseas - 1
 
@@ -716,40 +712,49 @@ begin
       outfile = panelling(wks, plots(:, is), 1, 2, pres)
       log_info("Wrote " + wks@fullname)
 
-      ; add meta data to plot (for reporting)
-
-      caption = "Multi model mean bias (left) and zonal averages (right) " \
-                + "for variable " + var0 + " (" + season(is) \
-                + "), reference = " + names(ref_ind) + "."
-      id = DIAG_SCRIPT + "_" + var0 + "_" + season(is)
-
-      contrib_authors = "A_laue_ax"
-
-;      ESMValMD(wks@fullname, alltags, caption, id, var0, \
-;               names, climofiles, DIAG_SCRIPT, \
-;               contrib_authors)
-
+      plotfile(is) = wks@fullname
     end if  ; if write_plots
   end do  ; is-loop (seasons)
 
   ; ###########################################
-  ; # Optional output to netCDF               #
+  ; # Output to netCDF                        #
   ; ###########################################
 
-  if (write_nc) then
-    nc_filename = work_dir + "clouds_ipcc_" + var0 + ".nc"
-    nc_outfile = ncdf_write(diff, nc_filename)
-    nc_filename = work_dir + "clouds_ipcc_zonal_means_" + var0 + ".nc"
-    zonalmean@var = var0
-    zonalmean@diag_script = DIAG_SCRIPT
-    nc_outfile = ncdf_write(zonalmean, nc_filename)
-    if (isvar("err_zm")) then
-      nc_filename = work_dir + "clouds_ipcc_error_zonal_means_" + var0 + ".nc"
-      err_zm@var = var1
-      err_zm@diag_script = DIAG_SCRIPT
-      nc_outfile = ncdf_write(err_zm, nc_filename)
-    end if
+  ; note: function ncdf_write currently does not support writing variables
+  ;       diff and zonalmean to the same netCDF.
+
+  nc_filename = work_dir + "clouds_ipcc_" + var0 + "_bias.nc"
+  diff@var = var0 + "_bias"
+  diff@diag_script = DIAG_SCRIPT
+  nc_outfile_bias = ncdf_write(diff, nc_filename)
+
+  nc_filename = work_dir + "clouds_ipcc_" + var0 + "_zonal.nc"
+  nc_filename@existing = "append"
+  zonalmean@var = var0 + "_zonal"
+  zonalmean@diag_script = DIAG_SCRIPT
+  nc_outfile_zonal = ncdf_write(zonalmean, nc_filename)
+  if (isvar("err_zm")) then
+    err_zm@var = var1 + "_zonal"
+    nc_outfile_zonal = ncdf_write(err_zm, nc_filename)
   end if
+
+  ; ------------------------------------------------------------------------
+  ; write provenance to netcdf output and plot file(s)
+  ; ------------------------------------------------------------------------
+
+  statistics = ("clim")
+  domain = ("glob")
+  plottype = (/"geo", "zonal"/)
+  caption = "Multi model mean bias (left) and zonal averages (right) " \
+            + "for variable " + var0 + " (" + allseas \
+            + "), reference = " + names(ref_ind) + "."
+
+  do is = 0, numseas - 1
+    log_provenance(nc_outfile_bias, plotfile(is), caption, statistics, \
+                   domain, plottype, "", "", climofiles)
+    log_provenance(nc_outfile_zonal, plotfile(is), caption, statistics, \
+                   domain, plottype, "", "", climofiles)
+  end do
 
   leave_msg(DIAG_SCRIPT, "")
 

--- a/esmvaltool/diag_scripts/clouds/clouds_taylor.ncl
+++ b/esmvaltool/diag_scripts/clouds/clouds_taylor.ncl
@@ -55,9 +55,7 @@
 ;   none
 ;
 ; Caveats
-;   TO DO (ESMValTool v2.0.0)
-;     1) get tags from namelist and write meta data to plots
-;   KNOWN LIMITATIONS (all versions)
+;   KNOWN LIMITATIONS
 ;     1) only 2-dim variables are currently supported
 ;     2) observational uncertainties are regridded like standard variables
 ;     3) for derived variables (e.g. SW_CRE), also the original variables have
@@ -69,6 +67,7 @@
 ;        variable has been calculated from) the *second* (third, ...)
 ;
 ; Modification history
+;   20190221-A_laue_ax: added provenance to output (v2.0)
 ;   20181120-A_laue_ax: adapted code to multi-variable capable framework
 ;   20180923-A_laue_ax: added writing of results to netcdf
 ;   20180611-A_laue_ax: code rewritten for ESMValTool v2.0
@@ -92,8 +91,6 @@ load "$diag_scripts/shared/plot/aux_plotting.ncl"
 load "$diag_scripts/shared/statistics.ncl"
 load "$diag_scripts/shared/plot/style.ncl"
 load "$diag_scripts/shared/plot/taylor_diagram_less_hardcoded.ncl"
-
-; load "$diag_scripts/lib/ncl/meta_data.ncl"
 
 begin
 
@@ -216,17 +213,6 @@ begin
     delete(auxind)
   end if
 
-  ; ========================================================================
-  ; ========================= write references =============================
-  ; ========================================================================
-  ; FIX-ME: to be replaced by new method
-  ; write_references(DIAG_SCRIPT,      \  ; script name
-  ;                  "A_laue_ax",      \  ; authors
-  ;                  "",               \  ; contributors
-  ;                  "D_lauer13jclim", \  ; diag_references
-  ;                  "",               \  ; obs_references
-  ;                  (/"P_embrace"/))     ; proj_references
-
   ; time averaging: at the moment, only "annualclim" and "seasonalclim"
   ; are supported
 
@@ -240,16 +226,18 @@ begin
     season = (/"DJF", "MAM", "JJA", "SON"/)
   end if
 
-  ; make sure path for (optional) netcdf output exists
+  ; create string for caption (netcdf provenance)
 
-  if (config_user_info@write_netcdf.eq."True") then
-    write_nc = True
-    work_dir = config_user_info@work_dir + "/"
-    ; Create work dir
-    system("mkdir -p " + work_dir)
-  else
-    write_nc = False
-  end if
+  allseas = season(0)
+  do is = 1, numseas - 1
+    allseas = allseas + "/" + season(i)
+  end do
+
+  ; make sure path for (mandatory) netcdf output exists
+
+  work_dir = config_user_info@work_dir + "/"
+  ; Create work dir
+  system("mkdir -p " + work_dir)
 
   if (config_user_info@write_plots.eq."True") then
     write_plots = True
@@ -693,9 +681,6 @@ begin
   ; ============================= plotting =================================
   ; ========================================================================
 
-;  alltags = array_append_record(tags, (/"PT_taylor", "DM_global",
-;                                "ST_clim"/), 0)
-
   nummods = dim_MOD - dim_REF
 
   colors  = new(nummods, string)
@@ -719,6 +704,8 @@ begin
                  "(/0.50, 0.50, 0.50/)", "(/0.30, 0.30, 0.30/)"/)
     markertab = (/16, 4, 5, 0/)
   end if
+
+  plotfile = new((/numseas/), string)
 
   do is = 0, numseas - 1
     if (isvar("wks")) then
@@ -889,36 +876,46 @@ begin
       plot = taylor_diagram(wks, legendwks, ratio(:, :, is), cc(:, :, is), \
                             ropts)
 
-      log_info("Wrote " + wks@fullname)
-
-      ; add meta data to plot (for reporting)
-
-      caption = "Taylor diagram for variable " + var0 \
-                + " (" + season(is) + "), reference = " \
-                + refname + "."
-      id = DIAG_SCRIPT + "_" + var0 + "_" + season(is)
-
-      contrib_authors = "A_laue_ax"
-
-;      ESMValMD(wks@fullname, alltags, caption, id, var0, \
-;               input_file_info@dataset, infiles, DIAG_SCRIPT, \
-;               contrib_authors)
+      plotfile(is) = wks@fullname
+      log_info("Wrote " + plotfile)
 
       if (embracelegend.and.(is.eq.(numseas-1))) then
         frame(legendwks)
       end if
+    else
+      plotfile(is) = ""
     end if  ; if write_plots
   end do  ; is-loop (seasons)
 
-  ; write optional netCDF output
+  ; write netCDF output
 
-  if (write_nc) then
-    if (any(rmsobs .gt. 0.0)) then
-      val@RMSE_observations = rmsobs
-    end if
-    nc_filename = work_dir + "clouds_taylor_" + var0 + filename_add + ".nc"
-    nc_outfile = ncdf_write(val, nc_filename)
+  if (any(rmsobs .gt. 0.0)) then
+    val@RMSE_observations = rmsobs
   end if
+
+  nc_filename = work_dir + "clouds_taylor_" + var0 + filename_add + ".nc"
+  nc_outfile = ncdf_write(val, nc_filename)
+
+  ; ------------------------------------------------------------------------
+  ; write provenance to netcdf output and plot file(s)
+  ; ------------------------------------------------------------------------
+
+  statistics = ("clim")
+  domain = ("glob")
+  plottype = ("taylor")
+
+  do is = 0, numseas - 1
+    ; note: because function log_provenance does not yet support to attach
+    ;       different captions to netcdf (contains all seasons) and plots
+    ;       (contain one season each), the caption cannot specifiy the
+    ;       season plotted; using "annual" or "DJF/MAM/JJA/SON" instead.
+
+    caption = "Taylor diagram for variable " + var0 + " (" + allseas \
+              + "), reference = " + refname + "."
+
+    log_provenance(nc_outfile, plotfile, caption, statistics, domain, \
+                   plottype, "", "", infiles)
+  end do
 
   leave_msg(DIAG_SCRIPT, "")
 

--- a/esmvaltool/recipes/recipe_clouds_bias.yml
+++ b/esmvaltool/recipes/recipe_clouds_bias.yml
@@ -130,6 +130,10 @@ diagnostics:
 
   clouds_bias_tas:
     description: IPCC AR5 Ch. 9, Fig. 9.2 (near-surface temperature)
+    themes:
+      - clouds
+    realms:
+      - atmos
     variables:
       tas:
         preprocessor: clim
@@ -157,6 +161,10 @@ diagnostics:
 
   clouds_bias_pr:
     description: IPCC AR5 Ch. 9, Fig. 9.4 (precipitation)
+    themes:
+      - clouds
+    realms:
+      - atmos
     variables:
       pr:
         preprocessor: clim
@@ -180,6 +188,10 @@ diagnostics:
   clouds_bias_clt:
     description: multi-model mean bias of annual mean compared with a
                  reference dataset (observations).
+    themes:
+      - clouds
+    realms:
+      - atmos
     variables:
       clt:
         preprocessor: clim

--- a/esmvaltool/recipes/recipe_clouds_ipcc.yml
+++ b/esmvaltool/recipes/recipe_clouds_ipcc.yml
@@ -131,6 +131,10 @@ diagnostics:
 
   clouds_ipcc_swcre:
     description: differences of multi-model mean and reference dataset
+    themes:
+      - clouds
+    realms:
+      - atmos
     variables:
       swcre:
         preprocessor: clim
@@ -150,6 +154,10 @@ diagnostics:
 
   clouds_ipcc_lwcre:
     description: differences of multi-model mean and reference dataset
+    themes:
+      - clouds
+    realms:
+      - atmos
     variables:
       lwcre:
         preprocessor: clim
@@ -166,6 +174,10 @@ diagnostics:
 
   clouds_ipcc_netcre:
     description: differences of multi-model mean and reference dataset
+    themes:
+      - clouds
+    realms:
+      - atmos
     variables:
       netcre:
         preprocessor: clim

--- a/esmvaltool/recipes/recipe_flato13ipcc.yml
+++ b/esmvaltool/recipes/recipe_flato13ipcc.yml
@@ -63,6 +63,10 @@ diagnostics:
 
   fig09-2:
     description: IPCC AR5 Ch. 9, Fig. 9.2 (near-surface temperature)
+    themes:
+      - phys
+    realms:
+      - atmos
     variables:
       tas:
         preprocessor: clim
@@ -174,6 +178,10 @@ diagnostics:
 
   fig09-4:
     description: IPCC AR5 Ch. 9, Fig. 9.4 (precipitation)
+    themes:
+      - clouds
+    realms:
+      - atmos
     variables:
       pr:
         preprocessor: clim
@@ -284,6 +292,10 @@ diagnostics:
 
   fig09-5a:
     description: differences of multi-model mean and reference dataset
+    themes:
+      - clouds
+    realms:
+      - atmos
     variables:
       swcre:
         preprocessor: clim
@@ -387,6 +399,10 @@ diagnostics:
 
   fig09-5b:
     description: differences of multi-model mean and reference dataset
+    themes:
+      - clouds
+    realms:
+      - atmos
     variables:
       lwcre:
         preprocessor: clim
@@ -487,6 +503,10 @@ diagnostics:
 
   fig09-5c:
     description: differences of multi-model mean and reference dataset
+    themes:
+      - clouds
+    realms:
+      - atmos
     variables:
       netcre:
         preprocessor: clim
@@ -595,6 +615,10 @@ diagnostics:
 
   fig09-8:
     description: IPCC AR5 Ch. 9, Fig. 9.8 (near-surface temperature)
+    themes:
+      - phys
+    realms:
+      - atmos
     variables:
       tas:
         preprocessor: clim_ref
@@ -684,6 +708,10 @@ diagnostics:
 
   ecs_cmip5:
     description: Calculate ECS for CMIP5 models.
+    themes:
+      - EC
+    realms:
+      - atmos
     variables:
       tas: &ecs_settings
         preprocessor: spatial_mean
@@ -734,6 +762,11 @@ diagnostics:
 
   fig09-42a_cmip5:
     description: Plot ECS vs. GMSAT for CMIP5 models.
+    themes:
+      - EC
+      - phys
+    realms:
+      - atmos
     variables:
       tas:
         <<: *ecs_settings
@@ -794,6 +827,10 @@ diagnostics:
 
   ecs_cmip6:
     description: Calculate ECS for CMIP6 models.
+    themes:
+      - EC
+    realms:
+      - atmos
     variables:
       tas:
         <<: *ecs_settings
@@ -814,6 +851,11 @@ diagnostics:
 
   fig09-42a_cmip6:
     description: Plot ECS vs. GMSAT for CMIP6 models.
+    themes:
+      - EC
+      - phys
+    realms:
+      - atmos
     variables:
       tas:
         <<: *ecs_settings

--- a/esmvaltool/recipes/recipe_lauer13jclim.yml
+++ b/esmvaltool/recipes/recipe_lauer13jclim.yml
@@ -17,6 +17,7 @@ documentation:
 
   projects:
     - esmval
+    - embrace
 
 datasets:
   - {dataset: ACCESS1-0, project: CMIP5, exp: historical, ensemble: r1i1p1,
@@ -127,6 +128,10 @@ diagnostics:
 
   clouds_fig1_lwp:
     description: climatological annual means
+    themes:
+      - clouds
+    realms:
+      - atmos
     variables:
       lwp:
         preprocessor: clim
@@ -153,6 +158,10 @@ diagnostics:
 
   clouds_fig1_clt:
     description: climatological annual means
+    themes:
+      - clouds
+    realms:
+      - atmos
     variables:
       clt:
         preprocessor: clim
@@ -168,6 +177,10 @@ diagnostics:
 
   clouds_fig1_pr:
     description: climatological annual means
+    themes:
+      - clouds
+    realms:
+      - atmos
     variables:
       pr:
         preprocessor: clim
@@ -183,6 +196,11 @@ diagnostics:
 
   clouds_fig1_swcre:
     description: climatological annual means
+    themes:
+      - clouds
+      - phys
+    realms:
+      - atmos
     variables:
       swcre:
         preprocessor: clim
@@ -199,6 +217,11 @@ diagnostics:
 
   clouds_fig1_lwcre:
     description: climatological annual means
+    themes:
+      - clouds
+      - phys
+    realms:
+      - atmos
     variables:
       lwcre:
         preprocessor: clim
@@ -220,6 +243,10 @@ diagnostics:
 
   clouds_fig3_clt:
     description: climatological annual means
+    themes:
+      - clouds
+    realms:
+      - atmos
     variables:
       clt:
         preprocessor: clim
@@ -272,6 +299,11 @@ diagnostics:
 
   clouds_fig3_lwp:
     description: climatological annual means
+    themes:
+      - clouds
+      - phys
+    realms:
+      - atmos
     variables:
       lwp:
         preprocessor: clim
@@ -288,6 +320,11 @@ diagnostics:
 
   clouds_fig3_swcre:
     description: climatological annual means
+    themes:
+      - clouds
+      - phys
+    realms:
+      - atmos
     variables:
       swcre:
         preprocessor: clim
@@ -304,6 +341,11 @@ diagnostics:
 
   clouds_fig3_lwcre:
     description: climatological annual means
+    themes:
+      - clouds
+      - phys
+    realms:
+      - atmos
     variables:
       lwcre:
         preprocessor: clim
@@ -320,6 +362,10 @@ diagnostics:
 
   clouds_fig3_pr:
     description: climatological annual means
+    themes:
+      - clouds
+    realms:
+      - atmos
     variables:
       pr:
         preprocessor: clim
@@ -342,6 +388,10 @@ diagnostics:
 
   clouds_fig8_lwp:
     description: interannual variability
+    themes:
+      - clouds
+    realms:
+      - atmos
     variables:
       lwp:
         preprocessor: clim
@@ -375,6 +425,10 @@ diagnostics:
 
   clouds_fig8_clt:
     description: interannual variability
+    themes:
+      - clouds
+    realms:
+      - atmos
     variables:
       clt:
         preprocessor: clim
@@ -390,6 +444,11 @@ diagnostics:
 
   clouds_fig8_swcre:
     description: interannual variability
+    themes:
+      - clouds
+      - phys
+    realms:
+      - atmos
     variables:
       swcre:
         preprocessor: clim
@@ -406,6 +465,11 @@ diagnostics:
 
   clouds_fig8_lwcre:
     description: interannual variability
+    themes:
+      - clouds
+      - phys
+    realms:
+      - atmos
     variables:
       lwcre:
         preprocessor: clim
@@ -422,6 +486,10 @@ diagnostics:
 
   clouds_fig8_pr:
     description: interannual variability
+    themes:
+      - clouds
+    realms:
+      - atmos
     variables:
       pr:
         preprocessor: clim


### PR DESCRIPTION
This PR adds provenance output to the following diagnostics:

* clouds/clouds.ncl
* clouds/clouds_interannual.ncl
* clouds/clouds_bias.ncl
* clouds/clouds_taylor.ncl
* clouds/clouds_ipcc.ncl

These diagnostics are used by the following recipes:

* recipe_lauer13jclim.yml
* recipe_clouds_bias.yml
* recipe_clouds_ipcc.yml
* recipe_flato13ipcc.yml