### PR TITLE
Activate automatic fixes

### DIFF
--- a/esmvalcore/_config.py
+++ b/esmvalcore/_config.py
@@ -54,6 +54,7 @@ def read_config_user_file(config_file, recipe_name):
         'remove_preproc_dir': False,
         'max_parallel_tasks': 1,
         'run_diagnostic': True,
+        'automatic_fixes': True,
         'profile_diagnostic': False,
         'config_developer_file': None,
         'drs': {},

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -339,6 +339,7 @@ def _get_default_settings(variable, config_user, derive=False):
             'mip': variable['mip'],
             'short_name': variable['short_name'],
             'frequency': variable['frequency'],
+            'automatic_fixes': config_user['automatic_fixes'],
         }
     # Configure final CMOR data check
     if variable.get('cmor_table'):
@@ -347,6 +348,7 @@ def _get_default_settings(variable, config_user, derive=False):
             'mip': variable['mip'],
             'short_name': variable['short_name'],
             'frequency': variable['frequency'],
+            'automatic_fixes': config_user['automatic_fixes']
         }
 
     # Clean up fixed files

--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -568,7 +568,8 @@ def _get_cmor_checker(table,
     return _checker
 
 
-def cmor_check_metadata(cube, cmor_table, mip, short_name, frequency):
+def cmor_check_metadata(cube, cmor_table, mip, short_name, frequency,
+                        automatic_fixes):
     """Check if metadata conforms to variable's CMOR definiton.
 
     None of the checks at this step will force the cube to load the data.
@@ -587,12 +588,15 @@ def cmor_check_metadata(cube, cmor_table, mip, short_name, frequency):
         Data frequency.
 
     """
-    checker = _get_cmor_checker(cmor_table, mip, short_name, frequency)
+    checker = _get_cmor_checker(
+        cmor_table, mip, short_name, frequency, automatic_fixes
+    )
     checker(cube).check_metadata()
     return cube
 
 
-def cmor_check_data(cube, cmor_table, mip, short_name, frequency):
+def cmor_check_data(cube, cmor_table, mip, short_name, frequency,
+                    automatic_fixes):
     """Check if data conforms to variable's CMOR definiton.
 
     The checks performed at this step require the data in memory.
@@ -611,12 +615,14 @@ def cmor_check_data(cube, cmor_table, mip, short_name, frequency):
         Data frequency
 
     """
-    checker = _get_cmor_checker(cmor_table, mip, short_name, frequency)
+    checker = _get_cmor_checker(
+        cmor_table, mip, short_name, frequency, automatic_fixes)
     checker(cube).check_data()
     return cube
 
 
-def cmor_check(cube, cmor_table, mip, short_name, frequency):
+def cmor_check(cube, cmor_table, mip, short_name, frequency,
+               automatic_fixes):
     """Check if cube conforms to variable's CMOR definiton.
 
     Equivalent to calling cmor_check_metadata and cmor_check_data
@@ -636,6 +642,10 @@ def cmor_check(cube, cmor_table, mip, short_name, frequency):
         Data frequency.
 
     """
-    cmor_check_metadata(cube, cmor_table, mip, short_name, frequency)
-    cmor_check_data(cube, cmor_table, mip, short_name, frequency)
+    cmor_check_metadata(
+        cube, cmor_table, mip, short_name, frequency, automatic_fixes
+    )
+    cmor_check_data(
+        cube, cmor_table, mip, short_name, frequency, automatic_fixes
+    )
     return cube

--- a/esmvalcore/config-user.yml
+++ b/esmvalcore/config-user.yml
@@ -36,6 +36,8 @@ config_developer_file: null
 # Only available for Python diagnostics
 profile_diagnostic: false
 
+# Try to automatically fix common errors from datasets
+automatic_fixes: True
 # Rootpaths to the data from different projects (lists are also possible)
 rootpath:
   CMIP5: [~/cmip5_inputpath1, ~/cmip5_inputpath2]

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -66,6 +66,7 @@ def config_user(tmp_path):
     filename = write_config_user_file(tmp_path)
     cfg = esmvalcore._config.read_config_user_file(filename, 'recipe_test')
     cfg['synda_download'] = False
+    cfg['automatic_fixes'] = True
     return cfg
 
 
@@ -296,12 +297,14 @@ def test_default_preprocessor(tmp_path, patched_datafinder, config_user):
             'mip': 'Oyr',
             'short_name': 'chl',
             'frequency': 'yr',
+            'automatic_fixes': True,
         },
         'cmor_check_data': {
             'cmor_table': 'CMIP5',
             'mip': 'Oyr',
             'short_name': 'chl',
             'frequency': 'yr',
+            'automatic_fixes': True,
         },
         'cleanup': {
             'remove': [fix_dir]


### PR DESCRIPTION
Just checked and find that we were not using the automatic fix feature of the cmor check. I activated it by default and allowed users to diable it through `config-user.yml`