### PR TITLE
Added monthly mean vars (ta, va, zg) to era5 cmorizer via recipe

### DIFF
--- a/esmvaltool/recipes/cmorizers/recipe_era5.yml
+++ b/esmvaltool/recipes/cmorizers/recipe_era5.yml
@@ -312,6 +312,10 @@ diagnostics:
         mip: Amon
         era5_name: surface_net_solar_radiation
         era5_freq: monthly
+      ta:
+        mip: Amon
+        era5_name: temperature
+        era5_freq: monthly
       tas:
         mip: Amon
         era5_name: 2m_temperature
@@ -327,4 +331,12 @@ diagnostics:
       tsn:
         mip: Amon
         era5_name: temperature_of_snow_layer
+        era5_freq: monthly
+      va:
+        mip: Amon
+        era5_name: v_component_of_wind
+        era5_freq: monthly
+      zg:
+        mip: Amon
+        era5_name: geopotential
         era5_freq: monthly


### PR DESCRIPTION
**Tasks**

-   [ ] [Create an issue](https://github.com/ESMValGroup/ESMValTool/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] Give this pull request a descriptive title that can be used as a one line summary in a changelog
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Preferably Codacy code quality checks pass, however a few remaining hard to solve Codacy issues are still acceptable. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes 

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *
Closes #issue_number

I would like to comment on a few issues: 
1. In order to cmorize geopotential height (zg) I had to edit ESMValCore/esmvalcore/cmor/_fixes/native6/era5.py to convert "geopotential" to "geopotential height". Should I create a new request in ESMValCore to add those couple lines? 
2. After additional ERA5 data was moved to native6, seems that 2 variables "temperature" (ta) and "temperature_of_snow_layer" (tsn) are now found simultaneously by recipe_era5.yml when given era5_name: temperature. Maybe, it worth renaming "temperature" to "t"  or so? 