### PR TITLE
Cmorizer wrapper now uses the in-built logger configuration and outputs stdout to out and stderr to err

### DIFF
--- a/esmvaltool/cmorizers/obs/cmorize_obs.py
+++ b/esmvaltool/cmorizers/obs/cmorize_obs.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 import esmvalcore
-from esmvalcore._config import read_config_user_file
+from esmvalcore._config import configure_logging, read_config_user_file
 from esmvalcore._task import write_ncl_settings
 
 from .utilities import read_cmor_config
@@ -170,20 +170,9 @@ def main():
     if not os.path.isdir(run_dir):
         os.makedirs(run_dir)
 
-    # set logging for screen and file output
-    root_logger = logging.getLogger()
-    out_fmt = ("%(asctime)s [%(process)d] %(levelname)-8s "
-               "%(name)s,%(lineno)s\t%(message)s")
-    logging.basicConfig(filename=os.path.join(run_dir, 'main_log.txt'),
-                        filemode='a',
-                        format=out_fmt,
-                        datefmt='%H:%M:%S',
-                        level=config_user['log_level'].upper())
-    root_logger.setLevel(config_user['log_level'].upper())
-    logfmt = logging.Formatter(out_fmt)
-    console_handler = logging.StreamHandler()
-    console_handler.setFormatter(logfmt)
-    root_logger.addHandler(console_handler)
+    # configure logging
+    log_files = configure_logging(
+        output=run_dir, console_log_level=config_user['log_level'])
 
     # print header
     logger.info(HEADER)

--- a/esmvaltool/cmorizers/obs/cmorize_obs.py
+++ b/esmvaltool/cmorizers/obs/cmorize_obs.py
@@ -173,6 +173,7 @@ def main():
     # configure logging
     log_files = configure_logging(
         output=run_dir, console_log_level=config_user['log_level'])
+    logger.info("Writing program log files to:\n%s", "\n".join(log_files))
 
     # print header
     logger.info(HEADER)


### PR DESCRIPTION

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValTool/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] Give this pull request a descriptive title that can be used as a one line summary in a changelog
-   [x] Make sure your code is composed of functions of no more than 50 lines and uses meaningful names for variables
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Preferably Codacy code quality checks pass, however a few remaining hard to solve Codacy issues are still acceptable. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes 
-   [ ] (Only if really necessary) Add any additional dependencies needed for the diagnostic script to setup.py, esmvaltool/install/R/r_requirements.txt or esmvaltool/install/Julia/julia_requirements.txt (depending on the language of your script) and also to meta.yaml for conda dependencies (includes Python and others, but not R/Julia)
-   [ ] If new dependencies are introduced, check that the license is compatible with [Apache2.0](https://github.com/ESMValGroup/ESMValTool/blob/master/LICENSE)

New recipe/diagnostic

-   [ ] Add documentation for the recipe to the `doc/sphinx/source/recipes` folder and add a new entry to index.rst
-   [ ] Add provenance information

Modified recipe/diagnostic

-   [ ] Update documentation for the recipe to the `doc/sphinx/source/recipes` folder
-   [ ] Update provenance information if needed
-   [ ] Assign the author(s) of the affected recipe(s) as reviewer(s)

New data reformatting script

-   [ ] Test the CMORized data using recipes/example/recipe_check_obs.yml, to make sure the CMOR checks pass without errors
-   [ ] Add the new dataset to the table in the [documentation](https://esmvaltool.readthedocs.io/en/latest/getting_started/inputdata.html)
-   [ ] Tag @mattiarighi in this pull request, so that the new dataset can be added to the OBS data pool at DKRZ and synchronized with CEDA-Jasmin

Modified data reformatting script

-   [ ] Test the CMORized data using recipes/example/recipe_check_obs.yml, to make sure the CMOR checks pass without errors
-   [ ] Tag @mattiarighi in this pull request, so that the updated dataset can be added to the OBS data pool at DKRZ and synchronized with CEDA-Jasmin

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes https://github.com/ESMValGroup/ESMValTool/issues/1510
