### PR TITLE
Quantilebias working for only a single dataset

### DIFF
--- a/esmvaltool/diag_scripts/quantilebias/quantilebias.R
+++ b/esmvaltool/diag_scripts/quantilebias/quantilebias.R
@@ -153,7 +153,6 @@ for (model_idx in c(1:(length(models_name)))) {
   unlink(
     c(
       modf,
-      reff,
       ref_perc_pf,
       mask_reff,
       mask_modf,


### PR DESCRIPTION
Quantilebias was deleting the reference dataset after processing the first dataset, preventing it from working with multiple datasets. This small fix repairs this.
