### PR TITLE
Improved plot labels in zmnam

### DIFF
--- a/esmvaltool/config-references.yml
+++ b/esmvaltool/config-references.yml
@@ -307,7 +307,7 @@ authors:
   serv_fe:
     name: Serva, Federico
     institute: CNR, Italy
-    email: federico.serva 'at' artov.isac.cnr.it
+    email: federico.serva 'at' artov.ismar.cnr.it
   somm_ph:
     name: Sommer, Philipp
     institute: Univ. of Hamburg, Germany

--- a/esmvaltool/diag_scripts/zmnam/zmnam_plot.py
+++ b/esmvaltool/diag_scripts/zmnam/zmnam_plot.py
@@ -202,7 +202,7 @@ def zmnam_plot(file_gh_mo, datafolder, figfolder, src_props,
         clabs = plt.clabel(inv_map, fontsize=8, fmt='%1.0f', zorder=30)
         bbox_dict = dict(boxstyle='square,pad=0', \
                          edgecolor='none', fc='white', zorder=25)
-        _, = [txt.set_bbox(bbox_dict) for txt in clabs]
+        [txt.set_bbox(bbox_dict) for txt in clabs]
 
         axis.coastlines()
         axis.set_global()

--- a/esmvaltool/diag_scripts/zmnam/zmnam_plot.py
+++ b/esmvaltool/diag_scripts/zmnam/zmnam_plot.py
@@ -199,9 +199,9 @@ def zmnam_plot(file_gh_mo, datafolder, figfolder, src_props,
             cmap.set_visible(False)
 
         # Add contour labels over white boxes
-        cb = plt.clabel(inv_map, fontsize=8, fmt='%1.0f', zorder=30)
-        [txt.set_bbox(dict(boxstyle='square,pad=0',edgecolor='none',fc='white',zorder=25)) for txt in cb]
-
+        clabs = plt.clabel(inv_map, fontsize=8, fmt='%1.0f', zorder=30)
+        _, = [txt.set_bbox(dict(boxstyle='square,pad=0', edgecolor='none', \
+                           fc='white', zorder=25)) for txt in clabs]
 
         axis.coastlines()
         axis.set_global()

--- a/esmvaltool/diag_scripts/zmnam/zmnam_plot.py
+++ b/esmvaltool/diag_scripts/zmnam/zmnam_plot.py
@@ -185,20 +185,23 @@ def zmnam_plot(file_gh_mo, datafolder, figfolder, src_props,
         mpl.rcParams['contour.negative_linestyle'] = 'solid'
         plt.contour(lonw, lat, slopew, levels=regr_levs,
                     colors='k', transform=ccrs.PlateCarree(),
-                    zorder=5)
+                    zorder=1)
 
         # Invisible contours, only for labels.
-        # Workaround for cartopy issue, as of Dec 18
+        # Change zorder for cartopy/matplotlib label issue, as of June 2019
         inv_map = plt.contour(lonw, lat, slopew, levels=regr_levs,
                               colors='k', transform=ccrs.PlateCarree(),
-                              zorder=10)
+                              zorder=15)
 
         mpl.rcParams['contour.negative_linestyle'] = 'dashed'
 
         for cmap in inv_map.collections:
             cmap.set_visible(False)
 
-        plt.clabel(inv_map, fontsize=8, fmt='%1.0f', zorder=15)
+        # Add contour labels over white boxes
+        cb = plt.clabel(inv_map, fontsize=8, fmt='%1.0f', zorder=30)
+        [txt.set_bbox(dict(boxstyle='square,pad=0',edgecolor='none',fc='white',zorder=25)) for txt in cb]
+
 
         axis.coastlines()
         axis.set_global()

--- a/esmvaltool/diag_scripts/zmnam/zmnam_plot.py
+++ b/esmvaltool/diag_scripts/zmnam/zmnam_plot.py
@@ -200,8 +200,9 @@ def zmnam_plot(file_gh_mo, datafolder, figfolder, src_props,
 
         # Add contour labels over white boxes
         clabs = plt.clabel(inv_map, fontsize=8, fmt='%1.0f', zorder=30)
-        _, = [txt.set_bbox(dict(boxstyle='square,pad=0', edgecolor='none', \
-                           fc='white', zorder=25)) for txt in clabs]
+        bbox_dict = dict(boxstyle='square,pad=0', \
+                         edgecolor='none', fc='white', zorder=25)
+        _, = [txt.set_bbox(bbox_dict) for txt in clabs]
 
         axis.coastlines()
         axis.set_global()

--- a/esmvaltool/diag_scripts/zmnam/zmnam_plot.py
+++ b/esmvaltool/diag_scripts/zmnam/zmnam_plot.py
@@ -202,7 +202,7 @@ def zmnam_plot(file_gh_mo, datafolder, figfolder, src_props,
         clabs = plt.clabel(inv_map, fontsize=8, fmt='%1.0f', zorder=30)
         bbox_dict = dict(boxstyle='square,pad=0',
                          edgecolor='none', fc='white', zorder=25)
-        [txt.set_bbox(bbox_dict) for txt in clabs]
+        clabs = [txt.set_bbox(bbox_dict) for txt in clabs]
 
         axis.coastlines()
         axis.set_global()

--- a/esmvaltool/diag_scripts/zmnam/zmnam_plot.py
+++ b/esmvaltool/diag_scripts/zmnam/zmnam_plot.py
@@ -200,7 +200,7 @@ def zmnam_plot(file_gh_mo, datafolder, figfolder, src_props,
 
         # Add contour labels over white boxes
         clabs = plt.clabel(inv_map, fontsize=8, fmt='%1.0f', zorder=30)
-        bbox_dict = dict(boxstyle='square,pad=0', \
+        bbox_dict = dict(boxstyle='square,pad=0',
                          edgecolor='none', fc='white', zorder=25)
         [txt.set_bbox(bbox_dict) for txt in clabs]
 


### PR DESCRIPTION
Hello, I am opening this pull request for an improvement of the zmnam recipe. 
In the previous version, due to a known bug with cartopy and matplotlib (see e.g. here https://stackoverflow.com/questions/49048411/cartopy-north-pole-stereographic-contour-plot-does-not-plot-correctly-even-with) the labels were not rendered correctly. After some more tests, I have been able to adjust the plot so that labels are now more legible. 
[CMIP5_MPI-ESM-MR_amip_r1i1p1_1979-2008_25000Pa_mo_reg_new.pdf](https://github.com/ESMValGroup/ESMValTool/files/3342998/CMIP5_MPI-ESM-MR_amip_r1i1p1_1979-2008_25000Pa_mo_reg_new.pdf)
[CMIP5_MPI-ESM-MR_amip_r1i1p1_1979-2008_25000Pa_mo_reg_old.pdf](https://github.com/ESMValGroup/ESMValTool/files/3342999/CMIP5_MPI-ESM-MR_amip_r1i1p1_1979-2008_25000Pa_mo_reg_old.pdf)
The plots for the 'old' and 'new' version are attached. Please also note that for this PR I have updated my e-mail address in the references file. Looking forward to feedback on this. Thanks

