### PR TITLE
updated references to documentation (now docs.esmvaltool.org)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,9 @@
-Before you start, read [CONTRIBUTING.md](https://github.com/ESMValGroup/ESMValTool/blob/master/CONTRIBUTING.md) and the [guide for diagnostic developers](https://esmvaltool.readthedocs.io/en/latest/esmvaldiag/index.html).
+<!---
+Please do not delete this text completely, but read the text below and keep items that seem relevant.
+If in doubt, just keep everything and add your own text at the top.
+--->
+
+Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/en/latest/community/introduction.html).
 
 Please discuss your idea with the development team before getting started, to avoid disappointment later. The way to do this is to open a new issue on GitHub. If you are planning to modify an existing functionality, please discuss it with the original author(s) by tagging them in the issue.
 
@@ -11,8 +16,8 @@ Please discuss your idea with the development team before getting started, to av
 -   [ ] Make sure your code is composed of functions of no more than 50 lines and uses meaningful names for variables
 -   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
 -   [ ] Preferably Codacy code quality checks pass, however a few remaining hard to solve Codacy issues are still acceptable. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
--   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes 
--   [ ] (Only if really necessary) Add any additional dependencies needed for the diagnostic script to setup.py, esmvaltool/install/R/r_requirements.txt or esmvaltool/install/Julia/julia_requirements.txt (depending on the language of your script) and also to package/meta.yaml for conda dependencies (includes Python and others, but not R/Julia)
+-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
+-   [ ] (Only if really necessary) Add any additional dependencies needed for the diagnostic script to setup.py, esmvaltool/install/R/r_requirements.txt or esmvaltool/install/Julia/Project.toml (depending on the language of your script) and also to package/meta.yaml for conda dependencies (includes Python and others, but not R/Julia)
 -   [ ] If new dependencies are introduced, check that the license is compatible with [Apache2.0](https://github.com/ESMValGroup/ESMValTool/blob/master/LICENSE)
 
 New recipe/diagnostic
@@ -29,7 +34,7 @@ Modified recipe/diagnostic
 New data reformatting script
 
 -   [ ] Test the CMORized data using recipes/example/recipe_check_obs.yml, to make sure the CMOR checks pass without errors
--   [ ] Add the new dataset to the table in the [documentation](https://esmvaltool.readthedocs.io/en/latest/getting_started/inputdata.html)
+-   [ ] Add the new dataset to the table in the [documentation](https://docs.esmvaltool.org/en/latest/input.html#supported-datasets)
 -   [ ] Tag @mattiarighi in this pull request, so that the new dataset can be added to the OBS data pool at DKRZ and synchronized with CEDA-Jasmin
 
 Modified data reformatting script

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributions are very welcome
 
-Please read our [contribution guidelines](https://esmvaltool.readthedocs.io/en/latest/community/introduction.html).
+Please read our [contribution guidelines](https://docs.esmvaltool.org/en/latest/community/introduction.html).

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ ESMValTool can run with the following types of data as input:
 
 # Getting started
 
-Please see [getting started](https://esmvaltool.readthedocs.io/en/latest/quickstart/index.html) on readthedocs.
+Please see [getting started](https://docs.esmvaltool.org/en/latest/quickstart/index.html) on readthedocs.
 
 ## Getting help
 
-The easiest way to get help if you cannot find the answer in the documentation on [readthedocs](https://esmvaltool.readthedocs.io), is to open an [issue on GitHub](https://github.com/ESMValGroup/ESMValTool/issues).
+The easiest way to get help if you cannot find the answer in the documentation on [readthedocs](https://docs.esmvaltool.org), is to open an [issue on GitHub](https://github.com/ESMValGroup/ESMValTool/issues).
 
 ## Contributing
 
-If you would like to contribute a new diagnostic or feature, please have a look at our [contribution guidelines](https://esmvaltool.readthedocs.io/en/latest/community/introduction.html).
+If you would like to contribute a new diagnostic or feature, please have a look at our [contribution guidelines](https://docs.esmvaltool.org/en/latest/community/introduction.html).

--- a/doc/sphinx/source/community/diagnostic.rst
+++ b/doc/sphinx/source/community/diagnostic.rst
@@ -63,7 +63,7 @@ and finally it will store provenance information. Provenance information is stor
 and also plotted in an SVG file for human inspection. In addition to provenance information, a caption is also added
 to the plots.
 
-In order to communicate with the diagnostic script, two interfaces have been defined, which are described in the `ESMValCore documentation <https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/interfaces.html>`_.
+In order to communicate with the diagnostic script, two interfaces have been defined, which are described in the `ESMValCore documentation <https://docs.esmvaltool.org/projects/esmvalcore/en/latest/interfaces.html>`_.
 Note that for Python and NCL diagnostics much more convenient methods are available than
 directly reading and writing the interface files. For other languages these are not implemented (yet).
 

--- a/doc/sphinx/source/community/introduction.rst
+++ b/doc/sphinx/source/community/introduction.rst
@@ -145,7 +145,7 @@ The standard document on best practices for Python code is
 documentation. We make use of `numpy style
 docstrings <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html>`__
 to document Python functions that are visible on
-`readthedocs <https://esmvaltool.readthedocs.io>`__.
+`readthedocs <https://docs.esmvaltool.org>`__.
 
 Most formatting issues in Python code can be fixed automatically by
 running the commands
@@ -225,7 +225,7 @@ What should be documented
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Any code documentation that is visible on
-`readthedocs <https://esmvaltool.readthedocs.io>`__ should be well
+`readthedocs <https://docs.esmvaltool.org>`__ should be well
 written and adhere to the standards for documentation for the respective
 language. Recipes should have a page in the *Recipes* section on
 readthedocs. This is also the place to document recipe options for the

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -421,9 +421,9 @@ intersphinx_mapping = {
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
     'esmvaltool':
-    ('https://esmvaltool.readthedocs.io/en/%s/' % rtd_version, None),
+    ('https://docs.esmvaltool.org/en/%s/' % rtd_version, None),
     'esmvalcore':
-    ('https://esmvaltool.readthedocs.io/projects/esmvalcore/en/%s/' %
+    ('https://docs.esmvaltool.org/projects/esmvalcore/en/%s/' %
      rtd_version, None),
 }
 

--- a/doc/sphinx/source/input.rst
+++ b/doc/sphinx/source/input.rst
@@ -87,7 +87,7 @@ The example cmorizer recipe can be run like any other ESMValTool recipe:
 
 (Note that the ``recipe_era5.yml`` adds the next day of the new year to the input data. This is because one of the fixes needed for the ERA5 data is to shift (some of) the data half an hour back in time, resulting in a missing record on the last day of the year.)
 
-To add support for new variables using this method, one needs to add dataset-specific fixes to the ESMValCore. For more information about fixes, see: `fixing data <https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/develop/fixing_data.html#fixing-data>`_.
+To add support for new variables using this method, one needs to add dataset-specific fixes to the ESMValCore. For more information about fixes, see: `fixing data <https://docs.esmvaltool.org/projects/esmvalcore/en/latest/develop/fixing_data.html#fixing-data>`_.
 
 
 Supported datasets

--- a/esmvaltool/diag_scripts/thermodyn_diagtool/thermodyn_diagnostics.py
+++ b/esmvaltool/diag_scripts/thermodyn_diagtool/thermodyn_diagnostics.py
@@ -68,7 +68,8 @@ production related to the kinetic energy dissipation is provided.
 PREREQUISITES
 
 The program shares the same prerequisites with the overall ESMValTool
-architecture (see http://esmvaltool.readthedocs.io/en/latest/install.html)
+architecture
+(see https://docs.esmvaltool.org/en/latest/quickstart/installation.html)
 
 USAGE
 
@@ -98,7 +99,7 @@ USAGE
    The pre-processing modules of ESMValTool scheme will take care of
    converting known grids and recognized datasets to CMOR standards. For a
    a list of known formats, see
-      http://esmvaltool.readthedocs.io/en/latest/running.html#tab-obs-dat
+      https://docs.esmvaltool.org/en/latest/input.html#observations
 
 2: A configuration template is available in the ESMValTool release. Set your
   own paths to local directories here. Input datasets are read in MODELPATH,

--- a/tests/unit/test_recipes.py
+++ b/tests/unit/test_recipes.py
@@ -20,7 +20,7 @@ def test_reference_tags(recipe_file):
         The tag '{tag}' is mentioned in recipe '{recipe}'.
         However, its reference file '{tag}.bibtex' is not available in {path}.
         Please check instructions on how to add references at
-        https://esmvaltool.readthedocs.io/en/latest/community/diagnostic.html#adding-references
+        https://docs.esmvaltool.org/en/latest/community/diagnostic.html#adding-references
     """)
     for tag in tags:
         bibtex_file = REFERENCES_PATH / f'{tag}.bibtex'


### PR DESCRIPTION
Changed references to documentation from esmvaltool.readthedocs.io to docs.esmvaltool.org. This addresses issue https://github.com/ESMValGroup/ESMValCore/issues/315.