### PR TITLE
pin r-lintr to last stable version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             conda update -y conda
             conda env update
             conda activate esmvaltool
-            conda install -c conda-forge -yS r-lintr
+            conda install -c conda-forge -yS r-lintr=1.0.2
             python setup.py test
       - save_cache:
           key: test-{{ .Branch }}-{{ checksum "cache_key.txt" }}


### PR DESCRIPTION
`r-lintr=1.0.3` (noarch and OSX versions) gets installed after a conda env update and that one is creating problems, see the bottom of #1172 so pinning to the current stable version for `linux-64` solves it see https://anaconda.org/conda-forge/r-lintr