### PR TITLE
CMOR fix for CMIP6 data (UKESM1 & MIROC6)

### DIFF
--- a/esmvaltool/cmor/_fixes/CMIP6/BCC_CSM2_MR.py
+++ b/esmvaltool/cmor/_fixes/CMIP6/BCC_CSM2_MR.py
@@ -1,7 +1,6 @@
 """Fixes for BCC-CSM2-MR."""
-import numpy as np
-import iris
-
+# import numpy as np
+# import iris
 from ..fix import Fix
 
 
@@ -28,7 +27,8 @@ class allvars(Fix):
         for cube in cubes:
             coords_to_remove = []
             for coord in cube.coords():
-                if coord.var_name in ['time', ]: continue
+                if coord.var_name in ['time', ]:
+                    continue
                 if coord.var_name in ['lat', 'lon']:
                     coords_to_remove.append(coord)
 

--- a/esmvaltool/cmor/_fixes/CMIP6/BCC_CSM2_MR.py
+++ b/esmvaltool/cmor/_fixes/CMIP6/BCC_CSM2_MR.py
@@ -1,4 +1,3 @@
-# pylint: disable=invalid-name, no-self-use, too-few-public-methods
 """Fixes for BCC-CSM2-MR."""
 import numpy as np
 import iris
@@ -24,44 +23,6 @@ class allvars(Fix):
         iris.cube.CubeList
 
         """
-        for cube in cubes:
-            try:
-                old_time = cube.coord('time')
-                if old_time.is_monotonic():
-                    pass
-
-                time_units = old_time.units
-                time_data = old_time.points
-
-                idx_zeros = np.where(time_data == 0.0)[0]
-                time_diff = time_units.num2date(time_data[1]) \
-                    - time_units.num2date(time_data[0])
-                days = time_diff.days
-
-                for idx in idx_zeros:
-                    if idx == 0:
-                        continue
-                    correct_time = time_units.num2date(time_data[idx - 1])
-                    if days <= 31 and days >= 28:  # assume monthly time steps
-                        new_time = \
-                            correct_time.replace(month=correct_time.month + 1)
-                    else:  # use "time[1] - time[0]" as step
-                        new_time = correct_time + time_diff
-                    old_time.points[idx] = time_units.date2num(new_time)
-
-                # create new time bounds
-                old_time.bounds = None
-                old_time.guess_bounds()
-
-                # replace time coordinate with "repaired" values
-                new_time = iris.coords.DimCoord.from_coord(old_time)
-                time_idx = cube.coord_dims(old_time)
-                cube.remove_coord('time')
-                cube.add_dim_coord(new_time, time_idx)
-
-            except iris.exceptions.CoordinateNotFoundError:
-                pass
-
         # Remove 1D lat and lon as they are incorrect, this is an irregular
         # 2D grid and lat/lon need to be 2d.
         for cube in cubes:

--- a/esmvaltool/cmor/_fixes/CMIP6/BCC_CSM2_MR.py
+++ b/esmvaltool/cmor/_fixes/CMIP6/BCC_CSM2_MR.py
@@ -1,0 +1,82 @@
+# pylint: disable=invalid-name, no-self-use, too-few-public-methods
+"""Fixes for BCC-CSM2-MR."""
+import numpy as np
+import iris
+
+from ..fix import Fix
+
+
+class allvars(Fix):
+    """Common fixes to all vars"""
+
+    def fix_metadata(self, cubes):
+        """
+        Fix metadata.
+
+        Fixes error in time coordinate, sometimes contains trailing zeros
+
+        Parameters
+        ----------
+        cube: iris.cube.CubeList
+
+        Returns
+        -------
+        iris.cube.CubeList
+
+        """
+        for cube in cubes:
+            try:
+                old_time = cube.coord('time')
+                if old_time.is_monotonic():
+                    pass
+
+                time_units = old_time.units
+                time_data = old_time.points
+
+                idx_zeros = np.where(time_data == 0.0)[0]
+                time_diff = time_units.num2date(time_data[1]) \
+                    - time_units.num2date(time_data[0])
+                days = time_diff.days
+
+                for idx in idx_zeros:
+                    if idx == 0:
+                        continue
+                    correct_time = time_units.num2date(time_data[idx - 1])
+                    if days <= 31 and days >= 28:  # assume monthly time steps
+                        new_time = \
+                            correct_time.replace(month=correct_time.month + 1)
+                    else:  # use "time[1] - time[0]" as step
+                        new_time = correct_time + time_diff
+                    old_time.points[idx] = time_units.date2num(new_time)
+
+                # create new time bounds
+                old_time.bounds = None
+                old_time.guess_bounds()
+
+                # replace time coordinate with "repaired" values
+                new_time = iris.coords.DimCoord.from_coord(old_time)
+                time_idx = cube.coord_dims(old_time)
+                cube.remove_coord('time')
+                cube.add_dim_coord(new_time, time_idx)
+
+            except iris.exceptions.CoordinateNotFoundError:
+                pass
+
+        # Remove 1D lat and lon as they are incorrect, this is an irregular
+        # 2D grid and lat/lon need to be 2d.
+        for cube in cubes:
+            coords_to_remove = []
+            for coord in cube.coords():
+                if coord.var_name in ['time', ]: continue
+                if coord.var_name in ['lat', 'lon']:
+                    coords_to_remove.append(coord)
+
+            for coord in coords_to_remove:
+                cube.remove_coord(coord)
+
+            latitudes = cube.coord('latitude')
+            longitudes = cube.coord('longitude')
+            latitudes.var_name = 'lat'
+            longitudes.var_name = 'lon'
+
+        return cubes

--- a/esmvaltool/cmor/_fixes/CMIP6/BCC_ESM1.py
+++ b/esmvaltool/cmor/_fixes/CMIP6/BCC_ESM1.py
@@ -1,4 +1,3 @@
-# pylint: disable=invalid-name, no-self-use, too-few-public-methods
 """Fixes for BCC-ESM1."""
 import numpy as np
 import iris
@@ -24,45 +23,6 @@ class allvars(Fix):
         iris.cube.CubeList
 
         """
-        # time
-        for cube in cubes:
-            try:
-                old_time = cube.coord('time')
-                if old_time.is_monotonic():
-                    pass
-
-                time_units = old_time.units
-                time_data = old_time.points
-
-                idx_zeros = np.where(time_data == 0.0)[0]
-                time_diff = time_units.num2date(time_data[1]) \
-                    - time_units.num2date(time_data[0])
-                days = time_diff.days
-
-                for idx in idx_zeros:
-                    if idx == 0:
-                        continue
-                    correct_time = time_units.num2date(time_data[idx - 1])
-                    if days <= 31 and days >= 28:  # assume monthly time steps
-                        new_time = \
-                            correct_time.replace(month=correct_time.month + 1)
-                    else:  # use "time[1] - time[0]" as step
-                        new_time = correct_time + time_diff
-                    old_time.points[idx] = time_units.date2num(new_time)
-
-                # create new time bounds
-                old_time.bounds = None
-                old_time.guess_bounds()
-
-                # replace time coordinate with "repaired" values
-                new_time = iris.coords.DimCoord.from_coord(old_time)
-                time_idx = cube.coord_dims(old_time)
-                cube.remove_coord('time')
-                cube.add_dim_coord(new_time, time_idx)
-
-            except iris.exceptions.CoordinateNotFoundError:
-                pass
-
         # Remove 1D lat and lon as they are incorrect, this is an irregular
         # 2D grid and lat/lon need to be 2d.
         for cube in cubes:

--- a/esmvaltool/cmor/_fixes/CMIP6/BCC_ESM1.py
+++ b/esmvaltool/cmor/_fixes/CMIP6/BCC_ESM1.py
@@ -1,0 +1,83 @@
+# pylint: disable=invalid-name, no-self-use, too-few-public-methods
+"""Fixes for BCC-ESM1."""
+import numpy as np
+import iris
+
+from ..fix import Fix
+
+
+class allvars(Fix):
+    """Common fixes to all vars"""
+
+    def fix_metadata(self, cubes):
+        """
+        Fix metadata.
+
+        Fixes error in time coordinate, sometimes contains trailing zeros
+
+        Parameters
+        ----------
+        cube: iris.cube.CubeList
+
+        Returns
+        -------
+        iris.cube.CubeList
+
+        """
+        # time
+        for cube in cubes:
+            try:
+                old_time = cube.coord('time')
+                if old_time.is_monotonic():
+                    pass
+
+                time_units = old_time.units
+                time_data = old_time.points
+
+                idx_zeros = np.where(time_data == 0.0)[0]
+                time_diff = time_units.num2date(time_data[1]) \
+                    - time_units.num2date(time_data[0])
+                days = time_diff.days
+
+                for idx in idx_zeros:
+                    if idx == 0:
+                        continue
+                    correct_time = time_units.num2date(time_data[idx - 1])
+                    if days <= 31 and days >= 28:  # assume monthly time steps
+                        new_time = \
+                            correct_time.replace(month=correct_time.month + 1)
+                    else:  # use "time[1] - time[0]" as step
+                        new_time = correct_time + time_diff
+                    old_time.points[idx] = time_units.date2num(new_time)
+
+                # create new time bounds
+                old_time.bounds = None
+                old_time.guess_bounds()
+
+                # replace time coordinate with "repaired" values
+                new_time = iris.coords.DimCoord.from_coord(old_time)
+                time_idx = cube.coord_dims(old_time)
+                cube.remove_coord('time')
+                cube.add_dim_coord(new_time, time_idx)
+
+            except iris.exceptions.CoordinateNotFoundError:
+                pass
+
+        # Remove 1D lat and lon as they are incorrect, this is an irregular
+        # 2D grid and lat/lon need to be 2d.
+        for cube in cubes:
+            coords_to_remove = []
+            for coord in cube.coords():
+                if coord.var_name in ['time', ]: continue
+                if coord.var_name in ['lat', 'lon']:
+                    coords_to_remove.append(coord)
+
+            for coord in coords_to_remove:
+                cube.remove_coord(coord)
+
+            latitudes = cube.coord('latitude')
+            longitudes = cube.coord('longitude')
+            latitudes.var_name = 'lat'
+            longitudes.var_name = 'lon'
+
+        return cubes

--- a/esmvaltool/cmor/_fixes/CMIP6/BCC_ESM1.py
+++ b/esmvaltool/cmor/_fixes/CMIP6/BCC_ESM1.py
@@ -1,7 +1,6 @@
 """Fixes for BCC-ESM1."""
-import numpy as np
-import iris
-
+# import numpy as np
+# import iris
 from ..fix import Fix
 
 
@@ -28,7 +27,8 @@ class allvars(Fix):
         for cube in cubes:
             coords_to_remove = []
             for coord in cube.coords():
-                if coord.var_name in ['time', ]: continue
+                if coord.var_name in ['time', ]:
+                    continue
                 if coord.var_name in ['lat', 'lon']:
                     coords_to_remove.append(coord)
 

--- a/esmvaltool/cmor/_fixes/CMIP6/IPSL_CM6A_LR.py
+++ b/esmvaltool/cmor/_fixes/CMIP6/IPSL_CM6A_LR.py
@@ -1,0 +1,38 @@
+# pylint: disable=invalid-name, no-self-use, too-few-public-methods
+"""Fixes for IPSL-CM6A-LR."""
+
+from ..fix import Fix
+
+
+class allvars(Fix):
+    """Fixes for all vars."""
+
+    def fix_metadata(self, cubelist):
+        """
+        Removes addition cube in cube list (Cell area).
+        It has been created as a cell_area_cube which can be re-added here,
+        if needed.
+
+        Also forced the latitude and longitude to be 'lat' & 'lon',
+        instead of 'nav_lat' & 'nav_lon'.
+
+        Parameters
+        ----------
+        cubelist: iris CubeList
+            List of cubes to fix
+
+        Returns
+        -------
+        iris.cube.CubeList
+        """
+        for cube in cubelist:
+            if cube.standard_name == 'cell_area':
+                cell_area_cube = cube.copy()
+                cubelist.remove(cube)
+
+        for cube in cubelist:
+            lats = cube.coord('latitude')
+            lons = cube.coord('longitude')
+            lats.var_name = 'lat'
+            lons.var_name = 'lon'
+        return cubelist

--- a/esmvaltool/cmor/_fixes/CMIP6/IPSL_CM6A_LR.py
+++ b/esmvaltool/cmor/_fixes/CMIP6/IPSL_CM6A_LR.py
@@ -1,4 +1,3 @@
-# pylint: disable=invalid-name, no-self-use, too-few-public-methods
 """Fixes for IPSL-CM6A-LR."""
 
 from ..fix import Fix
@@ -27,7 +26,9 @@ class allvars(Fix):
         """
         for cube in cubelist:
             if cube.standard_name == 'cell_area':
-                cell_area_cube = cube.copy()
+                # If you need to add the cell area back in, uncomment this line
+                # cell_area_cube = cube.copy()
+                #
                 cubelist.remove(cube)
 
         for cube in cubelist:

--- a/esmvaltool/cmor/_fixes/CMIP6/IPSL_CM6A_LR.py
+++ b/esmvaltool/cmor/_fixes/CMIP6/IPSL_CM6A_LR.py
@@ -8,7 +8,7 @@ class allvars(Fix):
 
     def fix_metadata(self, cubelist):
         """
-        Removes addition cube in cube list (Cell area).
+        Remove addition cube in cube list (Cell area).
         It has been created as a cell_area_cube which can be re-added here,
         if needed.
 

--- a/esmvaltool/cmor/_fixes/CMIP6/MIROC6.py
+++ b/esmvaltool/cmor/_fixes/CMIP6/MIROC6.py
@@ -5,6 +5,7 @@
 
 from ..fix import Fix
 
+
 class allvars(Fix):
     """Fixes for all vars."""
 

--- a/esmvaltool/cmor/_fixes/CMIP6/MIROC6.py
+++ b/esmvaltool/cmor/_fixes/CMIP6/MIROC6.py
@@ -1,4 +1,3 @@
-# pylint: disable=invalid-name, no-self-use, too-few-public-methods
 """Fixes for MIROC6."""
 # import numpy as np
 # import iris

--- a/esmvaltool/cmor/_fixes/CMIP6/MIROC6.py
+++ b/esmvaltool/cmor/_fixes/CMIP6/MIROC6.py
@@ -1,0 +1,29 @@
+# pylint: disable=invalid-name, no-self-use, too-few-public-methods
+"""Fixes for MIROC6."""
+# import numpy as np
+# import iris
+
+from ..fix import Fix
+
+class allvars(Fix):
+    """Fixes for all vars."""
+
+    def fix_metadata(self, cubelist):
+        """
+        Fix non-standard dimension names.
+
+        Parameters
+        ----------
+        cubelist: iris CubeList
+            List of cubes to fix
+
+        Returns
+        -------
+        iris.cube.CubeList
+        """
+        for cube in cubelist:
+            lats = cube.coord('latitude')
+            lons = cube.coord('longitude')
+            lats.var_name = 'lat'
+            lons.var_name = 'lon'
+        return cubelist

--- a/esmvaltool/cmor/_fixes/CMIP6/UKESM1_0_LL.py
+++ b/esmvaltool/cmor/_fixes/CMIP6/UKESM1_0_LL.py
@@ -1,4 +1,3 @@
-# pylint: disable=invalid-name, no-self-use, too-few-public-methods
 """Fixes for UKESM1-0-LL."""
 # import numpy as np
 # import iris

--- a/esmvaltool/cmor/_fixes/CMIP6/UKESM1_0_LL.py
+++ b/esmvaltool/cmor/_fixes/CMIP6/UKESM1_0_LL.py
@@ -5,6 +5,7 @@
 
 from ..fix import Fix
 
+
 class allvars(Fix):
     """Fixes for all vars."""
 

--- a/esmvaltool/cmor/_fixes/CMIP6/UKESM1_0_LL.py
+++ b/esmvaltool/cmor/_fixes/CMIP6/UKESM1_0_LL.py
@@ -1,0 +1,29 @@
+# pylint: disable=invalid-name, no-self-use, too-few-public-methods
+"""Fixes for UKESM1-0-LL."""
+# import numpy as np
+# import iris
+
+from ..fix import Fix
+
+class allvars(Fix):
+    """Fixes for all vars."""
+
+    def fix_metadata(self, cubelist):
+        """
+        Fix non-standard dimension names.
+
+        Parameters
+        ----------
+        cubelist: iris CubeList
+            List of cubes to fix
+
+        Returns
+        -------
+        iris.cube.CubeList
+        """
+        for cube in cubelist:
+            lats = cube.coord('latitude')
+            lons = cube.coord('longitude')
+            lats.var_name = 'lat'
+            lons.var_name = 'lon'
+        return cubelist

--- a/esmvaltool/recipes/recipe_ocean_temperature_cmip6.yml
+++ b/esmvaltool/recipes/recipe_ocean_temperature_cmip6.yml
@@ -28,12 +28,15 @@ documentation:
 
 datasets:
      # CMIP6
+     - {dataset: BCC-CSM2-MR,      project: CMIP6,    exp: historical, ensemble: r1i1p1f1, grid: gn, start_year: 2000,  end_year: 2014}
+     - {dataset: BCC-ESM1,         project: CMIP6,    exp: historical, ensemble: r1i1p1f1, grid: gn, start_year: 2000,  end_year: 2014}
      - {dataset: CESM2,            project: CMIP6,    exp: historical, ensemble: r1i1p1f1, grid: gn, start_year: 2000,  end_year: 2014}
      - {dataset: CNRM-CM6-1,       project: CMIP6,    exp: historical, ensemble: r1i1p1f2, grid: gn, start_year: 2000,  end_year: 2014}
      - {dataset: GISS-E2-1-G,      project: CMIP6,    exp: historical, ensemble: r1i1p1f1, grid: gn, start_year: 2000,  end_year: 2014}
-     - {dataset: UKESM1-0-LL,      project: CMIP6,    exp: historical, ensemble: r1i1p1f2, grid: gn, start_year: 2000,  end_year: 2014}
-     - {dataset: MIROC6,           project: CMIP6,    exp: historical, ensemble: r1i1p1f1, grid: gn, start_year: 2000,  end_year: 2014}
      - {dataset: IPSL-CM6A-LR,     project: CMIP6,    exp: historical, ensemble: r1i1p1f1, grid: gn, start_year: 2000,  end_year: 2014}
+     - {dataset: MIROC6,           project: CMIP6,    exp: historical, ensemble: r1i1p1f1, grid: gn, start_year: 2000,  end_year: 2014}
+     - {dataset: UKESM1-0-LL,      project: CMIP6,    exp: historical, ensemble: r1i1p1f2, grid: gn, start_year: 2000,  end_year: 2014}
+
 
 preprocessors:
   # --------------------------------------------------

--- a/esmvaltool/recipes/recipe_ocean_temperature_cmip6.yml
+++ b/esmvaltool/recipes/recipe_ocean_temperature_cmip6.yml
@@ -33,6 +33,7 @@ datasets:
      - {dataset: GISS-E2-1-G,      project: CMIP6,    exp: historical, ensemble: r1i1p1f1, grid: gn, start_year: 2000,  end_year: 2014}
      - {dataset: UKESM1-0-LL,      project: CMIP6,    exp: historical, ensemble: r1i1p1f2, grid: gn, start_year: 2000,  end_year: 2014}
      - {dataset: MIROC6,           project: CMIP6,    exp: historical, ensemble: r1i1p1f1, grid: gn, start_year: 2000,  end_year: 2014}
+     - {dataset: IPSL-CM6A-LR,     project: CMIP6,    exp: historical, ensemble: r1i1p1f1, grid: gn, start_year: 2000,  end_year: 2014}
 
 preprocessors:
   # --------------------------------------------------

--- a/esmvaltool/recipes/recipe_ocean_temperature_cmip6.yml
+++ b/esmvaltool/recipes/recipe_ocean_temperature_cmip6.yml
@@ -1,0 +1,80 @@
+# ESMValTool
+# recipe_ocean_temperature_cmip6.yml
+---
+documentation:
+  description: |
+    Recipe to demonstrate a basic plots based on the monthly ocean
+    temperature in CMIP6.
+
+    Note that the time series will not function without the FX files, which
+    are not available yet on JASMIN (2019/04/15).
+
+    The maps will be plotted in their models native grids, which can sometimes
+    look strange. Regridding is a possible solution, but will not work without
+    the fx files, which are not yet available.
+
+  authors:
+    - demo_le
+
+  maintainer:
+    - demo_le
+
+  references:
+    - demora2018gmd
+
+  projects:
+    - ukesm
+
+
+datasets:
+     # CMIP6
+     - {dataset: CESM2,            project: CMIP6,    exp: historical, ensemble: r1i1p1f1, grid: gn, start_year: 2000,  end_year: 2014}
+     - {dataset: CNRM-CM6-1,       project: CMIP6,    exp: historical, ensemble: r1i1p1f2, grid: gn, start_year: 2000,  end_year: 2014}
+     - {dataset: GISS-E2-1-G,      project: CMIP6,    exp: historical, ensemble: r1i1p1f1, grid: gn, start_year: 2000,  end_year: 2014}
+     - {dataset: UKESM1-0-LL,      project: CMIP6,    exp: historical, ensemble: r1i1p1f2, grid: gn, start_year: 2000,  end_year: 2014}
+     - {dataset: MIROC6,           project: CMIP6,    exp: historical, ensemble: r1i1p1f1, grid: gn, start_year: 2000,  end_year: 2014}
+
+preprocessors:
+  # --------------------------------------------------
+  # Time series preprocessors
+  # --------------------------------------------------
+  # prep_timeseries_1: # For 2D fields
+  #   custom_order: true
+  #   average_region:
+  #     coord1: longitude
+  #     coord2: latitude
+  #   multi_model_statistics:
+  #     span: overlap
+  #     statistics: [mean ]
+
+  # --------------------------------------------------
+  # Maps preprocessors
+  # --------------------------------------------------
+  prep_map_1: # For Global 2D fields
+    time_average:
+
+diagnostics:
+  # --------------------------------------------------
+  # Time series diagnostics
+  # --------------------------------------------------
+  # diag_timeseries_1:
+  #   description: Global Ocean Surface mean timeseries
+  #   variables:
+  #     tos: # Temperature ocean surface
+  #       mip: Omon
+  #       preprocessor: prep_timeseries_1
+  #   scripts:
+  #     Global_Ocean_Surface_mean_timeseries:
+  #       script: ocean/diagnostic_timeseries.py
+  # --------------------------------------------------
+  # Map diagnostics
+  # --------------------------------------------------
+  diag_map_1:
+    description: Global Ocean Surface map
+    variables:
+      tos: # Temperature ocean surface
+        preprocessor: prep_map_1
+        mip: Omon
+    scripts:
+      Global_Ocean_Surface_mean_map:
+        script: ocean/diagnostic_maps.py


### PR DESCRIPTION
As per an email discussion with @valeriupredoi and others, I've written a couple a couple short fix files for the CMIP6 data for the models UKESM1 and MIROC6. 

The fix with both of these models is to change the latitude and longitude from `latitude` & `longitude` to `lat` & `lon`. 

N.B that there are currently no public recipes which include these models so no obvious way to test this code. Although it should be possible to add these models to a recipe with the lines:
```
- {dataset: UKESM1-0-LL,  project: CMIP6, mip: Omon, exp: historical, ensemble: r1i1p1f2, grid: gn}
- {dataset: MIROC6,       project: CMIP6, mip: Omon, exp: historical, ensemble: r1i1p1f1, grid: gn}
```