### PR TITLE
Pinning cdo to a fully functional version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - esmvalcore>=2.0.0b3,<2.1
   # Non-Python dependencies
   - graphviz
-  - cdo
+  - cdo>=1.9.7
   - imagemagick
   - nco
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -69,7 +69,7 @@ requirements:
     - xlrd
     - xlsxwriter
     # Command line tools used by diagnostic scripts
-    - cdo
+    - cdo>=1.9.7
     - imagemagick
     - nco
     # Multi language support:


### PR DESCRIPTION
We finally have a fully working version of `cdo` and the environment builds correctly and without hitches too. This fixes a problem initially reported in #1227 and widely examined in #1239 and reported again in #1294 and #1455 (all these should be closed upon acceptance of this PR). Can someone eg @mattiarighi test the quantilebias recipe with this pinning please :beer:

To my part, the bit that was previously failing now works a-OK:
```
(esmvaltool_cdo) valeriu@valeriu-PORTEGE-Z30-C:~/esmvaltool_workshop_21Jan2019$ cdo remapcon t2.nc out.nc
cdo    remapcon  : Enter grid description file or name > t2.nc
cdo    remapcon: YAC first order conservative weights from lonlat (144x96) to lonlat (144x96) grid
cdo    remapcon: Processed 1 variable over 1857 timesteps [10.99s 33MB].
```