### PR TITLE
Remove unused XML library import and sort imports

### DIFF
--- a/esmvaltool/diag_scripts/magic_bsc/PC.r
+++ b/esmvaltool/diag_scripts/magic_bsc/PC.r
@@ -1,5 +1,4 @@
 library(ggplot2)
-library(XML) # nolint
 library(plyr)
 
 read_pc <- function(file) {

--- a/esmvaltool/diag_scripts/magic_bsc/capacity_factor.r
+++ b/esmvaltool/diag_scripts/magic_bsc/capacity_factor.r
@@ -1,13 +1,15 @@
 
 Sys.setenv(TAR = "/bin/tar") # nolint
 
-library(multiApply) # nolint
-library(ggplot2)
-library(yaml)
-library(s2dverification)
+library(abind)
 library(climdex.pcic)
+library(ggplot2)
+library(multiApply) # nolint
 library(ncdf4)
-library("XML")
+library(RColorBrewer) # nolint
+library(s2dverification)
+library(yaml)
+
 #Parsing input file paths and creating output dirs
 args <- commandArgs(trailingOnly = TRUE)
 params <- read_yaml(args[1])
@@ -146,8 +148,6 @@ seas_data_cf5 <- Mean1Dim(data_cf5, 2)
 #---------------------------
 # Prepare data, labels and colorscales
 #---------------------------
-library(RColorBrewer) # nolint
-library(abind)
 p <- colorRampPalette(brewer.pal(9, "YlOrRd"))
 q <- colorRampPalette(rev(brewer.pal(11, "RdBu")))
 years <- seq(start_year, end_year)


### PR DESCRIPTION
recipe_capacity_factor.yml does not work because there is a `library(XML)` load in the diagnostic scripts. However, the XML library appears not to be used and is also not listed in r_requirements.txt. This pull request fixes that.