### PR TITLE
CMORizer based on CIS Tools

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,8 +8,9 @@ dependencies:
   # Python packages that cannot be installed from PyPI:
   # TODO when switching to iris 2.x, switch straight to 2.1+
   - basemap
-  - iris=1.13
+  - iris=1.13  # Only available on PyPI from version 2
   - python-stratify
+  - cis  # Version on PyPI is outdated
   # Multi language support:
   - ncl
   - ncurses=6.1=hfc679d8_1

--- a/esmvaltool/utils/prepare_observations.py
+++ b/esmvaltool/utils/prepare_observations.py
@@ -1,0 +1,59 @@
+"""CMORize observational datasets using CIS."""
+import argparse
+import logging
+import os
+
+import cis
+
+logger = logging.getLogger('esmvaltool.utils.prepare_observations')
+
+
+def convert(filenames, output_dir, suffix=''):
+    """Read data from filenames and save it to output/variable_suffix.nc"""
+    logger.info("Reading variables from files %s", filenames)
+    for var_name in cis.get_variables(filenames):
+        logger.info("Reading variable %s", var_name)
+        cube = cis.read_data(filenames=filenames, variable=var_name)
+
+        output_file = var_name
+        if suffix:
+            output_file += '_' + suffix
+        output_file += '.nc'
+        output_file = os.path.join(output_dir, output_file)
+        logger.info("Saving data to %s", output_file)
+        cube.save_data(output_file)
+
+    logger.info("Done")
+
+
+def _main():
+    """Run as a program."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('filenames', nargs='+', help='Input data files')
+    parser.add_argument(
+        '-o', '--output-dir', help='Output directory', default=os.getcwd())
+    parser.add_argument(
+        '-s', '--file-suffix', help='Output file suffix', default='')
+    parser.add_argument(
+        '-l',
+        '--log-level',
+        default='info',
+        choices=['debug', 'info', 'warning', 'error'])
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        format="%(asctime)s %(levelname)-8s %(name)s,%(lineno)s\t%(message)s")
+    logging.getLogger().setLevel(args.log_level.upper())
+
+    # Prepare input arguments
+    filenames = [os.path.abspath(p) for p in args.filenames]
+    output_dir = os.path.abspath(args.output_dir)
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    # Run
+    convert(filenames, output_dir, args.file_suffix)
+
+
+if __name__ == '__main__':
+    _main()

--- a/meta.yaml
+++ b/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - python-stratify
     # Normally installed via pip:
     - cartopy
+    - cis
     - cf_units
     - cython
     - matplotlib

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ REQUIREMENTS = {
     # Use with pip install . to install from source
     'install': [
         'basemap',
+        'cis',
         'cartopy',
         'cdo',
         'cf_units',
@@ -215,6 +216,7 @@ with open('README.md') as readme:
         entry_points={
             'console_scripts': [
                 'esmvaltool = esmvaltool._main:run',
+                'prepare_observations = esmvaltool.utils.prepare_observations:_main',
                 'nclcodestyle = esmvaltool.utils.nclcodestyle.nclcodestyle:_main',
             ],
         },


### PR DESCRIPTION
This is an example of how CIS tools could be used to CMORize data.

See #1655

* * *

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValTool/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] Give this pull request a descriptive title that can be used as a one line summary in a changelog
-   [ ] Make sure your code is composed of functions of no more than 50 lines and uses meaningful names for variables
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Preferably Codacy code quality checks pass, however a few remaining hard to solve Codacy issues are still acceptable. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes 
-   [ ] (Only if really necessary) Add any additional dependencies needed for the diagnostic script to setup.py, esmvaltool/install/R/r_requirements.txt or esmvaltool/install/Julia/julia_requirements.txt (depending on the language of your script) and also to package/meta.yaml for conda dependencies (includes Python and others, but not R/Julia)
-   [ ] If new dependencies are introduced, check that the license is compatible with [Apache2.0](https://github.com/ESMValGroup/ESMValTool/blob/master/LICENSE)
-   [ ] Test the CMORized data using recipes/example/recipe_check_obs.yml, to make sure the CMOR checks pass without errors
-   [ ] Add the new dataset to the table in the [documentation](https://esmvaltool.readthedocs.io/en/latest/getting_started/inputdata.html)
-   [ ] Tag @mattiarighi in this pull request, so that the new dataset can be added to the OBS data pool at DKRZ and synchronized with CEDA-Jasmin

* * *
