### PR TITLE
Automatic casting of CMORizer output data type

### DIFF
--- a/esmvaltool/cmorizers/obs/cmorize_obs_cru.py
+++ b/esmvaltool/cmorizers/obs/cmorize_obs_cru.py
@@ -41,6 +41,8 @@ def _extract_variable(short_name, var, cfg, filepath, out_dir):
     cube = iris.load_cube(filepath, utils.var_name_constraint(raw_var))
 
     # Fix units
+    if 'raw_units' in var:
+        cube.units = var['raw_units']
     cmor_info = cfg['cmor_table'].get_variable(var['mip'], short_name)
     cube.convert_units(cmor_info.units)
     utils.convert_timeunits(cube, 1950)

--- a/esmvaltool/cmorizers/obs/utilities.py
+++ b/esmvaltool/cmorizers/obs/utilities.py
@@ -25,13 +25,12 @@ def add_height2m(cube):
 def add_scalar_height_coord(cube, height=2.):
     """Add scalar coordinate 'height' with value of `height`m."""
     logger.info("Adding height coordinate (%sm)", height)
-    height_coord = iris.coords.AuxCoord(
-        height,
-        var_name='height',
-        standard_name='height',
-        long_name='height',
-        units=Unit('m'),
-        attributes={'positive': 'up'})
+    height_coord = iris.coords.AuxCoord(height,
+                                        var_name='height',
+                                        standard_name='height',
+                                        long_name='height',
+                                        units=Unit('m'),
+                                        attributes={'positive': 'up'})
     cube.add_aux_coord(height_coord, ())
 
 
@@ -131,8 +130,8 @@ def flip_dim_coord(cube, coord_name):
 
 def read_cmor_config(dataset):
     """Read the associated dataset-specific config file."""
-    reg_path = os.path.join(
-        os.path.dirname(__file__), 'cmor_config', dataset + '.yml')
+    reg_path = os.path.join(os.path.dirname(__file__), 'cmor_config',
+                            dataset + '.yml')
     with open(reg_path, 'r') as file:
         cfg = yaml.safe_load(file)
     cfg['cmor_table'] = \
@@ -145,6 +144,23 @@ def read_cmor_config(dataset):
 def save_variable(cube, var, outdir, attrs, **kwargs):
     """Saver function."""
     # CMOR standard
+    if cube.dtype != np.float32:
+        logger.info("Converting data type of data from '%s' to 'float32'",
+                    cube.dtype)
+        cube.data = cube.core_data().astype(np.float32, casting='same_kind')
+    for coord in cube.coords():
+        if coord.dtype != np.float64:
+            logger.info(
+                "Converting data type of coordinate points of '%s' from '%s' "
+                "to 'float64'", coord.name(), coord.dtype)
+            coord.points = coord.core_points().astype(np.float64,
+                                                      casting='same_kind')
+        if coord.has_bounds() and coord.bounds_dtype != np.float64:
+            logger.info(
+                "Converting data type of coordinate bounds of '%s' from '%s' "
+                "to 'float64'", coord.name(), coord.bounds_dtype)
+            coord.bounds = coord.core_bounds().astype(np.float64,
+                                                      casting='same_kind')
     try:
         time = cube.coord('time')
     except iris.exceptions.CoordinateNotFoundError:


### PR DESCRIPTION
Automatic conversion of CMORizer output dtype for the python CMORizers. I think for NCL this is already done here

https://github.com/ESMValGroup/ESMValTool/blob/75fa7da9dbf9777e8267b22361a387a40146f1b6/esmvaltool/cmorizers/obs/utilities.ncl#L1237

Is this correct @mattiarighi?

With these changes it is necessary to run all python CMORizers again, sorry for the troubles!

***

**Tasks**

-   [ ] [Create an issue](https://github.com/ESMValGroup/ESMValTool/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [ ] Give this pull request a descriptive title that can be used as a one line summary in a changelog
-   [ ] Make sure your code is composed of functions of no more than 50 lines and uses meaningful names for variables
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Preferably Codacy code quality checks pass, however a few remaining hard to solve Codacy issues are still acceptable. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes 
-   [ ] (Only if really necessary) Add any additional dependencies needed for the diagnostic script to setup.py, esmvaltool/install/R/r_requirements.txt or esmvaltool/install/Julia/julia_requirements.txt (depending on the language of your script) and also to meta.yaml for conda dependencies (includes Python and others, but not R/Julia)
-   [ ] If new dependencies are introduced, check that the license is compatible with [Apache2.0](https://github.com/ESMValGroup/ESMValTool/blob/version2_development/LICENSE)

* * *

Closes #1400 and closes #1401
