### PR TITLE
Allow specifying all information in dataset

### DIFF
--- a/esmvaltool/_recipe.py
+++ b/esmvaltool/_recipe.py
@@ -927,7 +927,10 @@ class Recipe:
         preprocessor_output = {}
 
         for variable_group, raw_variable in raw_variables.items():
-            raw_variable = deepcopy(raw_variable)
+            if raw_variable is None:
+                raw_variable = {}
+            else:
+                raw_variable = deepcopy(raw_variable)
             raw_variable['variable_group'] = variable_group
             if 'short_name' not in raw_variable:
                 raw_variable['short_name'] = variable_group

--- a/esmvaltool/recipe_schema.yml
+++ b/esmvaltool/recipe_schema.yml
@@ -50,7 +50,7 @@ diagnostic:
   description: str(required=False)
   themes: list(str(), required=False)
   realms: list(str(), required=False)
-  variables: map(include('variable'), required=False)
+  variables: map(include('variable'), null(), required=False)
 
 script:
   script: str()

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -313,6 +313,33 @@ def test_default_preprocessor(tmp_path, patched_datafinder, config_user):
     assert product.settings == defaults
 
 
+def test_empty_variable(tmp_path, patched_datafinder, config_user):
+    """Test that it is possible to specify all information in the dataset."""
+    content = dedent("""
+        diagnostics:
+          diagnostic_name:
+            additional_datasets:
+              - dataset: CanESM2
+                project: CMIP5
+                mip: Amon
+                exp: historical
+                start_year: 2000
+                end_year: 2005
+                ensemble: r1i1p1
+            variables:
+              pr:
+            scripts: null
+        """)
+
+    recipe = get_recipe(tmp_path, content, config_user)
+    assert len(recipe.tasks) == 1
+    task = recipe.tasks.pop()
+    assert len(task.products) == 1
+    product = task.products.pop()
+    assert product.attributes['short_name'] == 'pr'
+    assert product.attributes['dataset'] == 'CanESM2'
+
+
 def test_reference_dataset(tmp_path, patched_datafinder, config_user,
                            monkeypatch):
 


### PR DESCRIPTION
At the moment some recipes do no longer work, because they have empty variable sections after the `field` attribute was removed. E.g. recipe_cvdp.yml. This pull request fixes that.