### PR TITLE
Fixed JMA-TRANSCOM CMORizer

### DIFF
--- a/esmvaltool/cmorizers/obs/cmorize_obs_jma_transcom.py
+++ b/esmvaltool/cmorizers/obs/cmorize_obs_jma_transcom.py
@@ -58,9 +58,9 @@ def _extract_variable(cmor_info, attrs, in_dir, out_dir, ctl):
 
     # Mask appropriate parts
     if cmor_info.short_name == 'nbp':
-        cube = mask_landsea(cube, [], 'sea')
+        cube = mask_landsea(cube, {}, 'sea')
     elif cmor_info.short_name == 'fgco2':
-        cube = mask_landsea(cube, [], 'land')
+        cube = mask_landsea(cube, {}, 'land')
     else:
         raise NotImplementedError(
             f"CMORizer for '{cmor_info.short_name}' not implemented yet")


### PR DESCRIPTION
Fixed JMA-TRANSCOM CMORizer (necessary because signature of preprocessor function `mask_landsea` changed).

* * *

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValTool/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] Give this pull request a descriptive title that can be used as a one line summary in a changelog
-   [x] Make sure your code is composed of functions of no more than 50 lines and uses meaningful names for variables
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Preferably Codacy code quality checks pass, however a few remaining hard to solve Codacy issues are still acceptable. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [x] (Only if really necessary) Add any additional dependencies needed for the diagnostic script to setup.py, esmvaltool/install/R/r_requirements.txt or esmvaltool/install/Julia/Project.toml (depending on the language of your script) and also to package/meta.yaml for conda dependencies (includes Python and others, but not R/Julia)
-   [x] If new dependencies are introduced, check that the license is compatible with [Apache2.0](https://github.com/ESMValGroup/ESMValTool/blob/master/LICENSE)

Modified data reformatting script

-   [x] Test the CMORized data using recipes/example/recipe_check_obs.yml, to make sure the CMOR checks pass without errors
-   [x] Tag @mattiarighi in this pull request, so that the updated dataset can be added to the OBS data pool at DKRZ and synchronized with CEDA-Jasmin

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes #1733
