### PR TITLE
Remove R package ncdf4.helpers from list of dependencies

### DIFF
--- a/esmvaltool/install/R/r_requirements.txt
+++ b/esmvaltool/install/R/r_requirements.txt
@@ -12,7 +12,6 @@ mapproj
 maps
 multiApply
 ncdf4
-ncdf4.helpers
 PCICt
 plyr
 RColorBrewer


### PR DESCRIPTION
Remove R package ncdf4.helpers from list of dependencies, because it is no longer available on CRAN and it breaks the build. Removing the dependency will at least fix our build. In the longer term we will need a better solution, because now recipe_extreme_events.yml is broken (#1443)

* * *

**Tasks**

-   [x] Give this pull request a descriptive title that can be used as a one line summary in a changelog
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
