### PR TITLE
Miles: fill occasional missing values

### DIFF
--- a/esmvaltool/diag_scripts/miles/block_fast.R
+++ b/esmvaltool/diag_scripts/miles/block_fast.R
@@ -62,7 +62,8 @@ miles_block_fast <- # nolint
       namevar = "zg",
       tmonths = timeseason,
       tyears = years,
-      rotate = "full"
+      rotate = "full",
+      fillmiss = TRUE
     )
     print(str(fieldlist))
 

--- a/esmvaltool/diag_scripts/miles/eof_fast.R
+++ b/esmvaltool/diag_scripts/miles/eof_fast.R
@@ -90,7 +90,8 @@ miles_eofs_fast <- # nolint
       "zg",
       tmonths = timeseason,
       tyears = years,
-      rotate = rotation
+      rotate = rotation,
+      fillmiss = T
     )
     print(str(fieldlist))
 
@@ -109,7 +110,6 @@ miles_eofs_fast <- # nolint
 
     # new faster monthly mean function
     z500monthly <- monthly_mean(ics, ipsilon, z500, etime)
-
     # climatology
     print("climatological mean...")
     z500clim <-

--- a/esmvaltool/diag_scripts/miles/miles_block.R
+++ b/esmvaltool/diag_scripts/miles/miles_block.R
@@ -48,6 +48,7 @@ source(paste0(diag_scripts_dir, "/miles/basis_functions.R"))
 source(paste0(diag_scripts_dir, "/miles/block_figures.R"))
 source(paste0(diag_scripts_dir, "/miles/block_fast.R"))
 source(paste0(diag_scripts_dir, "/miles/miles_parameters.R"))
+source(paste0(diag_scripts_dir, "/shared/external.R")) # nolint
 
 # read settings and metadata files
 args <- commandArgs(trailingOnly = TRUE)

--- a/esmvaltool/diag_scripts/miles/miles_eof.R
+++ b/esmvaltool/diag_scripts/miles/miles_eof.R
@@ -41,6 +41,7 @@ source(paste0(diag_scripts_dir, "/miles/basis_functions.R"))
 source(paste0(diag_scripts_dir, "/miles/eof_figures.R"))
 source(paste0(diag_scripts_dir, "/miles/eof_fast.R"))
 source(paste0(diag_scripts_dir, "/miles/miles_parameters.R"))
+source(paste0(diag_scripts_dir, "/shared/external.R")) # nolint
 
 # read settings and metadata files
 args <- commandArgs(trailingOnly = TRUE)

--- a/esmvaltool/diag_scripts/miles/miles_regimes.R
+++ b/esmvaltool/diag_scripts/miles/miles_regimes.R
@@ -41,6 +41,7 @@ source(paste0(diag_scripts_dir, "/miles/basis_functions.R"))
 source(paste0(diag_scripts_dir, "/miles/regimes_figures.R"))
 source(paste0(diag_scripts_dir, "/miles/regimes_fast.R"))
 source(paste0(diag_scripts_dir, "/miles/miles_parameters.R"))
+source(paste0(diag_scripts_dir, "/shared/external.R")) # nolint
 
 # read settings and metadata files
 args <- commandArgs(trailingOnly = TRUE)

--- a/esmvaltool/diag_scripts/miles/regimes_fast.R
+++ b/esmvaltool/diag_scripts/miles/regimes_fast.R
@@ -65,7 +65,8 @@ miles_regimes_fast <-
       namevar = "zg",
       tmonths = timeseason,
       tyears = years,
-      rotate = "full"
+      rotate = "full",
+      fillmiss = TRUE
     )
 
     # extract calendar and time unit from the original file

--- a/esmvaltool/install/Julia/julia_requirements.txt
+++ b/esmvaltool/install/Julia/julia_requirements.txt
@@ -1,8 +1,8 @@
 ArgParse
-Compat
+YAML
 DataFrames
 RainFARM
-YAML
+Compat
 JSON
 PyCall
 PyPlot


### PR DESCRIPTION
This small modification of the miles diagnostics (miles_eof.R, miles_block.R, miles_regimes.R) addresses the fact that a few datasets (e.g. the CMIP6 ACCESS-CM2) present missing values in geopotential height fields, even at 500hPa (in the example dataset there is a couple of pixels poking through in the Himalaya region). This was preventing in particular miles_eof.R from working with these datasets.  Bilinear interpolation implemented with "cdo fillmiss" is used to fill in the missing values. 
Additionally, a part of code which was still using a direct call to cdo though system2 has been changed to use the standard R cdo interface from external.R.