### PR TITLE
Additional features and bugfixes for anav

### DIFF
--- a/doc/sphinx/source/recipes/recipe_anav13jclim.rst
+++ b/doc/sphinx/source/recipes/recipe_anav13jclim.rst
@@ -110,6 +110,7 @@ User settings in recipe
      on/off lines of volcano eruptions in evolution plot.
    * ``evolution_plot_color``, *int*, optional (default: ``0``): Hue of the
      contours in the evolution plot.
+   * ``ensemble_name``, *string*, optional: Name of ensemble for use in evolution plot legend
 
 #. Script carbon_cycle/mvi.ncl
 

--- a/esmvaltool/diag_scripts/carbon_cycle/main.ncl
+++ b/esmvaltool/diag_scripts/carbon_cycle/main.ncl
@@ -287,7 +287,7 @@ begin
 
   ; Convert units if appropriate [kg m-2 s-1] --> [PgC y-1]
   if ((isatt(VAR0, "plot_units")) .and. \
-        (all_data_yearly@units .ne. VAR0@plot_units)) then
+      (all_data_yearly@units .ne. VAR0@plot_units)) then
     if (VAR0@plot_units .eq. "degC") then
       all_data_yearly(:, :, 0) = convert_units(all_data_yearly(:, :, 0), \
                                                VAR0@plot_units)

--- a/esmvaltool/diag_scripts/carbon_cycle/main.ncl
+++ b/esmvaltool/diag_scripts/carbon_cycle/main.ncl
@@ -26,6 +26,7 @@
 ;                            automatically.
 ;     evolution_plot_volcanoes: Turns on/off lines of volcano eruptions.
 ;     evolution_plot_color: Hue of the contours; default: red = 0.
+;     ensemble_name: Name of ensemble for use in evolution plot legend
 ;
 ;     For external dataset input:
 ;     obsfile: Filename of external obs to read in.
@@ -533,7 +534,7 @@ begin
       data_arr@ref_name = diag_script_info@evolution_plot_ref_dataset
       data_arr@units = all_data_yearly@units
       data_arr@dim_Mod = dimsizes(model_ind)
-      data_arr@project = diag_script_info@project_name
+      data_arr@project = diag_script_info@ensemble_name
 
       ; Subtract mean 1901-1930 (coded as "until 1930") if anomaly plot
       ind_1930 = ind(all_data_yearly&year .eq. 1930)

--- a/esmvaltool/diag_scripts/carbon_cycle/main.ncl
+++ b/esmvaltool/diag_scripts/carbon_cycle/main.ncl
@@ -286,7 +286,7 @@ begin
 
   ; Convert units if appropriate [kg m-2 s-1] --> [PgC y-1]
     if ((isatt(VAR0, "plot_units")) .and. \
-      (all_data_yearly@units .ne. VAR0@plot_units)) then
+        (all_data_yearly@units .ne. VAR0@plot_units)) then
     if (VAR0@plot_units .eq. "degC") then
       all_data_yearly(:, :, 0) = convert_units(all_data_yearly(:, :, 0), \
                                                VAR0@plot_units)

--- a/esmvaltool/diag_scripts/carbon_cycle/main.ncl
+++ b/esmvaltool/diag_scripts/carbon_cycle/main.ncl
@@ -285,7 +285,8 @@ begin
   end do
 
   ; Convert units if appropriate [kg m-2 s-1] --> [PgC y-1]
-  if (isatt(VAR0, "plot_units")) then
+    if ((isatt(VAR0, "plot_units")) .and. \
+      (all_data_yearly@units .ne. VAR0@plot_units)) then
     if (VAR0@plot_units .eq. "degC") then
       all_data_yearly(:, :, 0) = convert_units(all_data_yearly(:, :, 0), \
                                                VAR0@plot_units)
@@ -532,6 +533,7 @@ begin
       data_arr@ref_name = diag_script_info@evolution_plot_ref_dataset
       data_arr@units = all_data_yearly@units
       data_arr@dim_Mod = dimsizes(model_ind)
+      data_arr@project = diag_script_info@project_name
 
       ; Subtract mean 1901-1930 (coded as "until 1930") if anomaly plot
       ind_1930 = ind(all_data_yearly&year .eq. 1930)

--- a/esmvaltool/diag_scripts/carbon_cycle/main.ncl
+++ b/esmvaltool/diag_scripts/carbon_cycle/main.ncl
@@ -286,7 +286,7 @@ begin
   end do
 
   ; Convert units if appropriate [kg m-2 s-1] --> [PgC y-1]
-    if ((isatt(VAR0, "plot_units")) .and. \
+  if ((isatt(VAR0, "plot_units")) .and. \
         (all_data_yearly@units .ne. VAR0@plot_units)) then
     if (VAR0@plot_units .eq. "degC") then
       all_data_yearly(:, :, 0) = convert_units(all_data_yearly(:, :, 0), \

--- a/esmvaltool/diag_scripts/carbon_cycle/mvi.ncl
+++ b/esmvaltool/diag_scripts/carbon_cycle/mvi.ncl
@@ -406,7 +406,8 @@ begin
   ; Diagnostic- and variable-specific units conversions
   regional_mvi@units = "1"
   trend_tmp = regional_trend
-  if (isatt(VAR0, "plot_units")) then
+  if ((isatt(VAR0, "plot_units")) .and. \
+      (all_data_yearly@units .ne. VAR0@plot_units)) then
     new_units = VAR0@plot_units
     regional_mean = convert_units(regional_mean, new_units)
     if (new_units .eq. "degC") then

--- a/esmvaltool/diag_scripts/carbon_cycle/mvi.ncl
+++ b/esmvaltool/diag_scripts/carbon_cycle/mvi.ncl
@@ -407,7 +407,7 @@ begin
   regional_mvi@units = "1"
   trend_tmp = regional_trend
   if ((isatt(VAR0, "plot_units")) .and. \
-      (all_data_yearly@units .ne. VAR0@plot_units)) then
+      (regional_mean@units .ne. VAR0@plot_units)) then
     new_units = VAR0@plot_units
     regional_mean = convert_units(regional_mean, new_units)
     if (new_units .eq. "degC") then

--- a/esmvaltool/diag_scripts/carbon_cycle/two_variables.ncl
+++ b/esmvaltool/diag_scripts/carbon_cycle/two_variables.ncl
@@ -147,7 +147,7 @@ begin
 
     ; Convert units if appropriate
     if ((isatt(variable_info[ivar], "plot_units")) .and. \
-        (all_data[ivar]@units .ne. VAR0@plot_units)) then
+        (all_data[ivar]@units .ne. variable_info[ivar]@plot_units)) then
       all_data[ivar] = convert_units(all_data[ivar], \
                                      variable_info[ivar]@plot_units)
     end if

--- a/esmvaltool/diag_scripts/carbon_cycle/two_variables.ncl
+++ b/esmvaltool/diag_scripts/carbon_cycle/two_variables.ncl
@@ -146,7 +146,8 @@ begin
     end do
 
     ; Convert units if appropriate
-    if (isatt(variable_info[ivar], "plot_units")) then
+    if ((isatt(variable_info[ivar], "plot_units")) .and. \
+        (all_data[ivar]@units .ne. VAR0@plot_units)) then
       all_data[ivar] = convert_units(all_data[ivar], \
                                      variable_info[ivar]@plot_units)
     end if

--- a/esmvaltool/diag_scripts/shared/plot/xy_line.ncl
+++ b/esmvaltool/diag_scripts/shared/plot/xy_line.ncl
@@ -2719,7 +2719,7 @@ begin
   res_lines@gsLineColor = interval_colors(n_val-1, :)
   plot@$unique_string("dum")$ = gsn_add_polyline(wks_out, plot, xx, yy, \
                                                  res_lines)
-  plot@$unique_string("dum")$ = gsn_add_text(wks_out, plot, "CMIP5", \
+  plot@$unique_string("dum")$ = gsn_add_text(wks_out, plot, data@project, \
                                              (xx(1) + 0.3 * (xx(1) - xx(0))), \
                                              yy(0), res_text)
 

--- a/esmvaltool/recipes/recipe_anav13jclim.yml
+++ b/esmvaltool/recipes/recipe_anav13jclim.yml
@@ -157,6 +157,7 @@ diagnostics:
         errorbar_plot: true
         mean_IAV_plot: true
         styleset: CMIP5
+        project_name: CMIP5
         region: global
         evolution_plot: true
         evolution_plot_volcanoes: true

--- a/esmvaltool/recipes/recipe_anav13jclim.yml
+++ b/esmvaltool/recipes/recipe_anav13jclim.yml
@@ -120,7 +120,6 @@ diagnostics:
     scripts:
       mvi_global: &mvi_global
         script: carbon_cycle/mvi.ncl
-        legend_year_outside: true
         sort: true
         styleset: CMIP5
         region: global
@@ -150,19 +149,18 @@ diagnostics:
     scripts:
       main_global: &main_global
         script: carbon_cycle/main.ncl
-        legend_year_outside: false
         legend_outside: false
         sort: true
         seasonal_cycle_plot: true
         errorbar_plot: true
         mean_IAV_plot: true
         styleset: CMIP5
-        project_name: CMIP5
         region: global
         evolution_plot: true
         evolution_plot_volcanoes: true
         evolution_plot_ref_dataset: CRU
         evolution_plot_anomaly: true
+        ensemble_name: CMIP5
       main_nh: &main_nh
         <<: *main_global
         region: nh
@@ -566,7 +564,7 @@ diagnostics:
     scripts:
       scat_global: &scat_glob
         script: carbon_cycle/two_variables.ncl
-        legend_year_outside: false
+        legend_outside: false
         styleset: CMIP5
         region: global
       scat_nh:


### PR DESCRIPTION
**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValTool/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] Give this pull request a descriptive title that can be used as a one line summary in a changelog
-   [x] Make sure your code is composed of functions of no more than 50 lines and uses meaningful names for variables
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Preferably Codacy code quality checks pass, however a few remaining hard to solve Codacy issues are still acceptable. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [x] (Only if really necessary) Add any additional dependencies needed for the diagnostic script to setup.py, esmvaltool/install/R/r_requirements.txt or esmvaltool/install/Julia/Project.toml (depending on the language of your script) and also to package/meta.yaml for conda dependencies (includes Python and others, but not R/Julia)
-   [x] If new dependencies are introduced, check that the license is compatible with [Apache2.0](https://github.com/ESMValGroup/ESMValTool/blob/master/LICENSE)

Modified recipe/diagnostic

-   [x] Update documentation for the recipe to the `doc/sphinx/source/recipes` folder
-   [x] Update provenance information if needed
-   [ ] Assign the author(s) of the affected recipe(s) as reviewer(s)

- all diagnostics for anav: check before convert_units that the data is not already in this unit (otherwise error) - application example: tos in CMIP6 has degC cmor unit and degC plot unit
- evolution plot: Fixed ensemble name from hardcoded "CMIP5" to name given in recipe. Why not simply take project name from data? My application uses the same ensemble but different experiments so wanted easy way to distinguish.
- removed "legend_year_outside" attribute that isn't used in any diagnostics
