### PR TITLE
Update links to point to master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,8 +261,7 @@ workflows:
           filters:
             branches:
               only:
-                - version2_development
-                - version2_master
+                - master
     jobs:
       - test
       - test_installation

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-Before you start, read [CONTRIBUTING.md](https://github.com/ESMValGroup/ESMValTool/blob/version2_development/CONTRIBUTING.md) and the [guide for diagnostic developers](https://esmvaltool.readthedocs.io/en/latest/esmvaldiag/index.html).
+Before you start, read [CONTRIBUTING.md](https://github.com/ESMValGroup/ESMValTool/blob/master/CONTRIBUTING.md) and the [guide for diagnostic developers](https://esmvaltool.readthedocs.io/en/latest/esmvaldiag/index.html).
 
 Please discuss your idea with the development team before getting started, to avoid disappointment later. The way to do this is to open a new issue on GitHub. If you are planning to modify an existing functionality, please discuss it with the original author(s) by tagging them in the issue.
 
@@ -13,7 +13,7 @@ Please discuss your idea with the development team before getting started, to av
 -   [ ] Preferably Codacy code quality checks pass, however a few remaining hard to solve Codacy issues are still acceptable. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
 -   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes 
 -   [ ] (Only if really necessary) Add any additional dependencies needed for the diagnostic script to setup.py, esmvaltool/install/R/r_requirements.txt or esmvaltool/install/Julia/julia_requirements.txt (depending on the language of your script) and also to meta.yaml for conda dependencies (includes Python and others, but not R/Julia)
--   [ ] If new dependencies are introduced, check that the license is compatible with [Apache2.0](https://github.com/ESMValGroup/ESMValTool/blob/version2_development/LICENSE)
+-   [ ] If new dependencies are introduced, check that the license is compatible with [Apache2.0](https://github.com/ESMValGroup/ESMValTool/blob/master/LICENSE)
 
 New recipe/diagnostic
 

--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ The easiest way to get help if you cannot find the answer in the documentation o
 
 ## Contributing
 
-If you would like to contribute a new diagnostic or feature, please have a look at [CONTRIBUTING.md](https://github.com/ESMValGroup/ESMValTool/blob/version2_development/CONTRIBUTING.md).
+If you would like to contribute a new diagnostic or feature, please have a look at [CONTRIBUTING.md](https://github.com/ESMValGroup/ESMValTool/blob/master/CONTRIBUTING.md).

--- a/doc/sphinx/source/esmvaldiag/observations.rst
+++ b/doc/sphinx/source/esmvaldiag/observations.rst
@@ -24,7 +24,7 @@ data set for the use in ESMValTool.
 
 Most variables are defined in the CMIP data request and can be found in the
 CMOR tables in the folder `/esmvalcore/cmor/tables/cmip6/Tables/
-<https://github.com/ESMValGroup/ESMValCore/tree/development/esmvalcore/cmor/tables/cmip6/Tables>`_,
+<https://github.com/ESMValGroup/ESMValCore/tree/master/esmvalcore/cmor/tables/cmip6/Tables>`_,
 differentiated according to the ``MIP`` they belong to. The tables are a
 copy of the `PCMDI <https://github.com/PCMDI>`_ guidelines. If you find the
 variable in one of these tables, you can proceed to the next section.
@@ -32,7 +32,7 @@ variable in one of these tables, you can proceed to the next section.
 If your variable is not available in the standard CMOR tables,
 you need to write a custom CMOR table entry for the variable
 as outlined below and add it to `/esmvalcore/cmor/tables/custom/
-<https://github.com/ESMValGroup/ESMValCore/tree/development/esmvalcore/cmor/tables/custom>`_.
+<https://github.com/ESMValGroup/ESMValCore/tree/master/esmvalcore/cmor/tables/custom>`_.
 
 To create a new custom CMOR table you need to follow these
 guidelines:
@@ -70,7 +70,7 @@ should then be stored then in the appropriate of these three folders.
 ====================================
 
 There are many cmorizing scripts available in `/esmvaltool/cmorizers/obs/
-<https://github.com/ESMValGroup/ESMValTool/blob/version2_development/esmvaltool/cmorizers/obs/>`_
+<https://github.com/ESMValGroup/ESMValTool/blob/master/esmvaltool/cmorizers/obs/>`_
 where solutions to many kinds of format issues with observational data are
 addressed. Most of these scripts are written in NCL at the moment, but more
 and more examples for Python-based cmorizing scripts become available.
@@ -91,12 +91,12 @@ and one written in NCL, are explained in more detail.
 
 Find here an example of a cmorizing script, written for the ``MTE`` dataset
 that is available at the MPI for Biogeochemistry in Jena: `cmorize_obs_mte.py
-<https://github.com/ESMValGroup/ESMValTool/blob/version2_development/esmvaltool/cmorizers/obs/cmorize_obs_mte.py>`_.
+<https://github.com/ESMValGroup/ESMValTool/blob/master/esmvaltool/cmorizers/obs/cmorize_obs_mte.py>`_.
 
 All the necessary information about the dataset to write the filename
 correctly, and which variable is of interest, is stored in a seperate
 configuration file: `MTE.yml
-<https://github.com/ESMValGroup/ESMValTool/blob/version2_development/esmvaltool/cmorizers/obs/cmor_config/MTE.yml>`_
+<https://github.com/ESMValGroup/ESMValTool/blob/master/esmvaltool/cmorizers/obs/cmor_config/MTE.yml>`_
 in the directory ``ESMValTool/esmvaltool/cmorizers/obs/cmor_config/``. Note
 that the name of this configuration file has to be identical to the name of
 your data set. It is recommended that you set ``project`` to ``OBS6`` in the
@@ -142,7 +142,7 @@ that code style). For example, the function ``_get_filepath`` converts the raw
 filepath to the correct one and the function ``_extract_variable`` extracts and
 saves a single variable from the raw data.
 
-.. _utilities.py: https://github.com/ESMValGroup/ESMValTool/blob/version2_development/esmvaltool/cmorizers/obs/utilities.py
+.. _utilities.py: https://github.com/ESMValGroup/ESMValTool/blob/master/esmvaltool/cmorizers/obs/utilities.py
 
 
 4.2 Cmorizer script written in NCL
@@ -151,7 +151,7 @@ saves a single variable from the raw data.
 Find here an example of a cmorizing script, written for the ``ESACCI XCH4``
 dataset that is available on the Copernicus Climate Data Store:
 `cmorize_obs_cds_xch4.ncl
-<https://github.com/ESMValGroup/ESMValTool/blob/version2_development/esmvaltool/cmorizers/obs/cmorize_obs_cds_xch4.ncl>`_.
+<https://github.com/ESMValGroup/ESMValTool/blob/master/esmvaltool/cmorizers/obs/cmorize_obs_cds_xch4.ncl>`_.
 
 The first part of the script collects all the information about the dataset
 that are necessary to write the filename correctly and to understand which
@@ -168,9 +168,9 @@ CMOR_TABLE.
   through the loading of the script interface.ncl_. There are similar
   functions available for python scripts.
 
-.. _interface.ncl: https://github.com/ESMValGroup/ESMValTool/blob/version2_development/esmvaltool/cmorizers/obs/interface.ncl
+.. _interface.ncl: https://github.com/ESMValGroup/ESMValTool/blob/master/esmvaltool/cmorizers/obs/interface.ncl
 
-.. _utilities.ncl: https://github.com/ESMValGroup/ESMValTool/blob/version2_development/esmvaltool/cmorizers/obs/utilities.ncl
+.. _utilities.ncl: https://github.com/ESMValGroup/ESMValTool/blob/master/esmvaltool/cmorizers/obs/utilities.ncl
 
 In the second part of the script each variable defined in ``VAR`` is separately
 extracted from the original data file and processed. Most parts of the code are
@@ -219,7 +219,7 @@ script has been used to create the netCDF file.
 
 The correct structure of an observational data set is defined in
 `config-developer.yml
-<https://github.com/ESMValGroup/ESMValCore/blob/development/esmvalcore/config-developer.yml>`_,
+<https://github.com/ESMValGroup/ESMValCore/blob/master/esmvalcore/config-developer.yml>`_,
 and looks like the following:
 
 .. code-block:: console

--- a/doc/sphinx/source/esmvaldiag/porting.rst
+++ b/doc/sphinx/source/esmvaldiag/porting.rst
@@ -4,7 +4,7 @@
 Porting a namelist (recipe) or diagnostic to ESMValTool v2.0
 ************************************************************
 
-This guide summarizes the main steps to be taken in order to port an ESMValTool namelist (now called **recipe**) and the corresponding diagnostic(s) from v1.0 to v2.0, hereafter also referred as the *"old"* and the *"new version"*, respectively. The new ESMValTool version is being developed in the public git branch ``version2_development``. An identical version of this branch is maintained in the private repository as well and kept synchronized on an hourly basis.
+This guide summarizes the main steps to be taken in order to port an ESMValTool namelist (now called **recipe**) and the corresponding diagnostic(s) from v1.0 to v2.0, hereafter also referred as the *"old"* and the *"new version"*, respectively. The new ESMValTool version is being developed in the public git branch ``master``. An identical version of this branch is maintained in the private repository as well and kept synchronized on an hourly basis.
 
 In the following, it is assumed that the user has successfully installed ESMValTool v2 and has a rough overview of its structure (see `Technical Overview <http://www.esmvaltool.org/download/Righi_ESMValTool2-TechnicalOverview.pdf>`_).
 
@@ -17,14 +17,15 @@ Do not forget to assign it to yourself.
 Create your own branch
 ======================
 
-Create your own branch from ``version2_development`` for each namelist (recipe) to be ported:
+Create your own branch from ``master`` for each namelist (recipe) to be ported:
 
 .. code-block:: bash
 
-    git checkout version2_development
-    git checkout -b version2_<recipe>
+    git checkout master
+    git pull
+    git checkout -b <recipe>
 
-``version2_development`` contains only v2.0 under the ``./esmvaltool/`` directory. 
+``master`` contains only v2.0 under the ``./esmvaltool/`` directory.
 
 Convert xml to yml
 ==================
@@ -40,8 +41,8 @@ Do not forget to also rewrite the recipe header in a ``documentation`` section u
 Create a copy of the diag script in v2.0
 ========================================
 
-The diagnostic script to be ported goes into the directory ./esmvaltool/diag_script/. It is recommended to get a copy of the very last version of the script to be ported from the development branch (either in the public or in the private repository). Just create a local (offline) copy of this file from the repository and add it to ../esmvaltool/diag_script/ as a new file.
- 
+The diagnostic script to be ported goes into the directory ./esmvaltool/diag_script/. It is recommended to get a copy of the very last version of the script to be ported from the ``version1`` branch (either in the public or in the private repository). Just create a local (offline) copy of this file from the repository and add it to ../esmvaltool/diag_script/ as a new file.
+
 Note that (in general) this is not necessary for plot scripts and for the libraries in ``./esmvaltool/diag_script/ncl/lib/``, which have already been ported. Changes may however still be necessary, especially in the plot scripts which have not yet been fully tested with all diagnostics.
 
 Check and apply renamings
@@ -128,7 +129,7 @@ The following changes may also have to be considered:
 - namelists are now called recipes and collected in ``esmvaltool/recipes``;
 - models are now called datasets and all files have been updated accordingly, including NCL functions (see table above);
 - ``run_dir`` (previous ``interface_data``), ``plot_dir``, ``work_dir`` are now unique to each diagnostic script, so it is no longer necessary to define specific paths in the diagnostic scripts to prevent file collision;
-- `input_file_info`` is now a list of a list of logicals, where each element describes one dataset and one variable. Convenience functions to extract the required elements (e.g., all datasets of a given variable) are provided in ``esmvaltool/interface_scripts/interface.ncl``;
+- ``input_file_info`` is now a list of a list of logicals, where each element describes one dataset and one variable. Convenience functions to extract the required elements (e.g., all datasets of a given variable) are provided in ``esmvaltool/interface_scripts/interface.ncl``;
 - the interface functions ``interface_get_*`` and ``get_figure_filename`` are no longer available: their functionalities can be easily reproduced using the ``input_file_info`` and the convenience functions in ``esmvaltool/interface_scripts/interface.ncl`` to access the required attributes;
 - there are now only 4 log levels (``debug``, ``info``, ``warning``, and ``error``) instead of (infinite) numerical values in ``verbosity``
 - diagnostic scripts are now organized in subdirectories in ``esmvaltool/diag_scripts/``: all scripts belonging to the same diagnostics are to be collected in a single subdirectory (see ``esmvaltool/diag_scripts/perfmetrics/`` for example). This applies also to the ``aux_`` scripts, unless they are shared among multiple diagnostics (in this case they go in ``shared/``);
@@ -158,7 +159,7 @@ In the new version, all settings are centralized in the recipe, completely repla
 Make sure the diagnostic script writes NetCDF output
 ======================================================
 
-Each diagnostic script is required to write the output of the anaylsis in one or more NetCDF files. This is to give the user the possibility to further look into the results, besides the plots, but (most importantly) for tagging purposes when publishing the data in a report and/or on a website. 
+Each diagnostic script is required to write the output of the anaylsis in one or more NetCDF files. This is to give the user the possibility to further look into the results, besides the plots, but (most importantly) for tagging purposes when publishing the data in a report and/or on a website.
 
 For each of the plot produced by the diagnostic script a single NetCDF file has to be generated. The variable saved in this file should also contain all the necessary metadata that documents the plot (dataset names, units, statistical methods, etc.).
 The files have to be saved in the work directory (defined in `cfg['work_dir']` and `config_user_info@work_dir`, for the python and NCL diagnostics, respectively).
@@ -208,9 +209,9 @@ Before submitting a pull request, the code should be cleaned to adhere to the co
 Update the documentation
 ========================
 
-If necessary, add or update the documentation for your recipes in the corrsponding rst file, which is now in ``doc\sphinx\source\recipes``. Do not forget to also add the documentation file to the list in ``doc\sphinx\source\annex_c`` to make sure it actually appears in the documentation. 
+If necessary, add or update the documentation for your recipes in the corrsponding rst file, which is now in ``doc\sphinx\source\recipes``. Do not forget to also add the documentation file to the list in ``doc\sphinx\source\annex_c`` to make sure it actually appears in the documentation.
 
 Open a pull request
 ===================
 
-Create a pull request on github to merge your branch back to ``version2_development``, provide a short description of what has been done and nominate one or more reviewers.
+Create a pull request on github to merge your branch back to ``master``, provide a short description of what has been done and nominate one or more reviewers.

--- a/doc/sphinx/source/getting_started/config_user.rst
+++ b/doc/sphinx/source/getting_started/config_user.rst
@@ -8,7 +8,7 @@ The ``config-user.yml`` configuration file contains all the global level
 information needed by ESMValTool. The configuration is passed to ESMValTool
 as a command line argument (see :ref:`Running ESMValTool <running>`).
 
-An example configuration file can be downloaded `here <https://github.com/ESMValGroup/ESMValTool/blob/version2_development/config-user-example.yml>`_
+An example configuration file can be downloaded `here <https://github.com/ESMValGroup/ESMValTool/blob/master/config-user-example.yml>`_
 and tailored for your system using the explanation below.
 
 Most of these settings are fairly self-explanatory, ie:

--- a/doc/sphinx/source/getting_started/running.rst
+++ b/doc/sphinx/source/getting_started/running.rst
@@ -9,7 +9,7 @@ conda environment for ESMValTool is active, you can just run the command
 ``esmvaltool <options> <recipe>``. One of the options that must be specified
 is the user configuration file, which is specified using the
 option ``-c /path/to/config-user.yaml``. An
-`example recipe <https://github.com/ESMValGroup/ESMValTool/blob/version2_development/esmvaltool/recipes/examples/recipe_python.yml>`_
+`example recipe <https://github.com/ESMValGroup/ESMValTool/blob/master/esmvaltool/recipes/examples/recipe_python.yml>`_
 is available in the ESMValTool installation folder as
 ``examples/recipe_python.yml``.
 
@@ -17,7 +17,7 @@ This recipe finds data from CanESM2 and MPI-ESM-LR for 2000 - 2002,
 extracts a single level (850 hPa), regrids it to a 1x1 degree mesh and runs
 a diagnostic script that creates some plots of Air temperature and
 precipitation flux. You can download the recipe from
-`github <https://github.com/ESMValGroup/ESMValTool/blob/version2_development/esmvaltool/recipes/examples/recipe_python.yml>`_
+`github <https://github.com/ESMValGroup/ESMValTool/blob/master/esmvaltool/recipes/examples/recipe_python.yml>`_
 and save it in your project directory as (e.g.) ``recipe_python.yml``
 and then run ESMValTool with
 

--- a/doc/sphinx/source/recipes/recipe_oceans.rst
+++ b/doc/sphinx/source/recipes/recipe_oceans.rst
@@ -492,8 +492,8 @@ The diagnostic_maps_multimodel.py_ diagnostic makes model(s) vs observations map
 and if data are not provided it draws only model field.
 
 It is always nessary to define the overall layout trough the argument `layout_rowcol`,
-which is a list of two integers indicating respectively the number of rows and columns 
-to organize the plot. Observations has not be accounted in here as they are automatically 
+which is a list of two integers indicating respectively the number of rows and columns
+to organize the plot. Observations has not be accounted in here as they are automatically
 added at the top of the figure.
 
 This diagnostic also includes the optional arguments, `maps_range` and
@@ -821,22 +821,22 @@ The file needs to be reformatted using the `cmorize_obs_py` script with output n
 .. Links:
 
 .. Recipes:
-.. _recipe_ocean_amoc.yml: https://github.com/ESMValGroup/ESMValTool/tree/version2_development/esmvaltool/recipes/recipe_ocean_amoc.yml
-.. _recipe_ocean_example.yml: https://github.com/ESMValGroup/ESMValTool/tree/version2_development/esmvaltool/recipes/recipe_ocean_example.yml
-.. _recipe_ocean_scalar_fields.yml: https://github.com/ESMValGroup/ESMValTool/tree/version2_development/esmvaltool/recipes/recipe_ocean_scalar_fields.yml
-.. _recipe_ocean_bgc.yml: https://github.com/ESMValGroup/ESMValTool/tree/version2_development/esmvaltool/recipes/recipe_ocean_bgc.yml
-.. _recipe_ocean_quadmap.yml: https://github.com/ESMValGroup/ESMValTool/tree/version2_development/esmvaltool/recipes/recipe_ocean_quadmap.yml
-.. _recipe_ocean_Landschuetzer2016.yml: https://github.com/ESMValGroup/ESMValTool/tree/version2_development/esmvaltool/recipes/recipe_ocean_Landschuetzer2016.yml
-.. _recipe_ocean_multimap.yml: https://github.com/ESMValGroup/ESMValTool/tree/version2_development/esmvaltool/recipes/recipe_ocean_multimap.yml
+.. _recipe_ocean_amoc.yml: https://github.com/ESMValGroup/ESMValTool/tree/master/esmvaltool/recipes/recipe_ocean_amoc.yml
+.. _recipe_ocean_example.yml: https://github.com/ESMValGroup/ESMValTool/tree/master/esmvaltool/recipes/recipe_ocean_example.yml
+.. _recipe_ocean_scalar_fields.yml: https://github.com/ESMValGroup/ESMValTool/tree/master/esmvaltool/recipes/recipe_ocean_scalar_fields.yml
+.. _recipe_ocean_bgc.yml: https://github.com/ESMValGroup/ESMValTool/tree/master/esmvaltool/recipes/recipe_ocean_bgc.yml
+.. _recipe_ocean_quadmap.yml: https://github.com/ESMValGroup/ESMValTool/tree/master/esmvaltool/recipes/recipe_ocean_quadmap.yml
+.. _recipe_ocean_Landschuetzer2016.yml: https://github.com/ESMValGroup/ESMValTool/tree/master/esmvaltool/recipes/recipe_ocean_Landschuetzer2016.yml
+.. _recipe_ocean_multimap.yml: https://github.com/ESMValGroup/ESMValTool/tree/master/esmvaltool/recipes/recipe_ocean_multimap.yml
 
 .. Diagnostics:
-.. _ocean: https://github.com/ESMValGroup/ESMValTool/tree/version2_development/esmvaltool/diag_scripts/ocean/:
-.. _diagnostic_maps.py: https://github.com/ESMValGroup/ESMValTool/tree/version2_development/esmvaltool/diag_scripts/ocean/diagnostic_maps.py
-.. _diagnostic_maps_quad.py: https://github.com/ESMValGroup/ESMValTool/tree/version2_development/esmvaltool/diag_scripts/ocean/diagnostic_maps_quad.py
-.. _diagnostic_model_vs_obs.py: https://github.com/ESMValGroup/ESMValTool/tree/version2_development/esmvaltool/diag_scripts/ocean/diagnostic_model_vs_obs.py
-.. _diagnostic_maps_multimodel.py: https://github.com/ESMValGroup/ESMValTool/tree/version2_development/esmvaltool/diag_scripts/ocean/diagnostic_maps_multimodel.py
-.. _diagnostic_profiles.py: https://github.com/ESMValGroup/ESMValTool/tree/version2_development/esmvaltool/diag_scripts/ocean/diagnostic_profiles.py
-.. _diagnostic_timeseries.py: https://github.com/ESMValGroup/ESMValTool/tree/version2_development/esmvaltool/diag_scripts/ocean/diagnostic_timeseries.py
-.. _diagnostic_transects.py: https://github.com/ESMValGroup/ESMValTool/tree/version2_development/esmvaltool/diag_scripts/ocean/diagnostic_transects.py
-.. _diagnostic_seaice.py: https://github.com/ESMValGroup/ESMValTool/tree/version2_development/esmvaltool/diag_scripts/ocean/diagnostic_seaice.py
-.. _diagnostic_tools.py: https://github.com/ESMValGroup/ESMValTool/tree/version2_development/esmvaltool/diag_scripts/ocean/diagnostic_tools.py
+.. _ocean: https://github.com/ESMValGroup/ESMValTool/tree/master/esmvaltool/diag_scripts/ocean/:
+.. _diagnostic_maps.py: https://github.com/ESMValGroup/ESMValTool/tree/master/esmvaltool/diag_scripts/ocean/diagnostic_maps.py
+.. _diagnostic_maps_quad.py: https://github.com/ESMValGroup/ESMValTool/tree/master/esmvaltool/diag_scripts/ocean/diagnostic_maps_quad.py
+.. _diagnostic_model_vs_obs.py: https://github.com/ESMValGroup/ESMValTool/tree/master/esmvaltool/diag_scripts/ocean/diagnostic_model_vs_obs.py
+.. _diagnostic_maps_multimodel.py: https://github.com/ESMValGroup/ESMValTool/tree/master/esmvaltool/diag_scripts/ocean/diagnostic_maps_multimodel.py
+.. _diagnostic_profiles.py: https://github.com/ESMValGroup/ESMValTool/tree/master/esmvaltool/diag_scripts/ocean/diagnostic_profiles.py
+.. _diagnostic_timeseries.py: https://github.com/ESMValGroup/ESMValTool/tree/master/esmvaltool/diag_scripts/ocean/diagnostic_timeseries.py
+.. _diagnostic_transects.py: https://github.com/ESMValGroup/ESMValTool/tree/master/esmvaltool/diag_scripts/ocean/diagnostic_transects.py
+.. _diagnostic_seaice.py: https://github.com/ESMValGroup/ESMValTool/tree/master/esmvaltool/diag_scripts/ocean/diagnostic_seaice.py
+.. _diagnostic_tools.py: https://github.com/ESMValGroup/ESMValTool/tree/master/esmvaltool/diag_scripts/ocean/diagnostic_tools.py

--- a/doc/sphinx/source/recipes/recipe_perfmetrics.rst
+++ b/doc/sphinx/source/recipes/recipe_perfmetrics.rst
@@ -6,7 +6,7 @@ Performance metrics for essential climate parameters
 Overview
 --------
 
-The goal is to create a standard recipe for the calculation of performance metrics to quantify the ability of the models to reproduce the climatological mean annual cycle for selected "Essential Climate Variables" (ECVs) plus some additional corresponding diagnostics and plots to better understand and interpret the results. 
+The goal is to create a standard recipe for the calculation of performance metrics to quantify the ability of the models to reproduce the climatological mean annual cycle for selected "Essential Climate Variables" (ECVs) plus some additional corresponding diagnostics and plots to better understand and interpret the results.
 
 The recipe can be used to calculate performance metrics at different vertical levels (e.g., 5, 30, 200, 850 hPa as in `Gleckler et al. (2008) <http://dx.doi.org/10.1029/2007JD008972>`_ and in different regions. As an additional reference, we consider `Righi et al. (2015) <https://doi.org/10.5194/gmd-8-733-2015>`_.
 
@@ -36,9 +36,9 @@ User settings in recipe
    * plot_type: cycle (time), zonal (plev, lat), latlon (lat, lon), cycle_latlon (time, lat, lon), cycle_zonal (time, plev, lat)
    * time_avg: type of time average (monthlyclim, seasonalclim, annualclim)
    * region: selected region (global, trop, nhext, shext, nhtrop, shtrop, nh, sh, nhmidlat, shmidlat, nhpolar, shpolar, eq)
-   
+
    *Optional settings (scripts)*
-   
+
    * styleset: for plot_type cycle only (cmip5, righi15gmd, cmip6, default)
    * plot_stddev: for plot_type cycle only, plots standard deviation as shading
    * legend_outside: for plot_type cycle only, plots the legend in a separate file
@@ -57,11 +57,11 @@ User settings in recipe
    * zonal_ymin: for plot_type zonal only, minimum pressure level on the y-axis (default: 5. hPa)
    * latlon_cmap: for plot_type latlon only, chosen color table (default: "amwg_blueyellowred")
    * plot_units: plotting units (if different from standard CMOR units)
-   
+
    *Required settings (variables)*
-   
+
    * reference_dataset: reference dataset to compare with (usually the observations).
-   
+
    *Optional settings (variables)*
 
    * alternative_dataset: a second dataset to compare with.
@@ -76,9 +76,9 @@ User settings in recipe
    * label_bounds: for RMSD and BIAS metrics, min and max of the labelbar
    * label_scale: for RMSD and BIAS metrics, bin width of the labelbar
    * colormap: for RMSD and BIAS metrics, color table of the labelbar
-   
+
    *Optional settings (scripts)*
-   
+
    * label_lo: adds lower triange for values outside range
    * label_hi: adds upper triange for values outside range
    * cm_interval: min and max color of the color table
@@ -112,7 +112,7 @@ Observations and reformat scripts
 ---------------------------------
 
 The following list shows the currently used observational data sets for this recipe with their variable names and the reference to their respective reformat scripts in parentheses. Please note that obs4mips data can be used directly without any reformating. For non-obs4mips data see headers of cmorization scripts (in `/esmvaltool/cmorizers/obs/
-<https://github.com/ESMValGroup/ESMValTool/blob/version2_development/esmvaltool/cmorizers/obs/>`_) for downloading and processing instructions.
+<https://github.com/ESMValGroup/ESMValTool/blob/master/esmvaltool/cmorizers/obs/>`_) for downloading and processing instructions.
 
 * AIRS (hus - obs4mips)
 * CERES-EBAF (rlut, rlutcs, rsut, rsutcs - obs4mips)
@@ -163,4 +163,4 @@ Example plots
    :width: 90%
    :align: center
 
-   Relative space-time root-mean-square deviation (RMSD) calculated from the climatological seasonal cycle of CMIP5 simulations. A relative performance is displayed, with blue shading indicating better and red shading indicating worse performance than the median of all model results. A diagonal split of a grid square shows the relative error with respect to the reference data set (lower right triangle) and the alternative data set (upper left triangle). White boxes are used when data are not available for a given model and variable. 
+   Relative space-time root-mean-square deviation (RMSD) calculated from the climatological seasonal cycle of CMIP5 simulations. A relative performance is displayed, with blue shading indicating better and red shading indicating worse performance than the median of all model results. A diagonal split of a grid square shows the relative error with respect to the reference data set (lower right triangle) and the alternative data set (upper left triangle). White boxes are used when data are not available for a given model and variable.

--- a/doc/sphinx/source/recipes/recipe_smpi.rst
+++ b/doc/sphinx/source/recipes/recipe_smpi.rst
@@ -73,7 +73,7 @@ Observations and reformat scripts
 ---------------------------------
 
 The following list shows the currently used observational data sets for this recipe with their variable names and the reference to their respective reformat scripts in parentheses. Please note that obs4mips data can be used directly without any reformating. For non-obs4mips data see headers of cmorization scripts (in `/esmvaltool/cmorizers/obs/
-<https://github.com/ESMValGroup/ESMValTool/blob/version2_development/esmvaltool/cmorizers/obs/>`_) for downloading and processing instructions.
+<https://github.com/ESMValGroup/ESMValTool/blob/master/esmvaltool/cmorizers/obs/>`_) for downloading and processing instructions.
 
 * ERA-Interim (hfds, hus, psl, ta, tas, tauu, tauv, ua, va - esmvaltool/utils/cmorizers/obs/cmorize_obs_ERA-Interim.ncl)
 * HadISST (sic, tos - reformat_scripts/obs/reformat_obs_HadISST.ncl)


### PR DESCRIPTION
Update links in the documentation to point to `master` branch instead of the `version2_development` branch, as is this the new default branch.

* * *

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValTool/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] Give this pull request a descriptive title that can be used as a one line summary in a changelog
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Preferably Codacy code quality checks pass, however a few remaining hard to solve Codacy issues are still acceptable. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
* * *

Closes #1174