### PR TITLE
Bugfix: segmentation violation in NCL provenance function log_provenance

### DIFF
--- a/esmvaltool/interface_scripts/logging.ncl
+++ b/esmvaltool/interface_scripts/logging.ncl
@@ -362,11 +362,8 @@ begin
   str := array_append_record(str1, str, 0)
   str := array_append_record(str0, str, 0)
 
-  str_list = [/str/]
-
   yaml_file = config_user_info@run_dir + "diagnostic_provenance.yml"
-  write_table(yaml_file, "a", str_list, "%s %s %s %s %s %s %s %s %s")
-  delete(str)
+  asciiwrite(yaml_file, str)
 
   log_info(" write meta data to " + yaml_file)
 


### PR DESCRIPTION
This pull request fixes a problem in function *log_provenance* (interface_scripts/logging.ncl):

NCL function *write_table* used in *log_provenance* crashes with segmentation violation (error -11) if one of the strings passed to the function is "very long". This happens when the list of ancestor files is very long e.g. when processing many variables and datasets. This fix uses NCL function *asciiwrite* instead, which does not have this problem.