### PR TITLE
Install lintr from conda-forge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             conda update -y conda
             conda env update
             conda activate esmvaltool
-            conda install -yS r-lintr
+            conda install -c conda-forge -yS r-lintr
             python setup.py test
       - save_cache:
           key: test-{{ .Branch }}-{{ checksum "cache_key.txt" }}


### PR DESCRIPTION
This will hopefully fix the currently failing R linter test in other pull requests, even when no R code has changed.