### PR TITLE
Pin iris to version greater than 2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,8 +20,8 @@ channels:
 
 dependencies:
   # Python packages that cannot be installed from PyPI:
-  - iris
   - esmpy
+  - iris>=2.2
   - matplotlib<3  # Can be installed from PyPI, but is a dependency of iris and should be pinned.
   - python-stratify
   - xarray  # Can be installed from PyPI, but here to get a consistent set of depencies with iris.

--- a/meta.yaml
+++ b/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - python
     - libunwind  #  specifically for Python3.7+
     - graphviz
-    - iris
+    - iris>=2.2
     - python-stratify
     # Normally installed via pip:
     - cartopy

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ REQUIREMENTS = {
         'prov[dot]',
         'psutil',
         'pyyaml',
-        'scitools-iris',
+        'scitools-iris>=2.2',
         'scikit-learn',
         'shapely',
         'six',


### PR DESCRIPTION
This is required for working with dask, which we already do in various places in the code.