### PR TITLE
R lintr install directly from CRAN

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             conda update -y conda
             conda env update
             conda activate esmvaltool
-            conda install -c conda-forge -yS r-lintr=1.0.2
+            Rscript esmvaltool/install/R/setup_lintr.R
             python setup.py test
       - save_cache:
           key: test-{{ .Branch }}-{{ checksum "cache_key.txt" }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ To install in development mode, follow these instructions.
 -   Create the esmvaltool conda environment `conda env create --name esmvaltool --file environment.yml`
 -   Activate the esmvaltool environment: `conda activate esmvaltool`
 -   Install in development mode: `pip install -e '.[develop]'`. If you are installing behind a proxy that does not trust the usual pip-urls you can declare them with the option `--trusted-host`, e.g. `pip install --trusted-host=pypi.python.org --trusted-host=pypi.org --trusted-host=files.pythonhosted.org -e .[develop]`
--   If you want to use R diagnostics, run `Rscript esmvaltool/install/R/setup.R` to install the R dependences.
+-   If you want to use R diagnostics, run `Rscript esmvaltool/install/R/setup.R` to install the R dependences. Note that if you only want to run the lint test for R scripts you will have to install the `lintr` package. You can do that by running `Rscript esmvaltool/install/R/setup_lintr.R`.
 -   If you want to use Julia diagnostics, run `julia esmvaltool/install/Julia/setup.jl` to install the Julia dependences.
 -   Test that your installation was succesful by running `esmvaltool -h`.
 -   If you log into a cluster or other device via `ssh` and your origin machine sends the `locale` environment via the `ssh` connection, make sure the environment is set correctly, specifically `LANG` and `LC_ALL` are set correctly (for GB English UTF-8 encoding these variables must be set to `en_GB.UTF-8`; you can set them by adding `export LANG=en_GB.UTF-8` and `export LC_ALL=en_GB.UTF-8` in your origin or login machines' `.profile`)

--- a/esmvaltool/install/R/setup_lintr.R
+++ b/esmvaltool/install/R/setup_lintr.R
@@ -1,0 +1,8 @@
+# mini script to compile and install lintr (r-lintr) from source
+pkg_mirror <- "https://cloud.r-project.org"
+install.packages(
+    "lintr",
+    repos = pkg_mirror,
+    Ncpus = 1,
+    dependencies = c("Depends", "Imports", "LinkingTo")
+)


### PR DESCRIPTION
Installing `lintr` directly from CRAN on CircleCI and instructing the user to do exactly that as well via the install script added to `esmvaltool/install/R` - this saves us the headaches produced by the installation of `r-lintr` via conda, see #1236 