### PR TITLE
Fix keyword argument

### DIFF
--- a/esmvaltool/cmorizers/obs/cmorize_obs.py
+++ b/esmvaltool/cmorizers/obs/cmorize_obs.py
@@ -172,7 +172,7 @@ def main():
 
     # configure logging
     log_files = configure_logging(
-        output=run_dir, console_log_level=config_user['log_level'])
+        output_dir=run_dir, console_log_level=config_user['log_level'])
     logger.info("Writing program log files to:\n%s", "\n".join(log_files))
 
     # print header


### PR DESCRIPTION
Fix keyword argument in `cmorizer_obs.py`.
Related to https://github.com/ESMValGroup/ESMValCore/issues/705.
It should be merged after https://github.com/ESMValGroup/ESMValCore/pull/709.