### PR TITLE
Exclude od550lt1aer from recipe_check_obs.yml

### DIFF
--- a/esmvaltool/recipes/examples/recipe_check_obs.yml
+++ b/esmvaltool/recipes/examples/recipe_check_obs.yml
@@ -145,7 +145,7 @@ diagnostics:
       abs550aer:
       od550aer:
       od550aerStderr:
-      od550lt1aer:
+      # od550lt1aer:   # NEEDS Iris 3.0
       od870aer:
       od870aerStderr:
     additional_datasets:


### PR DESCRIPTION
Until Iris 3 is released (see discussion in #1561).