### PR TITLE
updated meta file for conda build

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - git
     - python {{ python }}
     # Normally installed via pip:
+    - pytest-runner
     - setuptools_scm
   run:
     # esmvaltool
@@ -71,6 +72,7 @@ requirements:
     - r-base
     - r-curl  # Dependency of lintr, but fails to compile because it cannot find libcurl installed from conda.
     - r-udunits2  # Fails to compile because it cannot find udunits2 installed from conda.
+    - tiledb=1.6.0
 
 test:
   # TODO: add unit tests? This seems to require installing the tests


### PR DESCRIPTION
I have built a fresh conda package for esmvaltool; the `meta.yml` needed a couple changes included here. Can one of you @bouweandela or @fdiblen please update the conda package at source on `esmvalgroup` pls https://anaconda.org/ESMValGroup/esmvaltool/files - I got `esmvaltool-2.0.0b0-py37_0.tar.bz2` done that is up to date with all the new stuff we need :beer:

And yes, as @nielsdrost pointed out (in now a closed issue) but forwarded to #1266 the user needs to install `julia` before installing esmvaltool