### PR TITLE
Fix handling of dtype in irregular regridding.

### DIFF
--- a/esmvaltool/preprocessor/_mapping.py
+++ b/esmvaltool/preprocessor/_mapping.py
@@ -126,14 +126,14 @@ def get_associated_coords(cube, dimensions):
     return dim_coords, aux_coords
 
 
-def get_empty_data(shape):
+def get_empty_data(shape, dtype=np.float32):
     """
     Create an empty data object of the given shape.
 
     Creates an emtpy data object of the given shape, potentially of the lazy
     kind from biggus or dask, depending on the used iris version.
     """
-    data = np.empty(shape)
+    data = np.empty(shape, dtype=dtype)
     mask = np.empty(shape, dtype=bool)
     return np.ma.masked_array(data, mask)
 
@@ -223,7 +223,7 @@ def map_slices(src, func, src_rep, dst_rep):
     dim_coords = src_keep_spec[1] + dst_rep.coords(dim_coords=True)
     dim_coords_and_dims = [(c, i) for i, c in enumerate(dim_coords)]
     dst = iris.cube.Cube(
-        data=get_empty_data(res_shape),
+        data=get_empty_data(res_shape, dtype=src.dtype),
         standard_name=src.standard_name,
         long_name=src.long_name,
         var_name=src.var_name,

--- a/esmvaltool/preprocessor/_regrid_esmpy.py
+++ b/esmvaltool/preprocessor/_regrid_esmpy.py
@@ -178,7 +178,7 @@ def build_regridder_2d(src_rep, dst_rep, regrid_method, mask_threshold):
 
     def regridder(src):
         """Regrid 2d for irregular grids."""
-        res = get_empty_data(dst_rep.shape)
+        res = get_empty_data(dst_rep.shape, src.dtype)
         data = src.data
         if np.ma.is_masked(data):
             data = data.data
@@ -205,7 +205,7 @@ def build_regridder_3d(src_rep, dst_rep, regrid_method, mask_threshold):
 
     def regridder(src):
         """Regrid 2.5d for irregular grids."""
-        res = get_empty_data(dst_rep.shape)
+        res = get_empty_data(dst_rep.shape, src.dtype)
         for i, esmf_regridder in enumerate(esmf_regridders):
             res[i, ...] = esmf_regridder(src[i])
         return res
@@ -278,7 +278,7 @@ def get_grid_representants(src, dst):
     dim_coords += dst_horiz_rep.coords(dim_coords=True)
     dim_coords_and_dims = [(c, i) for i, c in enumerate(dim_coords)]
     dst_rep = iris.cube.Cube(
-        data=get_empty_data(dst_shape),
+        data=get_empty_data(dst_shape, src.dtype),
         standard_name=src.standard_name,
         long_name=src.long_name,
         var_name=src.var_name,

--- a/tests/unit/preprocessor/_mapping/test_mapping.py
+++ b/tests/unit/preprocessor/_mapping/test_mapping.py
@@ -43,6 +43,7 @@ class TestHelpers(tests.Test):
                 raise iris.exceptions.CoordinateNotFoundError('')
         self.cube = mock.Mock(
             spec=iris.cube.Cube,
+            dtype=np.float32,
             coord_system=self.coord_system,
             coords=self.coords,
             coord=coord,
@@ -209,6 +210,7 @@ class Test(tests.Test):
             return [self.scalar_coord] + dim_coords
         self.src_cube = mock.Mock(
             spec=iris.cube.Cube,
+            dtype=np.float32,
             coord_system=self.coord_system,
             coords=src_coords,
             coord=src_coord,
@@ -225,11 +227,13 @@ class Test(tests.Test):
         )
         self.src_repr = mock.Mock(
             spec=iris.cube.Cube,
+            dtype=np.float32,
             coords=src_repr_coords,
             ndim=2,
         )
         self.dst_repr = mock.Mock(
             spec=iris.cube.Cube,
+            dtype=np.float32,
             coords=dst_repr_coords,
             shape=(2, 2),
         )

--- a/tests/unit/preprocessor/_regrid_esmpy/test_regrid_esmpy.py
+++ b/tests/unit/preprocessor/_regrid_esmpy/test_regrid_esmpy.py
@@ -252,6 +252,7 @@ class TestHelpers(tests.Test):
             return list(self.coords.values())
         self.cube = mock.Mock(
             spec=iris.cube.Cube,
+            dtype=np.float32,
             long_name='longname',
             ndim=2,
             shape=self.data.shape,
@@ -263,6 +264,7 @@ class TestHelpers(tests.Test):
         self.cube.__getitem__ = mock.Mock(return_value=self.cube)
         self.unmasked_cube = mock.Mock(
             spec=iris.cube.Cube,
+            dtype=np.float32,
             long_name='longname',
         )
         self.coord_dims_3d = {
@@ -282,6 +284,7 @@ class TestHelpers(tests.Test):
             return self.coords[name]
         self.cube_3d = mock.Mock(
             spec=iris.cube.Cube,
+            dtype=np.float32,
             standard_name=None,
             long_name='longname',
             var_name='ln',
@@ -546,7 +549,7 @@ class TestHelpers(tests.Test):
         )
         mock_regrid.return_value = field_regridder
         regrid_method = mock.sentinel.rm_bilinear
-        src_rep = mock.MagicMock(data=self.data)
+        src_rep = mock.MagicMock(data=self.data, dtype=np.float32)
         dst_rep = mock.MagicMock(shape=(4, 4))
         regridder = build_regridder_2d(src_rep,
                                        dst_rep,


### PR DESCRIPTION
This adds handling of `dtype` to the irregular regridding. More specifically it creates the output with the same `dtype` as the input.

Fixes #897.