### PR TITLE
Added CMORizer for CRU

### DIFF
--- a/doc/sphinx/source/user_guide2/observations.inc
+++ b/doc/sphinx/source/user_guide2/observations.inc
@@ -37,6 +37,8 @@ A list of the datasets for which a cmorizers is available is provided in the fol
 | CERES-SYN1deg                | rlds, rldscs, rlus, rluscs, rlut, rlutcs, rsds, rsdscs, rsus, rsuscs, rsut, rsutcs (3hr)             |   3  | NCL             |
 |                              | rlds, rldscs, rlus, rlut, rlutcs, rsds, rsdt, rsus, rsut, rsutcs (Amon)                              |      |                 |
 +------------------------------+------------------------------------------------------------------------------------------------------+------+-----------------+
+| CRU                          | tas, pr (Amon)                                                                                       |   2  | Python          |
++------------------------------+------------------------------------------------------------------------------------------------------+------+-----------------+
 | ERA-Interim                  | clivi, clt, clwvi, hfds, hur, hus, pr, prw, ps, psl, ta, tas, tauu, tauv, ts, ua, va, wap, zg (Amon) |   3  | NCL             |
 |                              | pr, psl, tas, tasmin, tasmax, zg (day), sftlf (fx), tos (Omon)                                       |      |                 |
 +------------------------------+------------------------------------------------------------------------------------------------------+------+-----------------+

--- a/esmvaltool/config-references.yml
+++ b/esmvaltool/config-references.yml
@@ -600,6 +600,7 @@ references:
   # Observations
   aura-tes: "Beer, R., IEEE Trans. Geosci. Rem. Sens., doi:10.1109/TGRS.2005.863716, 2006."
   ceres-syn1deg: "Wielicki et al., Bull. Amer. Meteor. Soc., doi: 10.1175/1520-0477(1996)077<0853:CATERE>2.0.CO;2, 1996."
+  cru: "Harris, I. et al., Int. J. Climatol., 34, doi: 10.1002/joc.3711, 2014."
   era-interim: "Dee, D. P. et al., Q. J. Roy. Meteor. Soc., doi:10.1002/qj.828, 2011."
   esacci-aerosol: "Popp et al., ESA Aerosol Climate Change Initiative (ESA Aerosol_cci) data: AOD v4.21 via Centre for Environmental Data Analysis, 2016."
   esacci-cloud: "Stengel et al., Earth Syst. Sci. Data, doi:10.5194/essd-9-881-2017, 2017."

--- a/esmvaltool/recipes/examples/recipe_check_obs.yml
+++ b/esmvaltool/recipes/examples/recipe_check_obs.yml
@@ -565,7 +565,7 @@ diagnostics:
       gppStderr:
         mip: Lmon
     additional_datasets:
-      - {dataset: MTE, project: OBS, tier: 3, type: clim, version: May12, start_year: 1982, end_year: 2011}
+      - {dataset: MTE, project: OBS, tier: 3, type: reanaly, version: May12, start_year: 1982, end_year: 2011}
     scripts: null
 
 

--- a/esmvaltool/recipes/examples/recipe_check_obs.yml
+++ b/esmvaltool/recipes/examples/recipe_check_obs.yml
@@ -20,6 +20,17 @@ diagnostics:
 
   ### TIER 2 ##################################################################
 
+  CRU:
+    description: CRU
+    variables:
+      tas:
+        mip: Amon
+      pr:
+        mip: Amon
+    additional_datasets:
+      - {dataset: CRU, project: OBS, tier: 2, type: reanaly, version: TS4.02, start_year: 1901, end_year: 2017}
+    scripts: null
+
   ESACCI-AEROSOL:
     description: ESACCI-AEROSOL
     variables:

--- a/esmvaltool/utils/cmorizers/obs/cmor_config/CRU.yml
+++ b/esmvaltool/utils/cmorizers/obs/cmor_config/CRU.yml
@@ -1,6 +1,6 @@
 ---
 # Filename (will be extended by variable name)
-filename: 'cru_ts4.02.1901.2017.{raw_name}.dat.nc'
+filename: 'cru_ts4.02.1901.2017.{raw_name}.dat.nc.gz'
 
 # Common global attributes for Cmorizer output
 attributes:

--- a/esmvaltool/utils/cmorizers/obs/cmor_config/CRU.yml
+++ b/esmvaltool/utils/cmorizers/obs/cmor_config/CRU.yml
@@ -1,0 +1,23 @@
+---
+# Filename (will be extended by variable name)
+filename: 'cru_ts4.02.1901.2017.{raw_name}.dat.nc'
+
+# Common global attributes for Cmorizer output
+attributes:
+  dataset_id: CRU
+  version: 'TS4.02'
+  tier: 2
+  modeling_realm: reanaly
+  project_id: OBS
+  source: 'https://crudata.uea.ac.uk/cru/data/hrg/cru_ts_4.02/cruts.1811131722.v4.02/'
+  reference: 'cru'
+  comment: ''
+
+# Variables to cmorize
+variables:
+  tas:
+    mip: Amon
+    raw: tmp
+  pr:
+    mip: Amon
+    raw: pre

--- a/esmvaltool/utils/cmorizers/obs/cmorize_obs_CRU.py
+++ b/esmvaltool/utils/cmorizers/obs/cmorize_obs_CRU.py
@@ -36,6 +36,8 @@ def _extract_variable(raw_var, cmor_info, attrs, filepath, out_dir):
     utils.convert_timeunits(cube, 1950)
     utils.fix_coords(cube)
     utils.set_global_atts(cube, attrs)
+    if var in ('tas',):
+        utils.add_height2m(cube)
     utils.save_variable(
         cube, var, out_dir, attrs, unlimited_dimensions=['time'])
 

--- a/esmvaltool/utils/cmorizers/obs/cmorize_obs_CRU.py
+++ b/esmvaltool/utils/cmorizers/obs/cmorize_obs_CRU.py
@@ -11,13 +11,15 @@ Last access
 
 Download and processing instructions
     Download the following files:
-        cru_ts4.02.1901.2017.{raw_name}.dat.nc
-    where {raw_name} is the name of the desired variable.
+        {raw_name}/cru_ts4.02.1901.2017.{raw_name}.dat.nc.gz
+    where {raw_name} is the name of the desired variable(s).
 
 """
 
+import gzip
 import logging
 import os
+import shutil
 
 import iris
 
@@ -38,8 +40,22 @@ def _extract_variable(raw_var, cmor_info, attrs, filepath, out_dir):
     utils.set_global_atts(cube, attrs)
     if var in ('tas', ):
         utils.add_height2m(cube)
-    utils.save_variable(
-        cube, var, out_dir, attrs, unlimited_dimensions=['time'])
+    utils.save_variable(cube,
+                        var,
+                        out_dir,
+                        attrs,
+                        unlimited_dimensions=['time'])
+
+
+def _unzip(filepath, out_dir):
+    """Unzip `*.gz` file."""
+    filename = os.path.basename(filepath.replace('.gz', ''))
+    new_path = os.path.join(out_dir, filename)
+    with gzip.open(filepath, 'rb') as zip_file:
+        with open(new_path, 'wb') as new_file:
+            shutil.copyfileobj(zip_file, new_file)
+    logger.info("Succefully extracted file to %s", new_path)
+    return new_path
 
 
 def cmorization(in_dir, out_dir):
@@ -58,9 +74,10 @@ def cmorization(in_dir, out_dir):
         glob_attrs['mip'] = var_info['mip']
         cmor_info = cmor_table.get_variable(var_info['mip'], var)
         raw_var = var_info.get('raw', var)
-        filepath = raw_filepath.format(raw_name=raw_var)
-        if not os.path.isfile(filepath):
-            logger.debug("Skipping '%s', file '%s' not found", var, filepath)
+        zip_file = os.path.join(in_dir, raw_filepath.format(raw_name=raw_var))
+        if not os.path.isfile(zip_file):
+            logger.debug("Skipping '%s', file '%s' not found", var, zip_file)
             continue
-        logger.info("Found input file '%s'", filepath)
+        logger.info("Found input file '%s'", zip_file)
+        filepath = _unzip(zip_file, out_dir)
         _extract_variable(raw_var, cmor_info, glob_attrs, filepath, out_dir)

--- a/esmvaltool/utils/cmorizers/obs/cmorize_obs_CRU.py
+++ b/esmvaltool/utils/cmorizers/obs/cmorize_obs_CRU.py
@@ -1,0 +1,64 @@
+"""ESMValTool CMORizer for CRU data.
+
+Tier
+    Tier 2: other freely-available dataset.
+
+Source
+    https://crudata.uea.ac.uk/cru/data/hrg/cru_ts_4.02/cruts.1811131722.v4.02/
+
+Last access
+    20190516
+
+Download and processing instructions
+    Download the following files:
+        cru_ts4.02.1901.2017.{raw_name}.dat.nc
+    where {raw_name} is the name of the desired variable.
+
+"""
+
+import logging
+import os
+
+import iris
+
+import esmvaltool.utils.cmorizers.obs.utilities as utils
+
+logger = logging.getLogger(__name__)
+
+CFG = utils.read_cmor_config('CRU.yml')
+
+
+def _extract_variable(raw_var, cmor_info, attrs, filepath, out_dir):
+    """Extract variable."""
+    var = cmor_info.short_name
+    cube = iris.load_cube(filepath, utils.var_name_constraint(raw_var))
+    utils.fix_var_metadata(cube, cmor_info)
+    utils.convert_timeunits(cube, 1950)
+    utils.fix_coords(cube)
+    utils.set_global_atts(cube, attrs)
+    utils.save_variable(
+        cube, var, out_dir, attrs, unlimited_dimensions=['time'])
+
+
+def cmorization(in_dir, out_dir):
+    """Cmorization func call."""
+    glob_attrs = CFG['attributes']
+    cmor_table = CFG['cmor_table']
+    logger.info("Starting cmorization for Tier%s OBS files: %s",
+                glob_attrs['tier'], glob_attrs['dataset_id'])
+    logger.info("Input data from: %s", in_dir)
+    logger.info("Output will be written to: %s", out_dir)
+    raw_filepath = os.path.join(in_dir, CFG['filename'])
+
+    # Run the cmorization
+    for (var, var_info) in CFG['variables'].items():
+        logger.info("CMORizing variable '%s'", var)
+        glob_attrs['mip'] = var_info['mip']
+        cmor_info = cmor_table.get_variable(var_info['mip'], var)
+        raw_var = var_info.get('raw', var)
+        filepath = raw_filepath.format(raw_name=raw_var)
+        if not os.path.isfile(filepath):
+            logger.debug("Skipping '%s', file '%s' not found", var, filepath)
+            continue
+        logger.info("Found input file '%s'", filepath)
+        _extract_variable(raw_var, cmor_info, glob_attrs, filepath, out_dir)

--- a/esmvaltool/utils/cmorizers/obs/cmorize_obs_CRU.py
+++ b/esmvaltool/utils/cmorizers/obs/cmorize_obs_CRU.py
@@ -30,6 +30,13 @@ logger = logging.getLogger(__name__)
 CFG = utils.read_cmor_config('CRU.yml')
 
 
+def _clean(filepath):
+    """Remove unzipped input file."""
+    if os.path.isfile(filepath):
+        os.remove(filepath)
+        logger.info("Removed cached file %s", filepath)
+
+
 def _extract_variable(raw_var, cmor_info, attrs, filepath, out_dir):
     """Extract variable."""
     var = cmor_info.short_name
@@ -81,3 +88,4 @@ def cmorization(in_dir, out_dir):
         logger.info("Found input file '%s'", zip_file)
         filepath = _unzip(zip_file, out_dir)
         _extract_variable(raw_var, cmor_info, glob_attrs, filepath, out_dir)
+        _clean(filepath)

--- a/esmvaltool/utils/cmorizers/obs/cmorize_obs_CRU.py
+++ b/esmvaltool/utils/cmorizers/obs/cmorize_obs_CRU.py
@@ -36,7 +36,7 @@ def _extract_variable(raw_var, cmor_info, attrs, filepath, out_dir):
     utils.convert_timeunits(cube, 1950)
     utils.fix_coords(cube)
     utils.set_global_atts(cube, attrs)
-    if var in ('tas',):
+    if var in ('tas', ):
         utils.add_height2m(cube)
     utils.save_variable(
         cube, var, out_dir, attrs, unlimited_dimensions=['time'])

--- a/esmvaltool/utils/cmorizers/obs/utilities.py
+++ b/esmvaltool/utils/cmorizers/obs/utilities.py
@@ -21,8 +21,12 @@ def add_height2m(cube):
     """Add scalar coordinate 'height' with value of 2m."""
     logger.info("Adding height coordinate (2m)")
     height_coord = iris.coords.AuxCoord(
-        2.0, var_name='height', standard_name='height', long_name='height',
-        units=Unit('m'), attributes={'positive': 'up'})
+        2.0,
+        var_name='height',
+        standard_name='height',
+        long_name='height',
+        units=Unit('m'),
+        attributes={'positive': 'up'})
     cube.add_aux_coord(height_coord, ())
 
 

--- a/esmvaltool/utils/cmorizers/obs/utilities.py
+++ b/esmvaltool/utils/cmorizers/obs/utilities.py
@@ -17,6 +17,15 @@ from esmvaltool.cmor.table import CMOR_TABLES
 logger = logging.getLogger(__name__)
 
 
+def add_height2m(cube):
+    """Add scalar coordinate 'height' with value of 2m."""
+    logger.info("Adding height coordinate (2m)")
+    height_coord = iris.coords.AuxCoord(
+        2.0, var_name='height', standard_name='height', long_name='height',
+        units=Unit('m'), attributes={'positive': 'up'})
+    cube.add_aux_coord(height_coord, ())
+
+
 @contextmanager
 def constant_metadata(cube):
     """Do cube math without modifying units etc."""


### PR DESCRIPTION
This PR adds a CMORizer script for the CRU dataset (variables `tas` and `pr`).

There are several other variables available (see [here](https://crudata.uea.ac.uk/cru/data/hrg/cru_ts_4.02/cruts.1811131722.v4.02/)) which can be easily added to this PR by expanding the [config file](https://github.com/ESMValGroup/ESMValTool/blob/version2_cmorize_CRU/esmvaltool/utils/cmorizers/obs/cmor_config/CRU.yml), but I do not know the standard names for most of them. It may be necessary to add custom CMOR tables for them.