### PR TITLE
Do not fail if we get multiple cubes from file

### DIFF
--- a/esmvalcore/cmor/fix.py
+++ b/esmvalcore/cmor/fix.py
@@ -10,9 +10,7 @@ fixed.
 import logging
 from collections import defaultdict
 
-from iris import Constraint
 from iris.cube import CubeList
-from iris.exceptions import ConstraintMismatchError
 
 from ._fixes.fix import Fix
 from .check import _get_cmor_checker
@@ -119,7 +117,7 @@ def fix_metadata(cubes,
                     break
             if not cube:
                 raise ValueError(
-                    'Variable %s not found for %s : %s' % \
+                    'Variable %s not found for %s : %s' % 
                     (short_name, project, dataset)
                 )
             logger.warning(

--- a/esmvalcore/cmor/fix.py
+++ b/esmvalcore/cmor/fix.py
@@ -112,14 +112,15 @@ def fix_metadata(cubes,
         if len(cube_list) != 1:
             logger.warning('Cubes were not reduced to one after'
                            'fixing: %s', cube_list)
-            try:
-                cube = cube_list.extract_strict(Constraint(
-                    cube_func=lambda c: c.var_name == short_name
-                ))
-            except ConstraintMismatchError:
+            cube = None
+            for raw_cube in cube_list:
+                if raw_cube.var_name == short_name:
+                    cube = raw_cube
+                    break
+            if not cube:
                 raise ValueError(
-                    'Variable %s not found for %s:%s' %
-                    short_name, project, dataset
+                    'Variable %s not found for %s : %s' % \
+                    (short_name, project, dataset)
                 )
             logger.warning(
                 'Found variable %s for %s:%s, but there were other present in '


### PR DESCRIPTION
Changed the behaviour to try to select the final cube using the `short_name`. In those cases, ESMValTool will print a couple of warnings detailing the cubes found and the risks of let this kind of errors slip

Should reduce the frustration when using new datasets and the need for fixes, even if fixes can be developed to remove those warnings completely