### PR TITLE
Variable alias management

### DIFF
--- a/esmvaltool/cmor/table.py
+++ b/esmvaltool/cmor/table.py
@@ -639,7 +639,16 @@ class CustomInfo(CMIP5Info):
             found, returns None if not
 
         """
-        return self.tables['custom'].get(short_name, None)
+        var_info = self.tables['custom'].get(short_name, None)
+        if not var_info:
+            for alias_list in self.alias:
+                if short_name in alias_list:
+                    for alias in alias_list:
+                        try:
+                            return self.tables['custom'][alias]
+                        except KeyError:
+                            pass
+        return var_info
 
     def _read_table_file(self, table_file, table=None):
         with open(table_file) as self._current_table:

--- a/esmvaltool/cmor/variable_alias.yml
+++ b/esmvaltool/cmor/variable_alias.yml
@@ -1,0 +1,13 @@
+###############################################################################
+# Variable short name aliases
+###############################################################################
+# This file contains the list of variable short name aliases that are used
+# in different projects. Will allow us to keep track of changes in variable
+# short names across projects to simplify the usage for the users
+#
+# This file contains a list of lists
+###############################################################################
+---
+- ['sic', 'siconc']
+- ['sit', 'sithick']
+- ['tro3', 'o3']

--- a/tests/integration/cmor/test_table.py
+++ b/tests/integration/cmor/test_table.py
@@ -16,7 +16,11 @@ class TestCMIP6Info(unittest.TestCase):
 
         We read CMIP6Info once to keep tests times manageable
         """
-        cls.variables_info = CMIP6Info('cmip6', default=CustomInfo())
+        cls.variables_info = CMIP6Info(
+            'cmip6',
+            default=CustomInfo(),
+            alias=[['siconc', 'sic']]
+        )
 
     def test_custom_tables_location(self):
         """Test constructor with custom tables location."""
@@ -53,7 +57,8 @@ class Testobs4mipsInfo(unittest.TestCase):
         """
         cls.variables_info = CMIP6Info(
             cmor_tables_path='obs4mips',
-            default=CustomInfo()
+            default=CustomInfo(),
+            alias=[['siconc', 'sic']]
         )
 
     def test_custom_tables_location(self):
@@ -84,7 +89,11 @@ class TestCMIP5Info(unittest.TestCase):
 
         We read CMIP5Info once to keep testing times manageable
         """
-        cls.variables_info = CMIP5Info('cmip5', default=CustomInfo())
+        cls.variables_info = CMIP5Info(
+            'cmip5',
+            default=CustomInfo(),
+            alias=[['siconc', 'sic']]
+        )
 
     def test_custom_tables_location(self):
         """Test constructor with custom tables location."""
@@ -98,6 +107,11 @@ class TestCMIP5Info(unittest.TestCase):
         """Get tas variable."""
         var = self.variables_info.get_variable('Amon', 'tas')
         self.assertEqual(var.short_name, 'tas')
+
+    def test_get_variable_from_alias(self):
+        """Get a variable from a known alias."""
+        var = self.variables_info.get_variable('OImon', 'siconc')
+        self.assertEqual(var.short_name, 'sic')
 
     def test_get_bad_variable(self):
         """Get none if a variable is not in the given table."""


### PR DESCRIPTION
Generalize the alias management for variables that are known by different short names depending on the project.

All projects will now check the knwon alias for a variable to get the CMOR info (custom vars included) 

Automation of alias contrsuction is not advisable because we can face problems like siconc and siconca sharing the standard name. 

See discussion in #857 