### PR TITLE
Handling of Fx variables as regular variables for CMIP5 and CMIP6 (simple, no CMOR checks)

### DIFF
--- a/esmvaltool/_config.py
+++ b/esmvaltool/_config.py
@@ -175,18 +175,6 @@ def get_institutes(variable):
     return CFG.get(project, {}).get('institutes', {}).get(dataset, [])
 
 
-def replace_mip_fx(fx_file):
-    """Replace MIP so to retrieve correct fx files."""
-    default_mip = 'Amon'
-    if fx_file not in CFG['CMIP5']['fx_mip_change']:
-        logger.warning(
-            'mip for fx variable %s is not specified in '
-            'config_developer.yml, using default (%s)', fx_file, default_mip)
-    new_mip = CFG['CMIP5']['fx_mip_change'].get(fx_file, default_mip)
-    logger.debug("Switching mip for fx file finding to %s", new_mip)
-    return new_mip
-
-
 TAGS_CONFIG_FILE = os.path.join(
     os.path.dirname(__file__), 'config-references.yml')
 

--- a/esmvaltool/_data_finder.py
+++ b/esmvaltool/_data_finder.py
@@ -235,6 +235,9 @@ def _find_input_files(variable, rootpath, drs):
 
 def get_input_filelist(variable, rootpath, drs):
     """Return the full path to input files."""
+    # change ensemble to fixed r0i0p0 for fx variables
+    if variable['project'] == 'CMIP5'and variable['frequency'] == 'fx':
+        variable['ensemble'] = 'r0i0p0'
     files = _find_input_files(variable, rootpath, drs)
     # do time gating only for non-fx variables
     if variable['frequency'] != 'fx':

--- a/esmvaltool/_recipe.py
+++ b/esmvaltool/_recipe.py
@@ -494,7 +494,7 @@ def _get_input_files(variable, config_user):
                 variable['short_name'], variable['dataset'],
                 '\n'.join(input_files))
     if (not config_user.get('skip-nonexistent')
-            or var['dataset'] == variable.get('reference_dataset')):
+            or variable['dataset'] == variable.get('reference_dataset')):
         check.data_availability(input_files, variable)
 
     # Set up provenance tracking

--- a/esmvaltool/_recipe_checks.py
+++ b/esmvaltool/_recipe_checks.py
@@ -97,15 +97,18 @@ def data_availability(input_files, var):
 
     required_years = set(range(var['start_year'], var['end_year'] + 1))
     available_years = set()
-    for filename in input_files:
-        start, end = get_start_end_year(filename)
-        available_years.update(range(start, end + 1))
+    # check time avail only for non-fx variables
+    if var['frequency'] != 'fx':
+        for filename in input_files:
+            start, end = get_start_end_year(filename)
+            available_years.update(range(start, end + 1))
 
-    missing_years = required_years - available_years
-    if missing_years:
-        raise RecipeError(
-            "No input data available for years {} in files {}".format(
-                ", ".join(str(year) for year in missing_years), input_files))
+        missing_years = required_years - available_years
+        if missing_years:
+            raise RecipeError(
+                "No input data available for years {} in files {}".format(
+                    ", ".join(str(year) for year in missing_years),
+                    input_files))
 
 
 def tasks_valid(tasks):

--- a/esmvaltool/cmor/check.py
+++ b/esmvaltool/cmor/check.py
@@ -95,13 +95,15 @@ class CMORCheck():
         self._check_fill_value()
         self._check_dim_names()
         self._check_coords()
-        self._check_time_coord()
+        if self.frequency != 'fx':
+            self._check_time_coord()
         self._check_rank()
 
         self.report_warnings(logger)
         self.report_errors()
 
-        self._add_auxiliar_time_coordinates()
+        if self.frequency != 'fx':
+            self._add_auxiliar_time_coordinates()
         return self._cube
 
     def report_errors(self):

--- a/esmvaltool/config-developer.yml
+++ b/esmvaltool/config-developer.yml
@@ -24,7 +24,7 @@ CMIP6:
     BADC: '[institute]/[dataset]/[exp]/[ensemble]/[mip]/[short_name]/[grid]/[latestversion]'
     DKRZ: '[institute]/[dataset]/[exp]/[ensemble]/[mip]/[short_name]/[grid]/[latestversion]'
     ETHZ: '[exp]/[mip]/[short_name]/[dataset]/[ensemble]/[grid]/'
-  input_file: '[short_name]_[mip]_[dataset]_[exp]_[ensemble]_[grid]_*.nc'
+  input_file: '[short_name]_[mip]_[dataset]_[exp]_[ensemble]_[grid]*.nc'
   output_file: '[project]_[dataset]_[mip]_[exp]_[ensemble]_[short_name]_[start_year]-[end_year]'
   cmor_type: 'CMIP6'
   institutes:
@@ -147,26 +147,7 @@ CMIP5:
     ETHZ: '[exp]/[mip]/[short_name]/[dataset]/[ensemble]/'
     SMHI: '[dataset]/[ensemble]/[exp]/[frequency]'
     BSC: '[type]/[project]/[exp]/[dataset.lower]'
-  input_file: '[short_name]_[mip]_[dataset]_[exp]_[ensemble]_*.nc'
-  input_fx_dir:
-    default: '/'
-    BADC: '[institute]/[dataset]/[exp]/fx/[modeling_realm]/fx/r0i0p0/[latestversion]/[fx_var]'
-    CP4CDS: '[institute]/[dataset]/[exp]/fx/[modeling_realm]/fx/r0i0p0/[fx_var]/latest/'
-    DKRZ: '[institute]/[dataset]/[exp]/fx/[modeling_realm]/fx/r0i0p0/[latestversion]/[fx_var]'
-    ETHZ: '[exp]/fx/[fx_var]/[dataset]/r0i0p0'
-  input_fx_file: '[fx_var]_fx_[dataset]_[exp]_r0i0p0.nc'
-  fx_mip_change:
-    'areacella': 'Amon'
-    'areacello': 'Omon'
-    'basin': 'Omon'
-    'deptho': 'Omon'
-    'mrsofc': 'Lmon'
-    'orog': 'Amon'
-    'rootd': 'Lmon'
-    'sftgif': 'Lmon'
-    'sftlf': 'Amon'
-    'sftof': 'Omon'
-    'volcello': 'Omon'
+  input_file: '[short_name]_[mip]_[dataset]_[exp]_[ensemble]*.nc'
   output_file: '[project]_[dataset]_[mip]_[exp]_[ensemble]_[short_name]_[start_year]-[end_year]'
   institutes:
     'ACCESS1-0': ['CSIRO-BOM']
@@ -239,10 +220,6 @@ OBS:
   input_file:
     default: '[project]_[dataset]_[type]_[version]_[mip]_[short_name]_*.nc'
     BSC: '[short_name]_*.nc'
-  input_fx_dir:
-    default: 'Tier[tier]/[dataset]'
-  input_fx_file:
-    default: '[project]_[dataset]_[type]_[version]_fx_[fx_var].nc'
   output_file: '[project]_[dataset]_[type]_[version]_[mip]_[short_name]_[start_year]-[end_year]'
   cmor_type: 'CMIP5'
 
@@ -251,10 +228,6 @@ obs4mips:
   input_dir:
     default: 'Tier[tier]/[dataset]'
   input_file: '[short_name]_[dataset]_[level]_[version]_*.nc'
-  input_fx_dir:
-    default: 'Tier[tier]/[dataset]'
-  input_fx_file:
-    default: '[project]_[dataset]_fx_[fx_var].nc'
   output_file: '[project]_[dataset]_[level]_[version]_[short_name]_[start_year]-[end_year]'
   cmor_type: 'CMIP6'
   cmor_path: 'obs4mips'

--- a/esmvaltool/preprocessor/_derive/nbp_grid.py
+++ b/esmvaltool/preprocessor/_derive/nbp_grid.py
@@ -12,7 +12,7 @@ class DerivedVariable(DerivedVariableBase):
     # Required variables
     required = [{
         'short_name': 'nbp',
-        'fx_files': ['sftlf'],
+        'fx_files': [{'short_name': 'sftlf'}],
     }]
 
     @staticmethod

--- a/tests/integration/preprocessor/_derive/test_interface.py
+++ b/tests/integration/preprocessor/_derive/test_interface.py
@@ -26,7 +26,7 @@ def test_get_required_with_fx():
 
     reference = [{
         'short_name': 'nbp',
-        'fx_files': ['sftlf'],
+        'fx_files': [{'short_name': 'sftlf'}],
     }]
 
     assert variables == reference

--- a/tests/integration/test_data_finder.py
+++ b/tests/integration/test_data_finder.py
@@ -3,12 +3,11 @@ import os
 import shutil
 import tempfile
 
+import esmvaltool._config
 import pytest
 import yaml
-
-import esmvaltool._config
-from esmvaltool._data_finder import (get_input_filelist, get_input_fx_filelist,
-                                     get_output_file)
+from esmvaltool._data_finder import get_input_filelist, get_output_file
+from esmvaltool._recipe import get_input_fx_filelist
 from esmvaltool.cmor.table import read_cmor_tables
 
 # Initialize with standard config developer file
@@ -103,11 +102,18 @@ def test_get_input_fx_filelist(root, cfg):
     # Find files
     rootpath = {cfg['variable']['project']: [root]}
     drs = {cfg['variable']['project']: cfg['drs']}
-    fx_files = get_input_fx_filelist(cfg['variable'], rootpath, drs)
+    cfg['variable']['fx_files'] = [
+        {'short_name': short_name} for short_name
+        in cfg['variable']['fx_files']
+    ]
+    fx_files_dict = get_input_fx_filelist(
+        variable=cfg['variable'],
+        rootpath=rootpath,
+        drs=drs)
 
     # Test result
     reference = {
         fx_var: os.path.join(root, filename) if filename else None
         for fx_var, filename in cfg['found_files'].items()
     }
-    assert fx_files == reference
+    assert fx_files_dict == reference

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -100,7 +100,7 @@ def patched_datafinder(tmp_path, monkeypatch):
         filename = str(tmp_path / 'input' / filename)
         filenames = []
         if filename.endswith('*.nc'):
-            filename = filename[:-len('*.nc')]
+            filename = filename[:-len('*.nc')] + '_'
             intervals = [
                 '1990_1999',
                 '2000_2009',


### PR DESCRIPTION
The simplified version of #1037 (there are no CMOR checks and fixes for fx vars in this PR) - basically uses the standard input and output data structures for FX variables as well, removing the need for special fx I/O; tested with CMIP5 and CMIP6 data; note that now if a variable needs fx files for diagnostic they are specified slightly more complex:
```
    variables:
      tos:
        preprocessor: pp_rad
        mip: Omon
        grid: gn
        fx_files: [{short_name: areacello, mip: Ofx}, ]
```
since for CMIP5 this was not needed because mip=fx always for fx variables in CMIP5; a bit different for CMIP6 though.

@bouweandela can u pls have a look at the recipe tests that are systematically failing? I fail to see why this is happening. Cheers, dude :beer: 