### PR TITLE
Search for custom cmor table if OBS and table not found

### DIFF
--- a/esmvaltool/_recipe.py
+++ b/esmvaltool/_recipe.py
@@ -116,7 +116,7 @@ def _add_cmor_info(variable, override=False):
     short_name = variable['short_name']
     table_entry = CMOR_TABLES[cmor_table].get_variable(mip, short_name)
 
-    if derive and table_entry is None:
+    if table_entry is None and (derive or cmor_table == 'OBS'):
         custom_table = CMOR_TABLES['custom']
         table_entry = custom_table.get_variable(mip, short_name)
 

--- a/esmvaltool/_recipe.py
+++ b/esmvaltool/_recipe.py
@@ -116,7 +116,7 @@ def _add_cmor_info(variable, override=False):
     short_name = variable['short_name']
     table_entry = CMOR_TABLES[cmor_table].get_variable(mip, short_name)
 
-    if table_entry is None and (derive or cmor_table == 'OBS'):
+    if derive and table_entry is None:
         custom_table = CMOR_TABLES['custom']
         table_entry = custom_table.get_variable(mip, short_name)
 

--- a/esmvaltool/config-developer.yml
+++ b/esmvaltool/config-developer.yml
@@ -230,6 +230,7 @@ CMIP5:
     'NorESM1-ME': ['NCC']
 
 OBS:
+  cmor_strict: false
   input_dir:
     default: 'Tier[tier]/[dataset]'
     BSC: '[type]/[institute.lower]/[dataset.lower]/[freq_folder]/[short_name][freq_base]'
@@ -244,6 +245,7 @@ OBS:
   cmor_type: 'CMIP5'
 
 obs4mips:
+  cmor_strict: false
   input_dir:
     default: 'Tier[tier]/[dataset]'
   input_file: '[short_name]_[dataset]_[level]_[version]_*.nc'
@@ -254,9 +256,9 @@ obs4mips:
   output_file: '[project]_[dataset]_[level]_[version]_[field]_[short_name]_[start_year]-[end_year]'
   cmor_type: 'CMIP6'
   cmor_path: 'obs4mips'
-  cmor_strict: False
 
 ana4mips:
+  cmor_strict: false
   input_dir:
     default: 'Tier[tier]/[dataset]'
   input_file: '[short_name]_[mip]_[type]_[dataset]_*.nc'


### PR DESCRIPTION
Together with @axel-lauer we come up with a simple fix to the problem discussed [here](https://github.com/ESMValGroup/ESMValTool/pull/864#discussion_r26117203).

Without changing the existing logic, it allows to search for a custom CMOR table if the variable is not found in any of the `CMIP5`, `CMIP6` of `obs4mips` tables **and** the variable is not derived.

This is needed, for example, when reading a custom variable like `toz` with only 1 dataset from `OBS`.

I'm afraid @jvegasbsc is not available for review, but being a very small fix @bouweandela and/or @valeriupredoi can maybe help.

