### PR TITLE
Magic smpi cp4cds

### DIFF
--- a/esmvaltool/recipes/recipe_smpi.yml
+++ b/esmvaltool/recipes/recipe_smpi.yml
@@ -89,7 +89,6 @@ diagnostics:
         preprocessor: ppALL
         reference_dataset: ERA-Interim
         mip: Amon
-        field: T3M
     additional_datasets:
       - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
     scripts:
@@ -114,7 +113,6 @@ diagnostics:
         preprocessor: ppALL
         reference_dataset: ERA-Interim
         mip: Amon
-        field: T3M
     additional_datasets:
       - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
     scripts:
@@ -139,7 +137,6 @@ diagnostics:
         preprocessor: ppALL
         reference_dataset: ERA-Interim
         mip: Amon
-        field: T3M
     additional_datasets:
       - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
     scripts:
@@ -164,7 +161,6 @@ diagnostics:
         preprocessor: ppALL
         reference_dataset: ERA-Interim
         mip: Amon
-        field: T3M
     additional_datasets:
       - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
     scripts:
@@ -189,7 +185,6 @@ diagnostics:
         preprocessor: ppNOLEV
         reference_dataset: ERA-Interim
         mip: Amon
-        field: T2Ms
     additional_datasets:
       - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
     scripts:
@@ -214,7 +209,6 @@ diagnostics:
         preprocessor: ppNOLEV
         reference_dataset: ERA-Interim
         mip: Amon
-        field: T2Ms
     additional_datasets:
       - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
     scripts:
@@ -239,7 +233,6 @@ diagnostics:
         preprocessor: ppNOLEV
         reference_dataset: GPCP-SG
         mip: Amon
-        field: T2Ms
     additional_datasets:
       - {dataset: GPCP-SG, project: obs4mips, level: L3, version: v2.2, start_year: 1980, end_year: 2005, tier: 1}
     scripts:
@@ -264,7 +257,6 @@ diagnostics:
         preprocessor: ppNOLEVirreg
         reference_dataset: HadISST
         mip: Omon
-        field: T2Ms
     additional_datasets:
       - {dataset: HadISST, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 2}
     scripts:
@@ -289,7 +281,6 @@ diagnostics:
         preprocessor: ppNOLEVirreg
         reference_dataset: HadISST
         mip: OImon
-        field: T2Ms
     additional_datasets:
       - {dataset: HadISST, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 2}
     scripts:
@@ -314,7 +305,6 @@ diagnostics:
         preprocessor: ppNOLEVirreg
         reference_dataset: ERA-Interim
         mip: Omon
-        field: T2Ms
     additional_datasets:
       - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
     scripts:
@@ -339,7 +329,6 @@ diagnostics:
         preprocessor: ppNOLEV
         reference_dataset: ERA-Interim
         mip: Amon
-        field: TO2Ms
     additional_datasets:
       - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
     scripts:
@@ -364,7 +353,6 @@ diagnostics:
         preprocessor: ppNOLEV
         reference_dataset: ERA-Interim
         mip: Amon
-        field: TO2Ms
     additional_datasets:
       - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
     scripts:

--- a/esmvaltool/recipes/recipe_smpi_4cds.yml
+++ b/esmvaltool/recipes/recipe_smpi_4cds.yml
@@ -24,23 +24,23 @@ documentation:
     - c3s-magic
 
 datasets:
-  - {dataset: ACCESS1-0, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: CanESM2, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: CMCC-CESM, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: CNRM-CM5, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: CNRM-CM5-2, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: GFDL-CM3, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: GFDL-ESM2G, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: GFDL-ESM2M, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: HadGEM2-CC, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: HadGEM2-ES, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: IPSL-CM5A-LR, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: IPSL-CM5A-MR, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: IPSL-CM5B-LR, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: MPI-ESM-MR, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: MPI-ESM-P, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: NorESM1-M, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: NorESM1-ME, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: ACCESS1-0, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 1990}
+  - {dataset: CanESM2, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 1990}
+  - {dataset: CMCC-CESM, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 1990}
+  - {dataset: CNRM-CM5, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 1990}
+  - {dataset: CNRM-CM5-2, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 1990}
+  - {dataset: GFDL-CM3, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 1990}
+  - {dataset: GFDL-ESM2G, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 1990}
+  - {dataset: GFDL-ESM2M, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 1990}
+  - {dataset: HadGEM2-CC, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 1990}
+  - {dataset: HadGEM2-ES, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 1990}
+  - {dataset: IPSL-CM5A-LR, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 1990}
+  - {dataset: IPSL-CM5A-MR, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 1990}
+  - {dataset: IPSL-CM5B-LR, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 1990}
+  - {dataset: MPI-ESM-MR, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 1990}
+  - {dataset: MPI-ESM-P, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 1990}
+  - {dataset: NorESM1-M, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 1990}
+  - {dataset: NorESM1-ME, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 1990}
 
 
 preprocessors:
@@ -98,7 +98,7 @@ diagnostics:
         mip: Amon
         field: T3M
     additional_datasets:
-      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
+      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 3}
     scripts:
       grading: &grading_settings
         script: perfmetrics/main.ncl
@@ -123,7 +123,7 @@ diagnostics:
         mip: Amon
         field: T3M
     additional_datasets:
-      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
+      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 3}
     scripts:
       grading:
         script: perfmetrics/main.ncl
@@ -148,7 +148,7 @@ diagnostics:
         mip: Amon
         field: T3M
     additional_datasets:
-      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
+      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 3}
     scripts:
       grading:
         script: perfmetrics/main.ncl
@@ -173,7 +173,7 @@ diagnostics:
         mip: Amon
         field: T3M
     additional_datasets:
-      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
+      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 3}
     scripts:
       grading:
         script: perfmetrics/main.ncl
@@ -198,7 +198,7 @@ diagnostics:
         mip: Amon
         field: T2Ms
     additional_datasets:
-      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
+      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 3}
     scripts:
       grading:
         script: perfmetrics/main.ncl
@@ -223,7 +223,7 @@ diagnostics:
         mip: Amon
         field: T2Ms
     additional_datasets:
-      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
+      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 3}
     scripts:
       grading:
         script: perfmetrics/main.ncl
@@ -248,7 +248,7 @@ diagnostics:
         mip: Amon
         field: T2Ms
     additional_datasets:
-      - {dataset: GPCP-SG, project: obs4mips, level: L3, version: v2.2, start_year: 1980, end_year: 2005, tier: 1}
+      - {dataset: GPCP-SG, project: obs4mips, level: L3, version: v2.2, start_year: 1980, end_year: 1990, tier: 1}
     scripts:
       grading:
         script: perfmetrics/main.ncl
@@ -273,7 +273,7 @@ diagnostics:
         mip: Omon
         field: T2Ms
     additional_datasets:
-      - {dataset: HadISST, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 2}
+      - {dataset: HadISST, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 2}
     scripts:
       grading:
         script: perfmetrics/main.ncl
@@ -298,7 +298,7 @@ diagnostics:
         mip: OImon
         field: T2Ms
     additional_datasets:
-      - {dataset: HadISST, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 2}
+      - {dataset: HadISST, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 2}
     scripts:
       grading:
         script: perfmetrics/main.ncl
@@ -323,7 +323,7 @@ diagnostics:
 #        mip: Omon
 #        field: T2Ms
 #    additional_datasets:
-#      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
+#      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 3}
 #    scripts:
 #      grading:
 #        script: perfmetrics/main.ncl
@@ -348,7 +348,7 @@ diagnostics:
         mip: Amon
         field: TO2Ms
     additional_datasets:
-      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
+      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 3}
     scripts:
       grading:
         script: perfmetrics/main.ncl
@@ -373,7 +373,7 @@ diagnostics:
         mip: Amon
         field: TO2Ms
     additional_datasets:
-      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
+      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 3}
     scripts:
       grading:
         script: perfmetrics/main.ncl

--- a/esmvaltool/recipes/recipe_smpi_4cds.yml
+++ b/esmvaltool/recipes/recipe_smpi_4cds.yml
@@ -24,17 +24,28 @@ documentation:
     - c3s-magic
 
 datasets:
-  - {dataset: CNRM-CM5,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: CSIRO-Mk3-6-0,  project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-#  - {dataset: GFDL-ESM2G,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-#  - {dataset: MIROC5,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-#  - {dataset: MIROC-ESM,      project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-#  - {dataset: MIROC-ESM-CHEM, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-#  - {dataset: MPI-ESM-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-#  - {dataset: MPI-ESM-MR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-#  - {dataset: MRI-CGCM3,      project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-#  - {dataset: NorESM1-M,      project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-#  - {dataset: NorESM1-ME,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: ACCESS1-0, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: bcc-csm1-1, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: bcc-csm1-1-m, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: CanESM2, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: CMCC-CESM, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: CNRM-CM5, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: CNRM-CM5-2, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: GFDL-CM3, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: GFDL-ESM2G, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: GFDL-ESM2M, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: HadGEM2-CC, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: HadGEM2-ES, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: inmcm4, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: IPSL-CM5A-LR, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: IPSL-CM5A-MR, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: IPSL-CM5B-LR, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: MPI-ESM-LR, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: MPI-ESM-MR, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: MPI-ESM-P, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: NorESM1-M, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: NorESM1-ME, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+
 
 preprocessors:
 

--- a/esmvaltool/recipes/recipe_smpi_4cds.yml
+++ b/esmvaltool/recipes/recipe_smpi_4cds.yml
@@ -96,7 +96,6 @@ diagnostics:
         preprocessor: ppALL
         reference_dataset: ERA-Interim
         mip: Amon
-        field: T3M
     additional_datasets:
       - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 3}
     scripts:
@@ -121,7 +120,6 @@ diagnostics:
         preprocessor: ppALL
         reference_dataset: ERA-Interim
         mip: Amon
-        field: T3M
     additional_datasets:
       - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 3}
     scripts:
@@ -146,7 +144,6 @@ diagnostics:
         preprocessor: ppALL
         reference_dataset: ERA-Interim
         mip: Amon
-        field: T3M
     additional_datasets:
       - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 3}
     scripts:
@@ -171,7 +168,6 @@ diagnostics:
         preprocessor: ppALL
         reference_dataset: ERA-Interim
         mip: Amon
-        field: T3M
     additional_datasets:
       - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 3}
     scripts:
@@ -196,7 +192,6 @@ diagnostics:
         preprocessor: ppNOLEV
         reference_dataset: ERA-Interim
         mip: Amon
-        field: T2Ms
     additional_datasets:
       - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 3}
     scripts:
@@ -221,7 +216,6 @@ diagnostics:
         preprocessor: ppNOLEV
         reference_dataset: ERA-Interim
         mip: Amon
-        field: T2Ms
     additional_datasets:
       - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 3}
     scripts:
@@ -246,7 +240,6 @@ diagnostics:
         preprocessor: ppNOLEV
         reference_dataset: GPCP-SG
         mip: Amon
-        field: T2Ms
     additional_datasets:
       - {dataset: GPCP-SG, project: obs4mips, level: L3, version: v2.2, start_year: 1980, end_year: 1990, tier: 1}
     scripts:
@@ -271,7 +264,6 @@ diagnostics:
         preprocessor: ppNOLEVirreg
         reference_dataset: HadISST
         mip: Omon
-        field: T2Ms
     additional_datasets:
       - {dataset: HadISST, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 2}
     scripts:
@@ -296,7 +288,6 @@ diagnostics:
         preprocessor: ppNOLEVirreg
         reference_dataset: HadISST
         mip: OImon
-        field: T2Ms
     additional_datasets:
       - {dataset: HadISST, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 2}
     scripts:
@@ -321,7 +312,6 @@ diagnostics:
 #        preprocessor: ppNOLEVirreg
 #        reference_dataset: ERA-Interim
 #        mip: Omon
-#        field: T2Ms
 #    additional_datasets:
 #      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 3}
 #    scripts:
@@ -346,7 +336,6 @@ diagnostics:
         preprocessor: ppNOLEV
         reference_dataset: ERA-Interim
         mip: Amon
-        field: TO2Ms
     additional_datasets:
       - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 3}
     scripts:
@@ -371,7 +360,6 @@ diagnostics:
         preprocessor: ppNOLEV
         reference_dataset: ERA-Interim
         mip: Amon
-        field: TO2Ms
     additional_datasets:
       - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 1990, tier: 3}
     scripts:

--- a/esmvaltool/recipes/recipe_smpi_4cds.yml
+++ b/esmvaltool/recipes/recipe_smpi_4cds.yml
@@ -1,0 +1,388 @@
+###############################################################################
+# recipe_smpi.xml
+---
+documentation:
+  description: |
+    Recipe for computing Single Model Performance Index. Follows Reichler
+    and Kim 2008. Considers variables:
+    Sea level pressure, Air Temperature, Zonal Wind Stress, Meridional Wind
+    Stress, 2m air temperature, Zonal Wind, Meridional Wind, Net surface heat
+    flux, Precipitation, Specific Humidity, Snow fraction, Sea Surface
+    Temperature, Sea Ice Fraction and sea surface salinity.
+
+  authors:
+    - hass_bg
+    - gier_be
+    - righ_ma
+    - eyri_ve
+
+  references:
+    - rk2008bams
+
+  projects:
+    - crescendo
+    - c3s-magic
+
+datasets:
+  - {dataset: CNRM-CM5,       project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+  - {dataset: CSIRO-Mk3-6-0,  project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+#  - {dataset: GFDL-ESM2G,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+#  - {dataset: MIROC5,         project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+#  - {dataset: MIROC-ESM,      project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+#  - {dataset: MIROC-ESM-CHEM, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+#  - {dataset: MPI-ESM-LR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+#  - {dataset: MPI-ESM-MR,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+#  - {dataset: MRI-CGCM3,      project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+#  - {dataset: NorESM1-M,      project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+#  - {dataset: NorESM1-ME,     project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
+
+preprocessors:
+
+  ppALL:
+    extract_levels:
+      levels: reference_dataset
+      scheme: linear
+    regrid:
+      target_grid: reference_dataset
+      scheme: linear
+    mask_fillvalues:
+      threshold_fraction: 0.10
+    multi_model_statistics:
+      span: overlap
+      statistics: [mean]
+      exclude: [reference_dataset]
+
+  ppNOLEV:
+   # extract_levels: false
+    regrid:
+      target_grid: reference_dataset
+      scheme: linear
+    mask_fillvalues:
+      threshold_fraction: 0.10
+    multi_model_statistics:
+      span: overlap
+      statistics: [mean]
+      exclude: [reference_dataset]
+
+  ppNOLEVirreg:
+    #extract_levels: false
+    regrid:
+      target_grid: 1x1
+      scheme: linear
+    mask_fillvalues:
+      threshold_fraction: 0.10
+    multi_model_statistics:
+      span: overlap
+      statistics: [mean]
+      exclude: [reference_dataset]
+
+diagnostics:
+
+  ta:
+    description: Air temperature zonal mean
+    themes:
+      - phys
+    realms:
+      - atmos
+    variables:
+      ta:
+        preprocessor: ppALL
+        reference_dataset: ERA-Interim
+        mip: Amon
+        field: T3M
+    additional_datasets:
+      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
+    scripts:
+      grading: &grading_settings
+        script: perfmetrics/main.ncl
+        plot_type: cycle_zonal
+        time_avg: yearly
+        region: global
+        calc_grading: true
+        metric: [SMPI]
+        normalization: CMIP5
+        smpi_n_bootstrap: 100
+
+  va:
+    description: Meridional Wind
+    themes:
+      - phys
+    realms:
+      - atmos
+    variables:
+      va:
+        preprocessor: ppALL
+        reference_dataset: ERA-Interim
+        mip: Amon
+        field: T3M
+    additional_datasets:
+      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
+    scripts:
+      grading:
+        script: perfmetrics/main.ncl
+        plot_type: cycle_zonal
+        time_avg: yearly
+        region: global
+        calc_grading: true
+        metric: [SMPI]
+        normalization: CMIP5
+        smpi_n_bootstrap: 100
+
+  ua:
+    description: Zonal Wind
+    themes:
+      - phys
+    realms:
+      - atmos
+    variables:
+      ua:
+        preprocessor: ppALL
+        reference_dataset: ERA-Interim
+        mip: Amon
+        field: T3M
+    additional_datasets:
+      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
+    scripts:
+      grading:
+        script: perfmetrics/main.ncl
+        plot_type: cycle_zonal
+        time_avg: yearly
+        region: global
+        calc_grading: true
+        metric: [SMPI]
+        normalization: CMIP5
+        smpi_n_bootstrap: 100
+
+  hus:
+    description: Near-surface temperature
+    themes:
+      - phys
+    realms:
+      - atmos
+    variables:
+      hus:
+        preprocessor: ppALL
+        reference_dataset: ERA-Interim
+        mip: Amon
+        field: T3M
+    additional_datasets:
+      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
+    scripts:
+      grading:
+        script: perfmetrics/main.ncl
+        plot_type: cycle_zonal
+        time_avg: yearly
+        region: global
+        calc_grading: true
+        metric: [SMPI]
+        normalization: CMIP5
+        smpi_n_bootstrap: 100
+
+  tas:
+    description: Near-surface temperature
+    themes:
+      - phys
+    realms:
+      - atmos
+    variables:
+      tas:
+        preprocessor: ppNOLEV
+        reference_dataset: ERA-Interim
+        mip: Amon
+        field: T2Ms
+    additional_datasets:
+      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
+    scripts:
+      grading:
+        script: perfmetrics/main.ncl
+        plot_type: cycle_latlon
+        time_avg: yearly
+        region: global
+        calc_grading: true
+        metric: [SMPI]
+        normalization: CMIP5
+        smpi_n_bootstrap: 100
+
+  psl:
+    description: Sea-level pressure
+    themes:
+      - phys
+    realms:
+      - atmos
+    variables:
+      psl:
+        preprocessor: ppNOLEV
+        reference_dataset: ERA-Interim
+        mip: Amon
+        field: T2Ms
+    additional_datasets:
+      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
+    scripts:
+      grading:
+        script: perfmetrics/main.ncl
+        plot_type: cycle_latlon
+        time_avg: yearly
+        region: global
+        calc_grading: true
+        metric: [SMPI]
+        normalization: CMIP5
+        smpi_n_bootstrap: 100
+
+  pr:
+    description: Precipitation
+    themes:
+      - phys
+    realms:
+      - atmos
+    variables:
+      pr:
+        preprocessor: ppNOLEV
+        reference_dataset: GPCP-SG
+        mip: Amon
+        field: T2Ms
+    additional_datasets:
+      - {dataset: GPCP-SG, project: obs4mips, level: L3, version: v2.2, start_year: 1980, end_year: 2005, tier: 1}
+    scripts:
+      grading:
+        script: perfmetrics/main.ncl
+        plot_type: cycle_latlon
+        time_avg: yearly
+        region: global
+        calc_grading: true
+        metric: [SMPI]
+        normalization: CMIP5
+        smpi_n_bootstrap: 100
+
+  tos:
+    description: Sea surface temperature
+    themes:
+      - phys
+    realms:
+      - ocean
+    variables:
+      tos:
+        preprocessor: ppNOLEVirreg
+        reference_dataset: HadISST
+        mip: Omon
+        field: T2Ms
+    additional_datasets:
+      - {dataset: HadISST, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 2}
+    scripts:
+      grading:
+        script: perfmetrics/main.ncl
+        plot_type: cycle_latlon
+        time_avg: yearly
+        region: global
+        calc_grading: true
+        metric: [SMPI]
+        normalization: CMIP5
+        smpi_n_bootstrap: 100
+
+  sic:
+    description: Sea ice fraction
+    themes:
+      - phys
+    realms:
+      - seaIce
+    variables:
+      sic:
+        preprocessor: ppNOLEVirreg
+        reference_dataset: HadISST
+        mip: OImon
+        field: T2Ms
+    additional_datasets:
+      - {dataset: HadISST, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 2}
+    scripts:
+      grading:
+        script: perfmetrics/main.ncl
+        plot_type: cycle_latlon
+        time_avg: yearly
+        region: global
+        calc_grading: true
+        metric: [SMPI]
+        normalization: CMIP5
+        smpi_n_bootstrap: 100
+
+#  hfds:
+#    description: Net Surface Heat Flux
+#    themes:
+#      - phys
+#    realms:
+#      - ocean
+#    variables:
+#      hfds:
+#        preprocessor: ppNOLEVirreg
+#        reference_dataset: ERA-Interim
+#        mip: Omon
+#        field: T2Ms
+#    additional_datasets:
+#      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
+#    scripts:
+#      grading:
+#        script: perfmetrics/main.ncl
+#        plot_type: cycle_latlon
+#        time_avg: yearly
+#        region: global
+#        calc_grading: true
+#        metric: [SMPI]
+#        normalization: CMIP5
+#        smpi_n_bootstrap: 100
+
+  tauu:
+    description: Zonal Wind Stress
+    themes:
+      - phys
+    realms:
+      - atmos
+    variables:
+      tauu:
+        preprocessor: ppNOLEV
+        reference_dataset: ERA-Interim
+        mip: Amon
+        field: TO2Ms
+    additional_datasets:
+      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
+    scripts:
+      grading:
+        script: perfmetrics/main.ncl
+        plot_type: cycle_latlon
+        time_avg: yearly
+        region: global
+        calc_grading: true
+        metric: [SMPI]
+        normalization: CMIP5
+        smpi_n_bootstrap: 100
+
+  tauv:
+    description: Meridional Wind Stress
+    themes:
+      - phys
+    realms:
+      - atmos
+    variables:
+      tauv:
+        preprocessor: ppNOLEV
+        reference_dataset: ERA-Interim
+        mip: Amon
+        field: TO2Ms
+    additional_datasets:
+      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, start_year: 1980, end_year: 2005, tier: 3}
+    scripts:
+      grading:
+        script: perfmetrics/main.ncl
+        plot_type: cycle_latlon
+        time_avg: yearly
+        region: global
+        calc_grading: true
+        metric: [SMPI]
+        normalization: CMIP5
+        smpi_n_bootstrap: 100
+
+### COLLECT METRICS ###################
+  collect:
+    description: Wrapper to collect and plot previously calculated metrics
+    scripts:
+      SMPI:
+        script: perfmetrics/collect.ncl
+        ancestors: ['*/grading']
+        metric: SMPI

--- a/esmvaltool/recipes/recipe_smpi_4cds.yml
+++ b/esmvaltool/recipes/recipe_smpi_4cds.yml
@@ -25,8 +25,6 @@ documentation:
 
 datasets:
   - {dataset: ACCESS1-0, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: bcc-csm1-1, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: bcc-csm1-1-m, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
   - {dataset: CanESM2, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
   - {dataset: CMCC-CESM, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
   - {dataset: CNRM-CM5, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
@@ -36,11 +34,9 @@ datasets:
   - {dataset: GFDL-ESM2M, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
   - {dataset: HadGEM2-CC, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
   - {dataset: HadGEM2-ES, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: inmcm4, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
   - {dataset: IPSL-CM5A-LR, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
   - {dataset: IPSL-CM5A-MR, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
   - {dataset: IPSL-CM5B-LR, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
-  - {dataset: MPI-ESM-LR, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
   - {dataset: MPI-ESM-MR, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
   - {dataset: MPI-ESM-P, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}
   - {dataset: NorESM1-M, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1980, end_year: 2005}


### PR DESCRIPTION
The recipe `recipe_smpi_4cds.yml` was adjusted to the cp4cds datasets and was tested on Jasmin. Due to the memory requirements of this recipe and the available memory at the high-mem nodes we need to choose between 17 models/10 years or 5 Models/25 years or something in between.
We used the following resource request:
```
#!/bin/bash                   
#BSUB -q high-mem             
#BSUB -o %J.out               
#BSUB -e %J.err               
#BSUB -W 05:00                
#BSUB -M 256000               
#BSUB -R "rusage[mem=256000]" 
```
This is the useage summary:
```
    CPU time :                                   56341.02 sec.
    Max Memory :                                 220927 MB
    Average Memory :                             179419.31 MB
    Total Requested Memory :                     256000.00 MB
    Delta Memory :                               35073.00 MB
    Max Swap :                                   1196104 MB
    Max Processes :                              16
    Max Threads :                                480
    Run time :                                   11555 sec.
    Turnaround time :                            11555 sec.
``` 