### PR TITLE
Remove climdex.pcic and ClimProjDiags because no longer available on CRAN

### DIFF
--- a/esmvaltool/install/R/r_requirements.txt
+++ b/esmvaltool/install/R/r_requirements.txt
@@ -1,7 +1,5 @@
 abind
 akima
-climdex.pcic
-ClimProjDiags
 dotCall64
 functional
 ggplot2


### PR DESCRIPTION
Installation of the R dependencies fails because the following packages have been removed from CRAN:
climdex.pcic https://cran.r-project.org/web/packages/climdex.pcic/index.html
ClimProjDiags https://cran.r-project.org/web/packages/ClimProjDiags/index.html

This pull request removes those as a dependency so the R installation proceeds again.

Related to issues #1443 and #1496