### PR TITLE
pinned tiledb version and unpinned ncl

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ To install in development mode, follow these instructions.
 -   If you want to use Julia diagnostics, run `julia esmvaltool/install/Julia/setup.jl` to install the Julia dependences.
 -   Test that your installation was succesful by running `esmvaltool -h`.
 -   If you log into a cluster or other device via `ssh` and your origin machine sends the `locale` environment via the `ssh` connection, make sure the environment is set correctly, specifically `LANG` and `LC_ALL` are set correctly (for GB English UTF-8 encoding these variables must be set to `en_GB.UTF-8`; you can set them by adding `export LANG=en_GB.UTF-8` and `export LC_ALL=en_GB.UTF-8` in your origin or login machines' `.profile`)
+-   Do not run `conda update --update-all` in the `esmvaltool` environment since that will update some packages that are pinned to specific versions for the correct functionality of the environment.
 
 ## Using the development version of the ESMValTool Core package
 

--- a/environment.yml
+++ b/environment.yml
@@ -21,8 +21,8 @@ dependencies:
   # Multi language support:
   - python>=3.6
   - libunwind  # Needed for Python3.7+
-  - tiledb>=1.6.0  # Needed by the new ncl=6.6.2; conda keeps it at 1.2.2
-  - ncl>=6.5.0
+  - tiledb=1.6.0  # Needed by the new ncl=6.6.2; evolved to 1.6.2 but ncl 6.6.2 still needs libtiledb1.6.0.so
+  - ncl
   - r-base
   - r-curl  # Dependency of lintr, but fails to compile because it cannot find libcurl installed from conda.
   - r-udunits2  # Fails to compile because it cannot find udunits2 installed from conda.


### PR DESCRIPTION
Changes:
- unpinned `ncl` because `6.6.2` or above will be installed with the latest `conda` tree;
- pinned `tiledb` since bloody `ncl` is very strict about its `libtiledb1.6.0.so` and `tiledb` has now evolved to `1.6.2`

@jvegasbsc or @bjoernbroetz can I plz have a quick OK so we have the env working again for brand new users or the ones that are re-creating their envs? :beer: