### PR TITLE
Add lazy regridding for wflow diagnostic

### DIFF
--- a/esmvaltool/diag_scripts/hydrology/derive_evspsblpot.py
+++ b/esmvaltool/diag_scripts/hydrology/derive_evspsblpot.py
@@ -23,22 +23,17 @@ def tetens_derivative(tas):
     tas.convert_units('degC')
 
     # Saturated vapour pressure at 273 Kelvin
-    e0_const = iris.coords.AuxCoord(6.112,
+    e0_const = iris.coords.AuxCoord(np.float32(6.112),
                                     long_name='Saturated vapour pressure',
                                     units='hPa')
-    emp_a = 17.67  # empirical constant a
+    emp_a = np.float32(17.67)  # empirical constant a
 
     # Empirical constant b in Tetens formula
-    emp_b = iris.coords.AuxCoord(243.5,
+    emp_b = iris.coords.AuxCoord(np.float32(243.5),
                                  long_name='Empirical constant b',
                                  units='degC')
     exponent = iris.analysis.maths.exp(emp_a * tas / (emp_b + tas))
-    # return emp_a * emp_b * e0 * exponent / (emp_b + tas)**2
-    # iris.exceptions.NotYetImplementedError: coord * coord (emp_b * e0)
-    # workaround:
-    tmp1 = emp_a * emp_b
-    tmp2 = e0_const * exponent / (emp_b + tas)**2
-    return tmp1 * tmp2
+    return (emp_a * emp_b) * (e0_const * exponent / (emp_b + tas)**2)
 
 
 def get_constants(psl):
@@ -54,33 +49,33 @@ def get_constants(psl):
 
     # Definition of constants
     # source='Wallace and Hobbs (2006), 2.6 equation 3.14',
-    rv_const = iris.coords.AuxCoord(461.51,
+    rv_const = iris.coords.AuxCoord(np.float32(461.51),
                                     long_name='Gas constant water vapour',
                                     units='J K-1 kg-1')
     # source='Wallace and Hobbs (2006), 2.6 equation 3.14',
-    rd_const = iris.coords.AuxCoord(287.0,
+    rd_const = iris.coords.AuxCoord(np.float32(287.0),
                                     long_name='Gas constant dry air',
                                     units='J K-1 kg-1')
 
     # Latent heat of vaporization in J kg-1 (or J m-2 day-1)
     # source='Wallace and Hobbs 2006'
-    lambda_ = iris.coords.AuxCoord(2.5e6,
+    lambda_ = iris.coords.AuxCoord(np.float32(2.5e6),
                                    long_name='Latent heat of vaporization',
                                    units='J kg-1')
 
     # Specific heat of dry air constant pressure
     # source='Wallace and Hobbs 2006',
-    cp_const = iris.coords.AuxCoord(1004,
+    cp_const = iris.coords.AuxCoord(np.float32(1004),
                                     long_name='Specific heat of dry air',
                                     units='J K-1 kg-1')
 
     # source='De Bruin (2016), section 4a',
-    beta = iris.coords.AuxCoord(20,
+    beta = iris.coords.AuxCoord(np.float32(20),
                                 long_name='Correction Constant',
                                 units='W m-2')
 
     # source = 'De Bruin (2016), section 4a',
-    cs_const = iris.coords.AuxCoord(110,
+    cs_const = iris.coords.AuxCoord(np.float32(110),
                                     long_name='Empirical constant',
                                     units='W m-2')
 
@@ -103,12 +98,11 @@ def debruin_pet(psl, rsds, rsdt, tas):
     kdown = rsds
     kdown_ext = rsdt
     # Equation 6
-    rad_term = (1 - 0.23) * kdown - cs_const * kdown / kdown_ext
+    rad_term = np.float32(1 - 0.23) * kdown - cs_const * kdown / kdown_ext
     # the unit is W m-2
     ref_evap = delta_svp / (delta_svp + gamma) * rad_term + beta
 
     pet = ref_evap / lambda_
-    pet.data = pet.core_data().astype(np.float32)
     pet.var_name = 'evspsblpot'
     pet.standard_name = 'water_potential_evaporation_flux'
     pet.long_name = 'Potential Evapotranspiration'

--- a/esmvaltool/diag_scripts/hydrology/lazy_regrid.py
+++ b/esmvaltool/diag_scripts/hydrology/lazy_regrid.py
@@ -1,0 +1,88 @@
+"""Lazy regridding, because this is not supported by iris (yet).
+
+Iris issue requesting the feature:
+https://github.com/SciTools/iris/issues/3700
+"""
+import copy
+
+import iris
+import numpy as np
+
+
+def _compute_chunks(src, tgt):
+    """Compute the chunk sizes needed to regrid src to tgt."""
+    block_bytes = 10 * (1 << 20)  # 10 MB block size
+
+    if src.dtype == np.float32:
+        dtype_bytes = 4  # size of float32 in bytes
+    else:
+        dtype_bytes = 8  # size of float64 in bytes
+
+    ntime = src.coord('time').shape[0]
+    tgt_nlat = tgt.coord('latitude').shape[0]
+    tgt_nlon = tgt.coord('longitude').shape[0]
+
+    # Define blocks along the time dimension
+    min_nblocks = int(ntime * tgt_nlat * tgt_nlon * dtype_bytes / block_bytes)
+    timefull = ntime // min_nblocks
+    timepart = ntime % timefull
+
+    nfullblocks = ntime // timefull
+    npartblocks = int(timepart > 0)
+
+    time_chunks = (timefull, ) * nfullblocks + (timepart, ) * npartblocks
+    src_chunks = (
+        time_chunks,
+        (src.coord('latitude').shape[0], ),
+        (src.coord('longitude').shape[0], ),
+    )
+    tgt_chunks = (
+        time_chunks,
+        (tgt_nlat, ),
+        (tgt_nlon, ),
+    )
+
+    return src_chunks, tgt_chunks
+
+
+def _regrid_data(src, tgt):
+    """Regrid data from cube src onto grid of cube tgt."""
+    src_chunks, tgt_chunks = _compute_chunks(src, tgt)
+
+    # Define the block regrid function
+    regridder = iris.analysis.Linear().regridder(src, tgt)
+
+    def regrid(block):
+        tlen = block.shape[0]
+        cube = src[:tlen].copy(block)
+        return regridder(cube).core_data()
+
+    # Regrid
+    data = src.core_data().rechunk(src_chunks).map_blocks(regrid,
+                                                          dtype=src.dtype,
+                                                          chunks=tgt_chunks)
+
+    return data
+
+
+def lazy_linear_regrid(src, tgt):
+    """Regrid cube src onto the grid of cube tgt."""
+    data = _regrid_data(src, tgt)
+
+    result = iris.cube.Cube(data)
+    result.metadata = copy.deepcopy(src.metadata)
+
+    def copy_coords(src_coords, add_method):
+        for coord in src_coords:
+            dims = src.coord_dims(coord)
+            if coord == src.coord('longitude'):
+                coord = tgt.coord('longitude')
+            elif coord == src.coord('latitude'):
+                coord = tgt.coord('latitude')
+            result_coord = coord.copy()
+            add_method(result_coord, dims)
+
+    copy_coords(src.dim_coords, result.add_dim_coord)
+    copy_coords(src.aux_coords, result.add_aux_coord)
+
+    return result

--- a/esmvaltool/diag_scripts/hydrology/wflow.py
+++ b/esmvaltool/diag_scripts/hydrology/wflow.py
@@ -6,8 +6,9 @@ import iris
 import numpy as np
 from osgeo import gdal
 
-from esmvalcore.preprocessor import extract_region, regrid
+from esmvalcore.preprocessor import extract_region
 from esmvaltool.diag_scripts.hydrology.derive_evspsblpot import debruin_pet
+from esmvaltool.diag_scripts.hydrology.lazy_regrid import lazy_linear_regrid
 from esmvaltool.diag_scripts.shared import (ProvenanceLogger,
                                             get_diagnostic_filename,
                                             group_metadata, run_diagnostic)
@@ -97,7 +98,7 @@ def regrid_temperature(src_temp, src_height, target_height):
     src_slt = src_temp.copy(data=src_temp.core_data() + src_dtemp.core_data())
 
     # Interpolate sea-level temperature to target grid
-    target_slt = regrid(src_slt, target_grid=target_height, scheme='linear')
+    target_slt = lazy_linear_regrid(src_slt, target_height)
 
     # Convert sea-level temperature to new target elevation
     target_dtemp = lapse_rate_correction(target_height)
@@ -217,7 +218,7 @@ def main(cfg):
         dem = extract_region(dem, **cfg['region'])
 
         logger.info("Processing variable precipitation_flux")
-        pr_dem = regrid(all_vars['pr'], target_grid=dem, scheme='linear')
+        pr_dem = lazy_linear_regrid(all_vars['pr'], dem)
 
         logger.info("Processing variable temperature")
         tas_dem = regrid_temperature(all_vars['tas'], all_vars['orog'], dem)
@@ -225,20 +226,12 @@ def main(cfg):
         logger.info("Processing variable potential evapotranspiration")
         if 'evspsblpot' in all_vars:
             pet = all_vars['evspsblpot']
-            pet_dem = regrid(pet, target_grid=dem, scheme='linear')
+            pet_dem = lazy_linear_regrid(pet, dem)
         else:
             logger.info("Potential evapotransporation not available, deriving")
-            psl_dem = regrid(all_vars['psl'], target_grid=dem, scheme='linear')
-            rsds_dem = regrid(
-                all_vars['rsds'],
-                target_grid=dem,
-                scheme='linear'
-            )
-            rsdt_dem = regrid(
-                all_vars['rsdt'],
-                target_grid=dem,
-                scheme='linear'
-            )
+            psl_dem = lazy_linear_regrid(all_vars['psl'], dem)
+            rsds_dem = lazy_linear_regrid(all_vars['rsds'], dem)
+            rsdt_dem = lazy_linear_regrid(all_vars['rsdt'], dem)
             pet_dem = debruin_pet(
                 tas=tas_dem,
                 psl=psl_dem,


### PR DESCRIPTION
The wflow diagnostic was using too much memory since #1618, because regridding in iris is not lazy. This pull request implements a lazy regridder for that diagnostic.

The second commit reduces memory consumption by consistently using float32 everywhere, this causes small differences in the resulting pet (order 1e-6). On my computer, this reduced peak memory usage from 1.6 GB to 1.2 GB, so not strictly needed.

* * *

**Tasks**

-   [x] Give this pull request a descriptive title that can be used as a one line summary in a changelog
-   [x] Make sure your code is composed of functions of no more than 50 lines and uses meaningful names for variables
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Preferably Codacy code quality checks pass, however a few remaining hard to solve Codacy issues are still acceptable. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
