### PR TITLE
Get get_script_root function back to ESMValTool.

### DIFF
--- a/esmvaltool/__init__.py
+++ b/esmvaltool/__init__.py
@@ -1,2 +1,9 @@
 """ESMValTool diagnostics package."""
+import os
+
 __version__ = '2.0.0b0'
+
+
+def get_script_root():
+    """Return the location of the ESMValTool installation."""
+    return os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
This fixes some tests that are failing for me:
```
=========================================================================== ERRORS ===========================================================================
____________________________________________________ ERROR collecting tests/system/esmvaltool_testlib.py _____________________________________________________
tests/system/esmvaltool_testlib.py:47: in <module>
    _CFG = _load_config()
tests/system/esmvaltool_testlib.py:40: in _load_config
    script_root = esmvaltool.get_script_root()
E   AttributeError: module 'esmvaltool' has no attribute 'get_script_root'
_______________________________________________________ ERROR collecting tests/system/test_recipes.py ________________________________________________________
tests/system/test_recipes.py:8: in <module>
    from .esmvaltool_testlib import RECIPES, ESMValToolTest
tests/system/esmvaltool_testlib.py:47: in <module>
    _CFG = _load_config()
tests/system/esmvaltool_testlib.py:40: in _load_config
    script_root = esmvaltool.get_script_root()
E   AttributeError: module 'esmvaltool' has no attribute 'get_script_root'
_______________________________________________________ ERROR collecting tests/system/test_recipes.py ________________________________________________________
tests/system/test_recipes.py:8: in <module>
    from .esmvaltool_testlib import RECIPES, ESMValToolTest
tests/system/esmvaltool_testlib.py:47: in <module>
    _CFG = _load_config()
tests/system/esmvaltool_testlib.py:40: in _load_config
    script_root = esmvaltool.get_script_root()
E   AttributeError: module 'esmvaltool' has no attribute 'get_script_root'
====================================================================== warnings summary ======================================================================
```

Looks like this function went to the core package after the split and shouldn't have. 