### PR TITLE
Extend getting started instructions to obtain config-user.yml

### DIFF
--- a/doc/sphinx/source/quickstart/configuration.rst
+++ b/doc/sphinx/source/quickstart/configuration.rst
@@ -9,7 +9,9 @@ information needed by ESMValTool. The configuration is passed to ESMValTool
 as a command line argument (see :ref:`Running ESMValTool <running>`).
 
 An example configuration file can be downloaded `here <https://github.com/ESMValGroup/ESMValTool/blob/master/config-user-example.yml>`_
-and tailored for your system using the explanation below.
+(use the ``raw`` button to download the file; right-click it and ``save 
+linked content`` or left-click it and then just save the page), and 
+tailored for your system using the explanation below.
 
 Most of these settings are fairly self-explanatory, ie:
 

--- a/doc/sphinx/source/quickstart/configuration.rst
+++ b/doc/sphinx/source/quickstart/configuration.rst
@@ -9,8 +9,7 @@ information needed by ESMValTool. The configuration is passed to ESMValTool
 as a command line argument (see :ref:`Running ESMValTool <running>`).
 
 An example configuration file can be downloaded `here <https://github.com/ESMValGroup/ESMValTool/blob/master/config-user-example.yml>`_
-(use the ``raw`` button to download the file; right-click it and ``save 
-linked content`` or left-click it and then just save the page), and 
+(press the ``raw`` button to see a raw version of the file, right-click and press ``save as``, then you can save it on your computer), and 
 tailored for your system using the explanation below.
 
 Most of these settings are fairly self-explanatory, ie:


### PR DESCRIPTION
First time users that use conda to install esmvaltool might have trouble getting to the config-user file. The docs point to the config-user-example.yml on github, but for those new users it may not be clear how to download a single file from there. This should make it a little bit more accessible.

**Tasks**

-   ~[ ] [Create an issue](https://github.com/ESMValGroup/ESMValTool/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)~ I figured a PR was the easiest way to explain what I wanted to do.
-   [x] Give this pull request a descriptive title that can be used as a one line summary in a changelog
-   ~[ ] Make sure your code is composed of functions of no more than 50 lines and uses meaningful names for variables~
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Preferably Codacy code quality checks pass, however a few remaining hard to solve Codacy issues are still acceptable. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-  ~[ ] Please use `yamllint` to check that your YAML files do not contain mistakes~
-   ~[ ] (Only if really necessary) Add any additional dependencies needed for the diagnostic script to setup.py, esmvaltool/install/R/r_requirements.txt or esmvaltool/install/Julia/julia_requirements.txt (depending on the language of your script) and also to package/meta.yaml for conda dependencies (includes Python and others, but not R/Julia)~
-  ~[ ] If new dependencies are introduced, check that the license is compatible with [Apache2.0](https://github.com/ESMValGroup/ESMValTool/blob/master/LICENSE)~

