### PR TITLE
fixed bug in seaice_tsline.ncl (legend_outside)

### DIFF
--- a/esmvaltool/diag_scripts/seaice/seaice_tsline.ncl
+++ b/esmvaltool/diag_scripts/seaice/seaice_tsline.ncl
@@ -339,6 +339,7 @@ begin
       ; but is same for both area and extent anyway
       if (diag_script_info@legend_outside) then
         val_area@legend_outside = True
+        wks_area@legendfile = config_user_info@plot_dir + out_ext + "_legend"
       end if
     else
       diag_script_info@legend_outside = False


### PR DESCRIPTION
This PR fixes a small bug in seaice_tsline.ncl that caused the diagnostic to crash when setting the option "legend_outside" to True (draw legend in an extra plot).