### PR TITLE
ERA5 additional variables for cmorizer

### DIFF
--- a/doc/sphinx/source/getting_started/inputdata.rst
+++ b/doc/sphinx/source/getting_started/inputdata.rst
@@ -49,8 +49,8 @@ A list of the datasets for which a cmorizers is available is provided in the fol
 +------------------------------+------------------------------------------------------------------------------------------------------+------+-----------------+
 | Eppley-VGPM-MODIS            | intpp (Omon)                                                                                         |   2  | Python          |
 +------------------------------+------------------------------------------------------------------------------------------------------+------+-----------------+
-| ERA5                         | clt, evspsbl, evspsblpot, mrro, pr, prsn, psl, rls, rsds, rsdt, rss, uas, vas, tas, tasmax, tasmin,  |   3  | Python          |
-|                              | tdps, ts, tsn (E1hr)                                                                          |      |      |                 |
+| ERA5                         | cliwi, clt, evspsbl, evspsblpot, lwp, mrro, pr, prsn, prw, psl, rls, rsds, rsdt, rss, tas,           |   3  | Python          |
+|                              | tasmax, tasmin, tdps, ts, tsn, uas, vas (E1hr)                                                       |      |                 |
 +------------------------------+------------------------------------------------------------------------------------------------------+------+-----------------+
 | ERA-Interim                  | clivi, clt, clwvi, hfds, hur, hus, pr, prw, ps, psl, ta, tas, tauu, tauv, ts, ua, va, wap, zg (Amon) |   3  | NCL             |
 |                              | pr, psl, tas, tasmin, tasmax, zg (day), sftlf (fx), tos (Omon)                                       |      |                 |

--- a/esmvaltool/cmorizers/obs/cmor_config/ERA5.yml
+++ b/esmvaltool/cmorizers/obs/cmor_config/ERA5.yml
@@ -4,7 +4,7 @@ attributes:
   dataset_id: ERA5
   project_id: OBS6
   tier: 3
-  version: '1'
+  version: 'v1'
   modeling_realm: reanaly
   source: 'https://www.ecmwf.int/en/forecasts/datasets/reanalysis-datasets/era5'
   reference: 'era5'

--- a/esmvaltool/cmorizers/obs/cmor_config/ERA5.yml
+++ b/esmvaltool/cmorizers/obs/cmor_config/ERA5.yml
@@ -89,3 +89,15 @@ variables:
     mip: E1hr
     raw: tsn
     file: 'era5_temperature_of_snow_layer_*_hourly.nc'
+  prw:
+    mip: E1hr
+    raw: tcwv
+    file: 'era5_total_column_water_vapour_*_hourly.nc'
+  clivi:
+    mip: E1hr
+    raw: tciw
+    file: 'era5_total_column_cloud_ice_water_*_hourly.nc'
+  lwp:
+    mip: E1hr
+    raw: tclw
+    file: 'era5_total_column_cloud_liquid_water_*_hourly.nc'

--- a/esmvaltool/cmorizers/obs/cmorize_obs_era5.py
+++ b/esmvaltool/cmorizers/obs/cmorize_obs_era5.py
@@ -33,6 +33,9 @@ variables:
         toa_incident_solar_radiation
         total_cloud_cover
         total_precipitation
+        total_column_water_vapour
+        total_column_cloud_ice_water
+        total_column_cloud_liquid_water
 
     Downloading ERA5 data can either be done via the Climate Data Store (cds)
 web form or era5cli:

--- a/esmvaltool/recipes/examples/recipe_check_obs.yml
+++ b/esmvaltool/recipes/examples/recipe_check_obs.yml
@@ -469,25 +469,28 @@ diagnostics:
   ERA5:
     description: ERA5 check check
     variables:
+      clivi:
       clt:
       evspsbl:
       evspsblpot:
+      lwp:
       mrro:
       pr:
       prsn:
+      prw:
       psl:
       rls:
       rsds:
       rsdt:
       rss:
-      uas:
-      vas:
       tas:
       tasmax:
       tasmin:
       tdps:
       ts:
       tsn:
+      uas:
+      vas:
     additional_datasets:
       - {project: OBS6, dataset: ERA5, mip: E1hr,
          frequency: 1hr, tier: 3, type: reanaly, version: 1,


### PR DESCRIPTION
I added three more variables to the cmor config file of the ERA5 Data. I also added the variables to the header of the cmorizer script to reflect that these variables can be handled by the script now.

I have one additional change to the cmor config file: I changed the version from '1' to 'v1'. I used the cmorizer to process some ERA5 data files, and could not read the cmorized data with the ESMValTool. We figured out that the '1' from the version was not recognized as a string, and therefore the file name could not be found. By changing the version to 'v1' the file name is fully recognized as string again, and the file can be found by the ESMValTool. 