### PR TITLE
Better default configuration

### DIFF
--- a/config-user-example.yml
+++ b/config-user-example.yml
@@ -17,10 +17,14 @@ drs:
   CMIP5: default
   CMIP6: default
 
-# Run at most this many tasks in parallel null/[1]/2/3/4/..
+# Run at most this many tasks in parallel [null]/1/2/3/4/..
 # Set to null to use the number of available CPUs.
-# Make sure your system has enough memory for the specified number of tasks.
-max_parallel_tasks: 1
+# If you run out of memory, try setting max_parallel_tasks to 1 and check the
+# amount of memory you need for that by inspecting the file
+# run/resource_usage.txt in the output directory. Using the number there you
+# can increase the number of parallel tasks again to a reasonable number for
+# the amount of memory available in your system.
+max_parallel_tasks: null
 
 # Destination directory
 output_dir: ./esmvaltool_output
@@ -34,9 +38,9 @@ write_plots: true
 write_netcdf: true
 # Set the console log level debug, [info], warning, error
 log_level: info
-# Exit on warning? true/[false]
+# Exit on warning (only for NCL diagnostic scripts)? true/[false]
 exit_on_warning: false
-# Plot file format? [ps]/pdf/png/eps/epsi
+# Plot file format? [png]/pdf/ps/eps/epsi
 output_file_type: png
 # Use netCDF compression true/[false]
 compress_netcdf: false

--- a/doc/sphinx/source/getting_started/outputdata.rst
+++ b/doc/sphinx/source/getting_started/outputdata.rst
@@ -17,13 +17,13 @@ output_dir/recipe_name_YYYYMMDD_HHMMSS/
 
 This directory will contain 4 further subdirectories:
 
-1. `Preprocessed datasets`_ (preproc): This directory contains all the preprocessed netcdfs data and the `metadata.yml`_ interface files.
+1. `Diagnostic output`_ (work): A place for any diagnostic script results that are not plots, e.g. files in NetCDF format (depends on the diagnostics).
 
-2. `Run`_: This directory includes all log files, a copy of the recipe, a summary of the resource usage, and the `settings.yml`_ interface files and temporary files created by the diagnostic scripts.
+2. `Plots`_: The location for all the plots, split by individual diagnostics and fields.
 
-3. `Diagnostic output`_ (work): A place for any diagnostic script results that are not plots, e.g. files in NetCDF format (depends on the diagnostics).
+3. `Run`_: This directory includes all log files, a copy of the recipe, a summary of the resource usage, and the `settings.yml`_ interface files and temporary files created by the diagnostic scripts.
 
-4. `Plots`_: The location for all the plots, split by individual diagnostics and fields.
+4. `Preprocessed datasets`_ (preproc): This directory contains all the preprocessed netcdfs data and the `metadata.yml`_ interface files. Note that by default this directory will be deleted after each run, because most users will only need the results from the diagnostic scripts.
 
 
 Preprocessed datasets

--- a/doc/sphinx/source/getting_started/outputdata.rst
+++ b/doc/sphinx/source/getting_started/outputdata.rst
@@ -90,7 +90,6 @@ disk of the metadata.yml file (described below).
 
     input_files:[[...]recipe_ocean_bgc_20190118_134855/preproc/diag_timeseries_scalars/mfo/metadata.yml]
     log_level: debug
-    max_data_filesize: 100
     output_file_type: png
     plot_dir: [...]recipe_ocean_bgc_20190118_134855/plots/diag_timeseries_scalars/Scalar_timeseries
     profile_diagnostic: false

--- a/esmvaltool/utils/batch-jobs/job_DKRZ-MISTRAL.sh
+++ b/esmvaltool/utils/batch-jobs/job_DKRZ-MISTRAL.sh
@@ -5,7 +5,6 @@
 ### Author: Mattia Righi (DLR)
 ###############################################################################
 #SBATCH --partition=compute
-#SBATCH --ntasks=8
 #SBATCH --time=08:00:00
 #SBATCH --mail-type=FAIL,END
 #SBATCH --account=bd0854


### PR DESCRIPTION
This pull request aims to provide better default settings in config-user.yml. Main changes:

- run in parallel by default, because users seem to be afraid to use this option and then complain that the tool is slow.
- unused option max_data_filesize removed
- remove wrong instruction on number of tasks from running using slurm @dkrz

* * *

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValTool/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] Give this pull request a descriptive title that can be used as a one line summary in a changelog
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Preferably Codacy code quality checks pass, however a few remaining hard to solve Codacy issues are still acceptable. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes 

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Related to #93 and https://github.com/ESMValGroup/ESMValCore/pull/465
