### PR TITLE
Change OBS to OBS6 for ERA-Interim

### DIFF
--- a/esmvaltool/recipes/examples/recipe_check_obs.yml
+++ b/esmvaltool/recipes/examples/recipe_check_obs.yml
@@ -315,7 +315,7 @@ diagnostics:
       thetao:
     additional_datasets:
       - {dataset: PHC, project: OBS6, frequency: yr, mip: Omon, tier: 2,
-          type: clim, version: 3, start_year: 1950, end_year: 1950}
+         type: clim, version: 3, start_year: 1950, end_year: 1950}
     scripts: null
 
 
@@ -576,9 +576,6 @@ diagnostics:
         mip: Amon
       tasmax:
         mip: day
-      tas_month:
-        short_name: tas
-        mip: Amon
       tasmin:
         mip: day
       tauu:
@@ -599,9 +596,9 @@ diagnostics:
       ts_month:
         short_name: ts
         mip: Amon
-      tsn:
+      tsn_month:
         mip: LImon
-      tsn:
+      tsn_day:
         mip: Eday
       ua:
         mip: Amon
@@ -635,9 +632,6 @@ diagnostics:
 
   ERA5:
     description: ERA5 check
-    additional_datasets:
-      - {project: OBS6, dataset: ERA5, tier: 3, type: reanaly,
-         version: 1, start_year: 1990, end_year: 1990}
     variables:
       clt:
         mip: E1hr

--- a/esmvaltool/recipes/examples/recipe_concatenate_exps.yml
+++ b/esmvaltool/recipes/examples/recipe_concatenate_exps.yml
@@ -30,7 +30,8 @@ diagnostics:
         start_year: 1950
         end_year: 2000
         additional_datasets:
-          - {dataset: ERA-Interim, project: OBS, tier: 3, type: reanaly, version: 1, start_year: 1980, end_year: 2000}
+          - {dataset: ERA-Interim, project: OBS6, tier: 3, type: reanaly,
+             version: 1, start_year: 1980, end_year: 2000}
     scripts: null
 
   diag_concatenate_exps:

--- a/esmvaltool/recipes/examples/recipe_correlation.yml
+++ b/esmvaltool/recipes/examples/recipe_correlation.yml
@@ -50,8 +50,7 @@ diagnostics:
           # One or more datasets can be added here
           - {dataset: bcc-csm1-1}
           # The reference dataset is required
-          - {dataset: ERA-Interim, project: OBS6, tier: 3, type: reanaly,
-             version: 1}
+          - {dataset: ERA-Interim, project: OBS6, tier: 3, type: reanaly, version: 1}
     scripts:
       correlation_pressure:
         script: examples/correlate.py

--- a/esmvaltool/recipes/examples/recipe_correlation.yml
+++ b/esmvaltool/recipes/examples/recipe_correlation.yml
@@ -1,16 +1,16 @@
 # ESMValTool
 # recipe_correlation.yml
 ---
-documentation: 
+documentation:
   description: |
     Calculate the Pearsons r correlation coefficient over specified dimensions.
-    
+
   authors:
     - andela_bouwe
 
   maintainer:
     - andela_bouwe
-    
+
   projects:
     - c3s-magic
 
@@ -50,7 +50,8 @@ diagnostics:
           # One or more datasets can be added here
           - {dataset: bcc-csm1-1}
           # The reference dataset is required
-          - {dataset: ERA-Interim, project: OBS, tier: 3, type: reanaly, version: 1}
+          - {dataset: ERA-Interim, project: OBS6, tier: 3, type: reanaly,
+             version: 1}
     scripts:
       correlation_pressure:
         script: examples/correlate.py

--- a/esmvaltool/recipes/examples/recipe_extract_shape.yml
+++ b/esmvaltool/recipes/examples/recipe_extract_shape.yml
@@ -27,6 +27,9 @@ datasets:
 preprocessors:
 
   preproc:
+    regrid:
+      scheme: linear
+      target_grid: 0.25x0.25
     extract_shape:
       shapefile: Elbe.shp
 

--- a/esmvaltool/recipes/examples/recipe_julia.yml
+++ b/esmvaltool/recipes/examples/recipe_julia.yml
@@ -3,30 +3,34 @@
 ---
 documentation:
   description: Recipe for example diagnostic written in Julia.
-  
-  authors: 
+
+  authors:
     - vonhardenberg_jost
 
   maintainer:
     - vonhardenberg_jost
 
 datasets:
-  - {dataset: CESM1-CAM5, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 1997, end_year: 1997}
+  - {dataset: CESM1-CAM5, project: CMIP5, exp: historical, ensemble: r1i1p1}
 
 preprocessors:
   preproc:
-    extract_levels: false
+    regrid:
+      scheme: linear
+      target_grid: 1x1
 
 diagnostics:
   example:
     description: Example diagnostic written in Julia
     variables:
       tas:
+        mip: Amon
+        start_year: 1997
+        end_year: 1997
         preprocessor: preproc
         reference_dataset: "CESM1-CAM5"
-        mip: Amon
 
     scripts:
       main:
         script: examples/diagnostic.jl
-        parameter1:   1    # example parameter
+        parameter1: 1  # example parameter

--- a/esmvaltool/recipes/examples/recipe_my_personal_diagnostic.yml
+++ b/esmvaltool/recipes/examples/recipe_my_personal_diagnostic.yml
@@ -17,8 +17,8 @@ documentation:
     - predoi_valeriu
 
 datasets:
-  - {dataset: MPI-ESM-LR,  project: CMIP5, exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
-  - {dataset: NorESM1-M,   project: CMIP5, exp: historical,  ensemble: r1i1p1,  start_year: 2001,  end_year: 2005}
+  - {dataset: MPI-ESM-LR, project: CMIP5, exp: historical, ensemble: r1i1p1}
+  - {dataset: NorESM1-M, project: CMIP5, exp: historical, ensemble: r1i1p1}
 
 preprocessors:
   pp:
@@ -33,6 +33,8 @@ diagnostics:
       ta:
         preprocessor: pp
         mip: Amon
+        start_year: 2000
+        end_year: 2002
       sftlf:
         mip: fx
       sftof:
@@ -42,4 +44,3 @@ diagnostics:
     scripts:
       my_diagnostic:
         script: /path/to/your/my_little_diagnostic.py
-

--- a/esmvaltool/recipes/examples/recipe_ncl.yml
+++ b/esmvaltool/recipes/examples/recipe_ncl.yml
@@ -32,9 +32,6 @@ preprocessors:
     extract_levels:
       levels: 85000
       scheme: nearest
-    regrid: false
-    mask_landsea: false
-    multi_model_statistics: false
 
 diagnostics:
   example:

--- a/esmvaltool/recipes/examples/recipe_ncl.yml
+++ b/esmvaltool/recipes/examples/recipe_ncl.yml
@@ -10,7 +10,7 @@ documentation:
 
   maintainer:
     - righi_mattia
-    
+
   references:
     - acknow_project
 
@@ -18,10 +18,14 @@ documentation:
     - esmval
 
 datasets:
-  - {dataset: bcc-csm1-1, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
-  - {dataset: GFDL-ESM2G, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
-  - {dataset: MPI-ESM-LR, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2000, end_year: 2002}
-  - {dataset: ERA-Interim, project: OBS, tier: 3, type: reanaly, version: 1, start_year: 2000, end_year: 2002}
+  - {dataset: bcc-csm1-1, project: CMIP5, exp: historical, ensemble: r1i1p1,
+     start_year: 2000, end_year: 2002}
+  - {dataset: GFDL-ESM2G, project: CMIP5, exp: historical, ensemble: r1i1p1,
+     start_year: 2000, end_year: 2002}
+  - {dataset: MPI-ESM-LR, project: CMIP5, exp: historical, ensemble: r1i1p1,
+     start_year: 2000, end_year: 2002}
+  - {dataset: ERA-Interim, project: OBS6, tier: 3, type: reanaly, version: 1,
+     start_year: 2000, end_year: 2002}
 
 preprocessors:
   preprocessor_1:
@@ -45,7 +49,8 @@ diagnostics:
         reference_dataset: ERA-Interim
         mip: Amon
         additional_datasets:
-          - {dataset: NCEP, project: OBS, tier: 2, type: reanaly, version: 1, start_year: 2000, end_year: 2002}
+          - {dataset: NCEP, project: OBS, tier: 2, type: reanaly, version: 1,
+             start_year: 2000, end_year: 2002}
     scripts:
       test_ta: &settings
         script: examples/diagnostic.ncl

--- a/esmvaltool/recipes/examples/recipe_preprocessor_derive_test.yml
+++ b/esmvaltool/recipes/examples/recipe_preprocessor_derive_test.yml
@@ -37,7 +37,7 @@ diagnostics:
         derive: true
         force_derivation: false
         additional_datasets:
-          - {dataset: GFDL-CM3,  ensemble: r1i1p1}
+          - {dataset: GFDL-CM3, ensemble: r1i1p1}
           - {dataset: GISS-E2-H, ensemble: r1i1p2}
           - {dataset: GISS-E2-R, ensemble: r1i1p2}
       swcre:

--- a/esmvaltool/recipes/examples/recipe_preprocessor_test.yml
+++ b/esmvaltool/recipes/examples/recipe_preprocessor_test.yml
@@ -17,12 +17,9 @@ documentation:
     - c3s-magic
 
 datasets:
-  - {dataset: MPI-ESM-LR, project: CMIP5, exp: historical, ensemble: r1i1p1,
-     start_year: 2000, end_year: 2002}
-  - {dataset: bcc-csm1-1, project: CMIP5, exp: historical, ensemble: r1i1p1,
-     start_year: 2000, end_year: 2002}
-  - {dataset: GFDL-ESM2G, project: CMIP5, exp: historical, ensemble: r1i1p1,
-     start_year: 2000, end_year: 2002}
+  - {dataset: MPI-ESM-LR, project: CMIP5, exp: historical, ensemble: r1i1p1}
+  - {dataset: bcc-csm1-1, project: CMIP5, exp: historical, ensemble: r1i1p1}
+  - {dataset: GFDL-ESM2G, project: CMIP5, exp: historical, ensemble: r1i1p1}
 
 preprocessors:
 
@@ -83,11 +80,11 @@ diagnostics:
       ta:
         preprocessor: preprocessor_1
         mip: Amon
+        start_year: 2000
+        end_year: 2002
         additional_datasets:
-          - {dataset: NCEP, project: OBS, tier: 2, type: reanaly, version: 1,
-             start_year: 2000, end_year: 2002}
-          - {dataset: ERA-Interim, project: OBS6, tier: 3, type: reanaly,
-             version: 1, start_year: 2000, end_year: 2002}
+          - {dataset: NCEP, project: OBS, tier: 2, type: reanaly, version: 1}
+          - {dataset: ERA-Interim, project: OBS6, tier: 3, type: reanaly, version: 1}
       orog:
         mip: fx
       sftlf:
@@ -100,6 +97,8 @@ diagnostics:
       ta:
         preprocessor: preprocessor_2
         mip: Amon
+        start_year: 2000
+        end_year: 2002
     scripts: null
 
   diagnostic_3_and_4:
@@ -108,7 +107,11 @@ diagnostics:
       ta:
         preprocessor: preprocessor_3
         mip: Amon
+        start_year: 2000
+        end_year: 2002
       pr:
         preprocessor: preprocessor_4
         mip: Amon
+        start_year: 2000
+        end_year: 2002
     scripts: null

--- a/esmvaltool/recipes/examples/recipe_preprocessor_test.yml
+++ b/esmvaltool/recipes/examples/recipe_preprocessor_test.yml
@@ -4,7 +4,7 @@
 documentation:
   description: |
     Various example preprocessors.
-    
+
   authors:
     - righi_mattia
     - andela_bouwe
@@ -12,14 +12,17 @@ documentation:
 
   maintainer:
     - righi_mattia
-    
+
   projects:
     - c3s-magic
 
 datasets:
-  - {dataset: MPI-ESM-LR,   project: CMIP5,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
-  - {dataset: bcc-csm1-1,   project: CMIP5,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
-  - {dataset: GFDL-ESM2G,   project: CMIP5,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
+  - {dataset: MPI-ESM-LR, project: CMIP5, exp: historical, ensemble: r1i1p1,
+     start_year: 2000, end_year: 2002}
+  - {dataset: bcc-csm1-1, project: CMIP5, exp: historical, ensemble: r1i1p1,
+     start_year: 2000, end_year: 2002}
+  - {dataset: GFDL-ESM2G, project: CMIP5, exp: historical, ensemble: r1i1p1,
+     start_year: 2000, end_year: 2002}
 
 preprocessors:
 
@@ -30,7 +33,7 @@ preprocessors:
       # levels: {dataset: ERA-Interim, coordinate: air_pressure}
       scheme: linear
     mask_landsea:
-      mask_out: land #if land, will mask land out; if sea, will mask seas and oceans out
+      mask_out: land  # if land (sea), will mask land (sea and oceans) out
     regrid:
       target_grid: ERA-Interim
       scheme: linear
@@ -81,8 +84,10 @@ diagnostics:
         preprocessor: preprocessor_1
         mip: Amon
         additional_datasets:
-          - {dataset: NCEP,        project: OBS,    tier: 2,    type: reanaly,    version: 1,        start_year: 2000,  end_year: 2002}
-          - {dataset: ERA-Interim,  project: OBS,    tier: 3,    type: reanaly,    version: 1,        start_year: 2000,  end_year: 2002}
+          - {dataset: NCEP, project: OBS, tier: 2, type: reanaly, version: 1,
+             start_year: 2000, end_year: 2002}
+          - {dataset: ERA-Interim, project: OBS6, tier: 3, type: reanaly,
+             version: 1, start_year: 2000, end_year: 2002}
       orog:
         mip: fx
       sftlf:

--- a/esmvaltool/recipes/examples/recipe_python.yml
+++ b/esmvaltool/recipes/examples/recipe_python.yml
@@ -2,8 +2,7 @@
 # recipe_python.yml
 ---
 documentation:
-  description: |
-    Example recipe that plots the mean precipitation and temperature.
+  description: Example recipe that plots the mean precipitation and temperature.
 
   authors:
     - andela_bouwe
@@ -20,8 +19,8 @@ documentation:
     - c3s-magic
 
 datasets:
-  - {dataset: CanESM2,  project: CMIP5,  mip: Amon,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
-  - {dataset: MPI-ESM-LR,  project: CMIP5,  mip: Amon,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
+  - {dataset: CanESM2, project: CMIP5, exp: historical, ensemble: r1i1p1}
+  - {dataset: MPI-ESM-LR, project: CMIP5, exp: historical, ensemble: r1i1p1}
 
 preprocessors:
 
@@ -47,7 +46,13 @@ diagnostics:
     variables:
       ta:
         preprocessor: preprocessor1
+        mip: Amon
+        start_year: 2000
+        end_year: 2002
       pr:
+        mip: Amon
+        start_year: 2000
+        end_year: 2002
     scripts:
       script1:
         script: examples/diagnostic.py

--- a/esmvaltool/recipes/examples/recipe_python_object_oriented.yml
+++ b/esmvaltool/recipes/examples/recipe_python_object_oriented.yml
@@ -13,12 +13,9 @@ documentation:
     - schlund_manuel
 
 datasets:
-  - {dataset: GFDL-ESM2G, project: CMIP5, mip: Amon, exp: historical,
-     ensemble: r1i1p1, start_year: 2000, end_year: 2002}
-  - {dataset: MPI-ESM-LR, project: CMIP5, mip: Amon, exp: historical,
-     ensemble: r1i1p1, start_year: 2000, end_year: 2002}
-  - {dataset: ERA-Interim, project: OBS6, tier: 3, type: reanaly,
-     version: 1, start_year: 2000, end_year: 2002}
+  - {dataset: GFDL-ESM2G, project: CMIP5, exp: historical, ensemble: r1i1p1}
+  - {dataset: MPI-ESM-LR, project: CMIP5, exp: historical, ensemble: r1i1p1}
+  - {dataset: ERA-Interim, project: OBS6, tier: 3, type: reanaly, version: 1}
 
 preprocessors:
 
@@ -47,9 +44,15 @@ diagnostics:
     description: Air temperature and precipitation Python tutorial diagnostic.
     variables:
       ta:
+        mip: Amon
+        start_year: 2000
+        end_year: 2002
         preprocessor: preprocessor1
         reference_dataset: ERA-Interim
       pr:
+        mip: Amon
+        start_year: 2000
+        end_year: 2002
         preprocessor: preprocessor2
         reference_dataset: ERA-Interim
     scripts:
@@ -67,10 +70,12 @@ diagnostics:
     description: Another Python tutorial diagnostic.
     variables:
       tas:
+        mip: Amon
+        start_year: 2000
+        end_year: 2002
         preprocessor: preprocessor2
         additional_datasets:
-          - {dataset: bcc-csm1-1, project: CMIP5, mip: Amon, exp: historical,
-             ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+          - {dataset: bcc-csm1-1, project: CMIP5, exp: historical, ensemble: r1i1p1}
         reference_dataset: MPI-ESM-LR
     scripts:
       script2:

--- a/esmvaltool/recipes/examples/recipe_python_object_oriented.yml
+++ b/esmvaltool/recipes/examples/recipe_python_object_oriented.yml
@@ -3,7 +3,8 @@
 ---
 documentation:
   description: |
-    Example recipe that runs a Python example diagnostic with a more object oriented interface.
+    Example recipe that runs a Python example diagnostic with a more object
+    oriented interface.
 
   authors:
     - schlund_manuel
@@ -12,9 +13,12 @@ documentation:
     - schlund_manuel
 
 datasets:
-  - {dataset: GFDL-ESM2G,  project: CMIP5,  mip: Amon,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
-  - {dataset: MPI-ESM-LR,  project: CMIP5,  mip: Amon,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
-  - {dataset: ERA-Interim, project: OBS,    tier: 3,    type: reanaly,    version: 1,        start_year: 2000,  end_year: 2002}
+  - {dataset: GFDL-ESM2G, project: CMIP5, mip: Amon, exp: historical,
+     ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+  - {dataset: MPI-ESM-LR, project: CMIP5, mip: Amon, exp: historical,
+     ensemble: r1i1p1, start_year: 2000, end_year: 2002}
+  - {dataset: ERA-Interim, project: OBS6, tier: 3, type: reanaly,
+     version: 1, start_year: 2000, end_year: 2002}
 
 preprocessors:
 
@@ -65,7 +69,8 @@ diagnostics:
       tas:
         preprocessor: preprocessor2
         additional_datasets:
-          - {dataset: bcc-csm1-1,  project: CMIP5,  mip: Amon,  exp: historical,  ensemble: r1i1p1,  start_year: 2000,  end_year: 2002}
+          - {dataset: bcc-csm1-1, project: CMIP5, mip: Amon, exp: historical,
+             ensemble: r1i1p1, start_year: 2000, end_year: 2002}
         reference_dataset: MPI-ESM-LR
     scripts:
       script2:

--- a/esmvaltool/recipes/examples/recipe_r.yml
+++ b/esmvaltool/recipes/examples/recipe_r.yml
@@ -3,8 +3,8 @@
 ---
 documentation:
   description: Recipe for example diagnostic written in R.
-  
-  authors: 
+
+  authors:
     - arnone_enrico
 
   maintainer:
@@ -17,7 +17,7 @@ preprocessors:
     extract_levels: false
 diagnostics:
   example:
-    description: Example diagnostic written in R 
+    description: Example diagnostic written in R
     variables:
       pr:
         preprocessor: preproc
@@ -26,4 +26,4 @@ diagnostics:
     scripts:
       main:
         script: examples/diagnostic.R
-        parameter1:   1    # example parameter
+        parameter1: 1  # example parameter

--- a/esmvaltool/recipes/examples/recipe_variable_groups.yml
+++ b/esmvaltool/recipes/examples/recipe_variable_groups.yml
@@ -51,7 +51,8 @@ diagnostics:
         preprocessor: mask
         tag: TAS2
         additional_datasets:
-          - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, tier: 3}
+          - {dataset: ERA-Interim, project: OBS6, type: reanaly,
+             version: 1, tier: 3}
       tas_3:
         <<: *variable_settings
         exp: rcp45

--- a/esmvaltool/recipes/examples/recipe_variable_groups.yml
+++ b/esmvaltool/recipes/examples/recipe_variable_groups.yml
@@ -51,8 +51,7 @@ diagnostics:
         preprocessor: mask
         tag: TAS2
         additional_datasets:
-          - {dataset: ERA-Interim, project: OBS6, type: reanaly,
-             version: 1, tier: 3}
+          - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: 1, tier: 3}
       tas_3:
         <<: *variable_settings
         exp: rcp45
@@ -60,5 +59,4 @@ diagnostics:
         end_year: 2025
         tag: TAS3
         additional_datasets: *datasets
-    scripts:
-      null
+    scripts: null

--- a/esmvaltool/recipes/hydrology/recipe_pcrglobwb.yml
+++ b/esmvaltool/recipes/hydrology/recipe_pcrglobwb.yml
@@ -3,18 +3,20 @@
 ---
 documentation:
   description: |
-    Recipe pre-processes ERA-Interim reanalyses files for use in the PCR-GLOBWB hydrological model.
+    Recipe pre-processes ERA-Interim reanalyses files for use in the PCR-GLOBWB
+    hydrological model.
 
-    PCR-GLOBWB (PCRaster Global Water Balance) is a large-scale hydrological model intended for global
-    to regional studies and developed at the Department of Physical Geography, Utrecht University (Netherlands).
-    PCR-GLOBWB input and output files for the runs made in Sutanudjaja et al. (2018, https://doi.org/10.5194/gmd-11-2429-2018)
-    are available on https://geo.data.uu.nl/research-pcrglobwb/pcr-globwb_gmd_paper_sutanudjaja_et_al_2018/.
+    PCR-GLOBWB (PCRaster Global Water Balance) is a large-scale hydrological
+    model intended for global to regional studies and developed at the
+    Department of Physical Geography, Utrecht University (Netherlands).
+    PCR-GLOBWB input and output files for the runs made in Sutanudjaja et al.
+    (2018, https://doi.org/10.5194/gmd-11-2429-2018) are available on
+    https://geo.data.uu.nl/research-pcrglobwb/
+    pcr-globwb_gmd_paper_sutanudjaja_et_al_2018/.
     For requesting access, please send an e-mail to E.H.Sutanudjaja@uu.nl.
 
-    Main reference/paper: Sutanudjaja, E. H., van Beek, R., Wanders, N., Wada, Y., Bosmans, J. H. C., Drost, N., van der Ent,
-    R. J., de Graaf, I. E. M., Hoch, J. M., de Jong, K., Karssenberg, D., López López, P., Peßenteiner, S., Schmitz, O.,
-    Straatsma, M. W., Vannametee, E., Wisser, D., and Bierkens, M. F. P.: PCR-GLOBWB 2: a 5 arcmin global hydrological
-    and water resources model, Geosci. Model Dev., 11, 2429-2453, https://doi.org/10.5194/gmd-11-2429-2018, 2018.
+    Main reference/paper: Sutanudjaja, E. H. et al., Geosci. Model Dev.,
+    doi:10.5194/gmd-11-2429-2018, 2018.
 
   authors: ['aerts_jerom', 'andela_bouwe', 'drost_niels']
   projects: ['ewatercycle']
@@ -22,7 +24,7 @@ documentation:
 
 
 datasets:
-  - {dataset: ERA-Interim, project: OBS, tier: 3, type: reanaly, version: 1}
+  - {dataset: ERA-Interim, project: OBS6, tier: 3, type: reanaly, version: 1}
 
 preprocessors:
   preprocessor:

--- a/esmvaltool/recipes/recipe_ecs_scatter.yml
+++ b/esmvaltool/recipes/recipe_ecs_scatter.yml
@@ -75,7 +75,7 @@ diagnostics:
         end_year: 2005
         project: CMIP5
         additional_datasets:
-          - {dataset: ERA-Interim, project: OBS, type: reanaly,
+          - {dataset: ERA-Interim, project: OBS6, type: reanaly,
              version: 1, tier: 3}
           - {dataset: ACCESS1-0, ensemble: r1i1p1}
           # - {dataset: ACCESS1-3, ensemble: r1i1p1}
@@ -264,7 +264,8 @@ diagnostics:
         end_year: 2005
         project: CMIP5
     additional_datasets:
-      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, tier: 3}
+      - {dataset: ERA-Interim, project: OBS6, type: reanaly,
+         version: 1, tier: 3}
       - {dataset: ACCESS1-0, ensemble: r1i1p1}
       # - {dataset: ACCESS1-3, ensemble: r1i1p1}
       - {dataset: bcc-csm1-1, ensemble: r1i1p1}
@@ -375,7 +376,7 @@ diagnostics:
         exp: historical
         project: CMIP5
         additional_datasets:
-          - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1,
+          - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: 1,
              start_year: 2001, end_year: 2005, tier: 3}
       rsut:
         reference_dataset: CERES-EBAF
@@ -431,7 +432,8 @@ diagnostics:
           - {dataset: BCC-ESM1, grid: gn, ensemble: r1i1p1f1}
           - {dataset: CAMS-CSM1-0, grid: gn, ensemble: r1i1p1f1}
           - {dataset: CESM2, grid: gn, ensemble: r1i1p1f1}
-          - {dataset: CESM2-WACCM, institute: NCAR, grid: gn, ensemble: r1i1p1f1}
+          - {dataset: CESM2-WACCM, institute: NCAR, grid: gn,
+             ensemble: r1i1p1f1}
           - {dataset: CNRM-CM6-1, grid: gr, ensemble: r1i1p1f2}
           - {dataset: CNRM-ESM2-1, grid: gr, ensemble: r1i1p1f2}
           - {dataset: GFDL-CM4, grid: gr1, ensemble: r1i1p1f1}
@@ -480,7 +482,8 @@ diagnostics:
           - {dataset: BCC-ESM1, grid: gn, ensemble: r1i1p1f1}
           - {dataset: CAMS-CSM1-0, grid: gn, ensemble: r1i1p1f1}
           - {dataset: CESM2, grid: gn, ensemble: r1i1p1f1}
-          - {dataset: CESM2-WACCM, institute: NCAR, grid: gn, ensemble: r1i1p1f1}
+          - {dataset: CESM2-WACCM, institute: NCAR, grid: gn,
+             ensemble: r1i1p1f1}
           - {dataset: CNRM-CM6-1, grid: gr, ensemble: r1i1p1f2}
           - {dataset: CNRM-ESM2-1, grid: gr, ensemble: r1i1p1f2}
           - {dataset: GFDL-CM4, grid: gr1, ensemble: r1i1p1f1}
@@ -544,7 +547,8 @@ diagnostics:
       - {dataset: BCC-ESM1, grid: gn, ensemble: r1i1p1f1}
       - {dataset: CAMS-CSM1-0, grid: gn, ensemble: r1i1p1f1}
       - {dataset: CESM2, grid: gn, ensemble: r1i1p1f1}
-      - {dataset: CESM2-WACCM, institute: NCAR, grid: gn, ensemble: r1i1p1f1}
+      - {dataset: CESM2-WACCM, institute: NCAR, grid: gn,
+         ensemble: r1i1p1f1}
       - {dataset: CNRM-CM6-1, grid: gr, ensemble: r1i1p1f2}
       - {dataset: CNRM-ESM2-1, grid: gr, ensemble: r1i1p1f2}
       - {dataset: GFDL-CM4, grid: gr1, ensemble: r1i1p1f1}
@@ -553,7 +557,8 @@ diagnostics:
       - {dataset: IPSL-CM6A-LR, grid: gr, ensemble: r15i1p1f1}
       - {dataset: MIROC6, grid: gn, ensemble: r1i1p1f1}
       - {dataset: MRI-ESM2-0, grid: gn, ensemble: r1i1p1f1}
-      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, tier: 3}
+      - {dataset: ERA-Interim, project: OBS6, type: reanaly,
+         version: 1, tier: 3}
     scripts:
       ecs_scatter:
         diag: ltmi
@@ -582,7 +587,8 @@ diagnostics:
       - {dataset: BCC-ESM1, grid: gn, ensemble: r1i1p1f1}
       - {dataset: CAMS-CSM1-0, grid: gn, ensemble: r1i1p1f1}
       - {dataset: CESM2, grid: gn, ensemble: r1i1p1f1}
-      - {dataset: CESM2-WACCM, institute: NCAR, grid: gn, ensemble: r1i1p1f1}
+      - {dataset: CESM2-WACCM, institute: NCAR, grid: gn,
+         ensemble: r1i1p1f1}
       - {dataset: CNRM-CM6-1, grid: gr, ensemble: r1i1p1f2}
       - {dataset: CNRM-ESM2-1, grid: gr, ensemble: r1i1p1f2}
       - {dataset: GFDL-CM4, grid: gr1, ensemble: r1i1p1f1}
@@ -591,7 +597,8 @@ diagnostics:
       - {dataset: IPSL-CM6A-LR, grid: gr, ensemble: r15i1p1f1}
       - {dataset: MIROC6, grid: gn, ensemble: r1i1p1f1}
       - {dataset: MRI-ESM2-0, grid: gn, ensemble: r1i1p1f1}
-      - {dataset: ERA-Interim, project: OBS, type: reanaly, version: 1, tier: 3}
+      - {dataset: ERA-Interim, project: OBS6, type: reanaly,
+         version: 1, tier: 3}
     scripts:
       ecs_scatter:
         diag: shhc
@@ -619,9 +626,10 @@ diagnostics:
           - {dataset: HadISST, project: OBS, type: reanaly, version: 1, tier: 2}
           - {dataset: BCC-CSM2-MR, grid: gn, ensemble: r1i1p1f1}
           - {dataset: BCC-ESM1, grid: gn, ensemble: r2i1p1f1}
-#          - {dataset: CAMS-CSM1-0, grid: gn, ensemble: r1i1p1f1}
+          # - {dataset: CAMS-CSM1-0, grid: gn, ensemble: r1i1p1f1}
           - {dataset: CESM2, grid: gn, ensemble: r1i1p1f1}
-          - {dataset: CESM2-WACCM, institute: NCAR, grid: gn, ensemble: r1i1p1f1}
+          - {dataset: CESM2-WACCM, institute: NCAR, grid: gn,
+             ensemble: r1i1p1f1}
           - {dataset: CNRM-CM6-1, grid: gr, ensemble: r1i1p1f2}
           - {dataset: CNRM-ESM2-1, grid: gr, ensemble: r1i1p1f2}
           - {dataset: GFDL-CM4, grid: gr1, ensemble: r1i1p1f1}
@@ -639,13 +647,14 @@ diagnostics:
         mip: Amon
         project: CMIP6
         additional_datasets:
-          - {dataset: ERA-Interim, project: OBS, type: reanaly,
+          - {dataset: ERA-Interim, project: OBS6, type: reanaly,
              version: 1, tier: 3}
           - {dataset: BCC-CSM2-MR, grid: gn, ensemble: r1i1p1f1}
           - {dataset: BCC-ESM1, grid: gn, ensemble: r2i1p1f1}
-#          - {dataset: CAMS-CSM1-0, grid: gn, ensemble: r1i1p1f1}
+          # - {dataset: CAMS-CSM1-0, grid: gn, ensemble: r1i1p1f1}
           - {dataset: CESM2, grid: gn, ensemble: r1i1p1f1}
-          - {dataset: CESM2-WACCM, institute: NCAR, grid: gn, ensemble: r1i1p1f1}
+          - {dataset: CESM2-WACCM, institute: NCAR, grid: gn,
+             ensemble: r1i1p1f1}
           - {dataset: CNRM-CM6-1, grid: gr, ensemble: r1i1p1f2}
           - {dataset: CNRM-ESM2-1, grid: gr, ensemble: r1i1p1f2}
           - {dataset: GFDL-CM4, grid: gr1, ensemble: r1i1p1f1}
@@ -666,9 +675,10 @@ diagnostics:
              version: Ed2-7, tier: 1}
           - {dataset: BCC-CSM2-MR, grid: gn, ensemble: r1i1p1f1}
           - {dataset: BCC-ESM1, grid: gn, ensemble: r2i1p1f1}
-#          - {dataset: CAMS-CSM1-0, grid: gn, ensemble: r1i1p1f1}
+          # - {dataset: CAMS-CSM1-0, grid: gn, ensemble: r1i1p1f1}
           - {dataset: CESM2, grid: gn, ensemble: r1i1p1f1}
-          - {dataset: CESM2-WACCM, institute: NCAR, grid: gn, ensemble: r1i1p1f1}
+          - {dataset: CESM2-WACCM, institute: NCAR, grid: gn,
+             ensemble: r1i1p1f1}
           - {dataset: CNRM-CM6-1, grid: gr, ensemble: r1i1p1f2}
           - {dataset: CNRM-ESM2-1, grid: gr, ensemble: r1i1p1f2}
           - {dataset: GFDL-CM4, grid: gr1, ensemble: r1i1p1f1}
@@ -689,9 +699,10 @@ diagnostics:
              version: Ed2-7, tier: 1}
           - {dataset: BCC-CSM2-MR, grid: gn, ensemble: r1i1p1f1}
           - {dataset: BCC-ESM1, grid: gn, ensemble: r2i1p1f1}
-#          - {dataset: CAMS-CSM1-0, grid: gn, ensemble: r1i1p1f1}
+          # - {dataset: CAMS-CSM1-0, grid: gn, ensemble: r1i1p1f1}
           - {dataset: CESM2, grid: gn, ensemble: r1i1p1f1}
-          - {dataset: CESM2-WACCM, institute: NCAR, grid: gn, ensemble: r1i1p1f1}
+          - {dataset: CESM2-WACCM, institute: NCAR, grid: gn,
+             ensemble: r1i1p1f1}
           - {dataset: CNRM-CM6-1, grid: gr, ensemble: r1i1p1f2}
           - {dataset: CNRM-ESM2-1, grid: gr, ensemble: r1i1p1f2}
           - {dataset: GFDL-CM4, grid: gr1, ensemble: r1i1p1f1}
@@ -712,9 +723,10 @@ diagnostics:
              version: Ed2-7, tier: 1}
           - {dataset: BCC-CSM2-MR, grid: gn, ensemble: r1i1p1f1}
           - {dataset: BCC-ESM1, grid: gn, ensemble: r2i1p1f1}
-#          - {dataset: CAMS-CSM1-0, grid: gn, ensemble: r1i1p1f1}
+          # - {dataset: CAMS-CSM1-0, grid: gn, ensemble: r1i1p1f1}
           - {dataset: CESM2, grid: gn, ensemble: r1i1p1f1}
-          - {dataset: CESM2-WACCM, institute: NCAR, grid: gn, ensemble: r1i1p1f1}
+          - {dataset: CESM2-WACCM, institute: NCAR, grid: gn,
+             ensemble: r1i1p1f1}
           - {dataset: CNRM-CM6-1, grid: gr, ensemble: r1i1p1f2}
           - {dataset: CNRM-ESM2-1, grid: gr, ensemble: r1i1p1f2}
           - {dataset: GFDL-CM4, grid: gr1, ensemble: r1i1p1f1}


### PR DESCRIPTION
The `project` key for the `ERA-Interim` dataset has been updated to `OBS6` in #1297, but not all recipes have been updated accordingly.

This PR fixes the problem.