### PR TITLE
pin ArgParse Julia dependency to 0.6.2

### DIFF
--- a/esmvaltool/install/Julia/setup.jl
+++ b/esmvaltool/install/Julia/setup.jl
@@ -16,7 +16,12 @@ open(scriptDir * "/julia_requirements.txt") do f
       pkgId=i[1]
       pkgName=i[2]
       @info "Installing" pkgName
-      Pkg.add(pkgName)
+      if pkgName == "ArgParse"
+          Pkg.add(pkgName)
+          Pkg.pin(PackageSpec(name = "ArgParse", version = "0.6.2"))
+      else
+          Pkg.add(pkgName)
+      end
 
       @info "Testing: ", pkgName
       # load the package this needs to be called at top-level


### PR DESCRIPTION
ArgParse=1.0.1 is not playing well with RainFarm and the installation tests die at install Julia stage:
```
┌ Info: Installing the packages from
└   scriptDir * "/julia_requirements.txt" = "/test_installation/esmvaltool/install/Julia/julia_requirements.txt"
┌ Info: Installing
└   pkgName = "ArgParse"
[ Info: ("Testing: ", "ArgParse")
┌ Info: Installing
└   pkgName = "Compat"
[ Info: ("Testing: ", "Compat")
┌ Info: Installing
└   pkgName = "DataFrames"
[ Info: ("Testing: ", "DataFrames")
┌ Info: Installing
└   pkgName = "RainFARM"
ERROR: LoadError: Unsatisfiable requirements detected for package ArgParse [c7e460c6]:
 ArgParse [c7e460c6] log:
 ├─possible versions are: [0.6.1-0.6.2, 1.0.0-1.0.1] or uninstalled
 ├─restricted to versions 1.0.1 by an explicit requirement, leaving only versions 1.0.1
 └─restricted by compatibility requirements with RainFARM [e9a4e08f] to versions: 0.6.1-0.6.2 — no versions left
   └─RainFARM [e9a4e08f] log:
     ├─possible versions are: 1.0.1-1.0.2 or uninstalled
     └─restricted to versions * by an explicit requirement, leaving only versions 1.0.1-1.0.2
Stacktrace:
 [1] #propagate_constraints!#61(::Bool, ::Function, ::Pkg.GraphType.Graph, ::Set{Int64}) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Pkg/src/GraphType.jl:1005
 [2] propagate_constraints! at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Pkg/src/GraphType.jl:946 [inlined]
 [3] #simplify_graph!#121(::Bool, ::Function, ::Pkg.GraphType.Graph, ::Set{Int64}) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Pkg/src/GraphType.jl:1460
 [4] simplify_graph! at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Pkg/src/GraphType.jl:1460 [inlined] (repeats 2 times)
 [5] resolve_versions!(::Pkg.Types.Context, ::Array{Pkg.Types.PackageSpec,1}, ::Nothing) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Pkg/src/Operations.jl:373
 [6] resolve_versions! at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Pkg/src/Operations.jl:316 [inlined]
 [7] #add_or_develop#62(::Array{Base.UUID,1}, ::Symbol, ::Function, ::Pkg.Types.Context, ::Array{Pkg.Types.PackageSpec,1}) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Pkg/src/Operations.jl:1201
 [8] #add_or_develop at ./none:0 [inlined]
 [9] #add_or_develop#13(::Symbol, ::Bool, ::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::Function, ::Pkg.Types.Context, ::Array{Pkg.Types.PackageSpec,1}) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Pkg/src/API.jl:64
 [10] #add_or_develop#12 at ./none:0 [inlined]
 [11] #add_or_develop at ./none:0 [inlined]
 [12] #add_or_develop#11 at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Pkg/src/API.jl:28 [inlined]
 [13] #add_or_develop at ./none:0 [inlined]
 [14] #add_or_develop#10 at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Pkg/src/API.jl:27 [inlined]
 [15] #add_or_develop at ./none:0 [inlined]
 [16] #add#18 at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Pkg/src/API.jl:69 [inlined]
 [17] add at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Pkg/src/API.jl:69 [inlined]
 [18] (::getfield(Main, Symbol("##3#4")))(::IOStream) at /test_installation/esmvaltool/install/Julia/setup.jl:19
 [19] #open#294(::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::Function, ::getfield(Main, Symbol("##3#4")), ::String) at ./iostream.jl:369
 [20] open(::Function, ::String) at ./iostream.jl:367
 [21] top-level scope at none:0
 [22] include at ./boot.jl:317 [inlined]
 [23] include_relative(::Module, ::String) at ./loading.jl:1044
 [24] include(::Module, ::String) at ./sysimg.jl:29
 [25] exec_options(::Base.JLOptions) at ./client.jl:266
 [26] _start() at ./client.jl:425
in expression starting at /test_installation/esmvaltool/install/Julia/setup.jl:13
   Cloning default registries into /root/.julia/registries
   Cloning registry General from "https://github.com/JuliaRegistries/General.git"
[?25l    Fetching: [>                                        ]  0.0 %
    Resolving Deltas: [==>                                      ]  3.7 %
    Resolving Deltas: [=================>                       ]  41.8 %
[2K[?25h Resolving package versions...
 Installed TextWrap ─ v1.0.1
 Installed ArgParse ─ v1.0.1
  Updating `~/.julia/environments/v1.0/Project.toml`
  [c7e460c6] + ArgParse v1.0.1
  Updating `~/.julia/environments/v1.0/Manifest.toml`
  [c7e460c6] + ArgParse v1.0.1
  [b718987f] + TextWrap v1.0.1
  [56ddb016] + Logging 
 Resolving package versions...
 Installed Compat ─ v3.5.0
  Updating `~/.julia/environments/v1.0/Project.toml`
  [34da2185] + Compat v3.5.0
  Updating `~/.julia/environments/v1.0/Manifest.toml`
  [34da2185] + Compat v3.5.0
  [2a0f44e3] + Base64 
  [ade2ca70] + Dates 
  [8bb1440f] + DelimitedFiles 
  [8ba89e20] + Distributed 
  [b77e0a4c] + InteractiveUtils 
  [76f85450] + LibGit2 
  [8f399da3] + Libdl 
  [37e2e46d] + LinearAlgebra 
  [d6f4376e] + Markdown 
  [a63ad114] + Mmap 
  [44cfe95a] + Pkg 
  [de0858da] + Printf 
  [3fa0cd96] + REPL 
  [9a3f8284] + Random 
  [ea8e919c] + SHA 
  [9e88b42a] + Serialization 
  [1a1011a3] + SharedArrays 
  [6462fe0b] + Sockets 
  [2f01184e] + SparseArrays 
  [10745b16] + Statistics 
  [8dfed614] + Test 
  [cf7118a7] + UUIDs 
  [4ec0a83e] + Unicode 
 Resolving package versions...
 Installed InvertedIndices ───────────── v1.0.0
 Installed DataValueInterfaces ───────── v1.0.0
 Installed DataStructures ────────────── v0.17.9
 Installed Parsers ───────────────────── v0.3.11
 Installed OrderedCollections ────────── v1.1.0
 Installed DataAPI ───────────────────── v1.1.0
 Installed DataFrames ────────────────── v0.20.2
 Installed Missings ──────────────────── v0.4.3
 Installed PooledArrays ──────────────── v0.5.3
 Installed SortingAlgorithms ─────────── v0.3.1
 Installed TableTraits ───────────────── v1.0.0
 Installed JSON ──────────────────────── v0.21.0
 Installed Tables ────────────────────── v1.0.1
 Installed CategoricalArrays ─────────── v0.7.7
 Installed IteratorInterfaceExtensions ─ v1.0.0
 Installed Reexport ──────────────────── v0.2.0
  Updating `~/.julia/environments/v1.0/Project.toml`
  [a93c6f00] + DataFrames v0.20.2
  Updating `~/.julia/environments/v1.0/Manifest.toml`
  [324d7699] + CategoricalArrays v0.7.7
  [9a962f9c] + DataAPI v1.1.0
  [a93c6f00] + DataFrames v0.20.2
  [864edb3b] + DataStructures v0.17.9
  [e2d170a0] + DataValueInterfaces v1.0.0
  [41ab1584] + InvertedIndices v1.0.0
  [82899510] + IteratorInterfaceExtensions v1.0.0
  [682c06a0] + JSON v0.21.0
  [e1d29d7a] + Missings v0.4.3
  [bac558e1] + OrderedCollections v1.1.0
  [69de0a69] + Parsers v0.3.11
  [2dfb63ee] + PooledArrays v0.5.3
  [189a3867] + Reexport v0.2.0
  [a2af1166] + SortingAlgorithms v0.3.1
  [3783bdb8] + TableTraits v1.0.0
  [bd369af6] + Tables v1.0.1
  [9fa8497b] + Future 
 Resolving package versions...
```
0.6.2 (previous version) works well, until RainFarm decides to be compatible with the new one