### PR TITLE
Add yamllint configuration file

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,8 @@
+---
+
+extends: default
+
+rules:
+  line-length:
+    max: 120
+  octal-values: enable


### PR DESCRIPTION
This adds a yamllint configuration file, with two settings different from the default
- Do not allow octal values, see https://github.com/ESMValGroup/ESMValCore/issues/25
- Increase maximum allowed line-length to 120, because spreading a dataset definition over two lines is much less readable.

* * *

**Tasks**

-   [Create an issue](https://github.com/ESMValGroup/ESMValTool/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [ ] Give this pull request a descriptive title that can be used as a one line summary in a changelog
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes 
