### PR TITLE
fix for data sets written with iris

### DIFF
--- a/esmvaltool/_recipe.py
+++ b/esmvaltool/_recipe.py
@@ -431,7 +431,7 @@ def _read_attributes(filename):
 
     with Dataset(filename, 'r') as dataset:
         for attr in dataset.ncattrs():
-            attributes[attr] = getattr(dataset, attr)
+            attributes[attr] = dataset.getncattr(attr)
     return attributes
 
 


### PR DESCRIPTION
I had issues with a dataset I cmorized and wrote the output with iris.save().

Original error message:
```
  File "/media/bmueller/Work/GIT/ESMValTool_V2_c3s511/esmvaltool/_provenance.py", line 114, in __init__
    self.attributes = copy.deepcopy(attributes)
  File "/home/bmueller/anaconda2/envs/esmvaltool/lib/python3.6/copy.py", line 150, in deepcopy
    y = copier(x, memo)
  File "/home/bmueller/anaconda2/envs/esmvaltool/lib/python3.6/copy.py", line 240, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/home/bmueller/anaconda2/envs/esmvaltool/lib/python3.6/copy.py", line 180, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/home/bmueller/anaconda2/envs/esmvaltool/lib/python3.6/copy.py", line 306, in _reconstruct
    value = deepcopy(value, memo)
  File "/home/bmueller/anaconda2/envs/esmvaltool/lib/python3.6/copy.py", line 180, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/home/bmueller/anaconda2/envs/esmvaltool/lib/python3.6/copy.py", line 280, in _reconstruct
    state = deepcopy(state, memo)
  File "/home/bmueller/anaconda2/envs/esmvaltool/lib/python3.6/copy.py", line 150, in deepcopy
    y = copier(x, memo)
  File "/home/bmueller/anaconda2/envs/esmvaltool/lib/python3.6/copy.py", line 220, in _deepcopy_tuple
    y = [deepcopy(a, memo) for a in x]
  File "/home/bmueller/anaconda2/envs/esmvaltool/lib/python3.6/copy.py", line 220, in <listcomp>
    y = [deepcopy(a, memo) for a in x]
  File "/home/bmueller/anaconda2/envs/esmvaltool/lib/python3.6/copy.py", line 169, in deepcopy
    rv = reductor(4)
  File "netCDF4/_netCDF4.pyx", line 2472, in netCDF4._netCDF4.Dataset.__reduce__
NotImplementedError: Dataset is not picklable
```

@jvegasbsc tracked this down to the _get_attributes method and suggested the applied change.

The reasoning was:

> it is a corner case: the old code will fail when trying to read a netcdf attribute that matches the name of a python attribute because we were using the generic way of doing this in Python. It works when there is no name coinciedence because netcdf4 objects expose netcdf attributes as python attributes *only when* there is no name collision

> To read a netcdf attribute when names are colliding we should use the method in the new code


