### PR TITLE
Increase minimum required ESMValCore version to v2.0.0b8

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
   # Python packages that cannot be installed from PyPI:
   - gdal
-  - esmvalcore>=2.0.0b7,<2.1
+  - esmvalcore>=2.0.0b8,<2.1
   # Non-Python dependencies
   - graphviz
   - cdo>=1.9.7

--- a/meta.yaml
+++ b/meta.yaml
@@ -51,7 +51,7 @@ requirements:
     - ecmwf-api-client  # in esmvalgroup channel
     - eofs
     - esmpy
-    - esmvalcore>=2.0.0b7,<2.1  # in esmvalgroup channel
+    - esmvalcore>=2.0.0b8,<2.1  # in esmvalgroup channel
     - jinja2
     - matplotlib
     - nc-time-axis

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ REQUIREMENTS = {
         'cython',
         'ecmwf-api-client',
         'eofs',
-        'esmvalcore>=2.0.0b7,<2.1',
+        'esmvalcore>=2.0.0b8,<2.1',
         'fiona',
         'jinja2',
         'matplotlib<3',


### PR DESCRIPTION
Increase the minimum required ESMValCore version to v2.0.0b8, because v2.0.0b7 contained a serious bug (ESMValGroup/ESMValCore#554).

* * *

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValTool/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] Give this pull request a descriptive title that can be used as a one line summary in a changelog
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Preferably Codacy code quality checks pass, however a few remaining hard to solve Codacy issues are still acceptable. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes 

