### PR TITLE
Increase stdout buffer size to prevent NCL crash

### DIFF
--- a/esmvaltool/_task.py
+++ b/esmvaltool/_task.py
@@ -190,7 +190,7 @@ def write_ncl_settings(settings, filename, mode='wt'):
         file.write('\n')
 
 
-class BaseTask(object):
+class BaseTask:
     """Base class for defining task classes."""
 
     def __init__(self, ancestors=None, name=''):
@@ -416,6 +416,7 @@ class DiagnosticTask(BaseTask):
         try:
             process = subprocess.Popen(
                 cmd,
+                bufsize=2**20,  # Use a large buffer to prevent NCL crash
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 cwd=cwd,


### PR DESCRIPTION
Hopefully this should prevent the seemingly random cases where NCL scripts become defunct and esmvaltool never finishes the run.

This issue is also discussed in #1075, #1097, and #1059.