### PR TITLE
Miles default domains to include lat=0

### DIFF
--- a/esmvaltool/diag_scripts/miles/block_fast.R
+++ b/esmvaltool/diag_scripts/miles/block_fast.R
@@ -143,6 +143,9 @@ miles_block_fast <- # nolint
     north <- central + step0 # lowest north latitude
     south <- central - step0 # lowest sourth latitude
     maxsouth <- central - 2 * step0
+    if (maxsouth <= 0) {
+      stop("Latitude=0 has to be included in the domain.")
+    }
     fin <- ipsilon[north]
     fis <- ipsilon[south]
     range <- (90 - fi0 - jump) / yreso # escursion to the north for

--- a/esmvaltool/recipes/recipe_miles_block.yml
+++ b/esmvaltool/recipes/recipe_miles_block.yml
@@ -58,7 +58,7 @@ preprocessors:
       extract_region:
         start_longitude: 0.
         end_longitude: 360.
-        start_latitude: 1.25
+        start_latitude: -1.25
         end_latitude: 90.
 
 diagnostics:

--- a/esmvaltool/recipes/recipe_miles_eof.yml
+++ b/esmvaltool/recipes/recipe_miles_eof.yml
@@ -58,7 +58,7 @@ preprocessors:
       extract_region:
         start_longitude: 0.
         end_longitude: 360.
-        start_latitude: 1.25
+        start_latitude: -1.25
         end_latitude: 90.
 
 diagnostics:

--- a/esmvaltool/recipes/recipe_miles_regimes.yml
+++ b/esmvaltool/recipes/recipe_miles_regimes.yml
@@ -58,7 +58,7 @@ preprocessors:
       extract_region:
         start_longitude: 0.
         end_longitude: 360.
-        start_latitude: 1.25
+        start_latitude: -1.25
         end_latitude: 90.
 
 diagnostics:


### PR DESCRIPTION
This is a minor maintenance PR extending the default NH domain used by all miles recipes (blocking regimes and eofs) to include also lat=0 (before it started at 2.5N). 
For blocking this is essential for the computation of the "ExtraBlock" indices (based on constraint (A4) in Davini et al. 2012). Without lat=0 the code currently accesses an array at position 0 (not valid in R) but keeps running. Actually this has no significant impact on the scientific results of the recipes.
While the user should not change the domain specified in the preprocessor part of the recipe, I still added a check in the blocking calculation to avoid this possibility.
