### PR TITLE
Quick fix for recipe_ocean_ice_extent.yml

### DIFF
--- a/esmvaltool/diag_scripts/ocean/diagnostic_seaice.py
+++ b/esmvaltool/diag_scripts/ocean/diagnostic_seaice.py
@@ -289,7 +289,7 @@ def make_polar_map(
         ax1 = plt.subplot(111, projection=cartopy.crs.SouthPolarStereo())
         ax1.set_extent([-180, 180, -90, -50], cartopy.crs.PlateCarree())
 
-    linrange = np.linspace(0., 100., 21.)
+    linrange = np.linspace(0, 100, 21)
     qplt.contourf(cube, linrange, cmap=cmap, linewidth=0, rasterized=True)
     plt.tight_layout()
 


### PR DESCRIPTION
The recipe was returning the following error:
```
Traceback (most recent call last):
  File "/mnt/lustre01/pf/b/b309057/ESMValTool/public/esmvaltool/diag_scripts/ocean/diagnostic_seaice.py", line 705, in <module>
    main(config)
  File "/mnt/lustre01/pf/b/b309057/ESMValTool/public/esmvaltool/diag_scripts/ocean/diagnostic_seaice.py", line 694, in main
    make_map_plots(cfg, metadatas[filename], filename)
  File "/mnt/lustre01/pf/b/b309057/ESMValTool/public/esmvaltool/diag_scripts/ocean/diagnostic_seaice.py", line 449, in make_map_plots
    make_polar_map(cube, pole=pole, cmap=cmap)
  File "/mnt/lustre01/pf/b/b309057/ESMValTool/public/esmvaltool/diag_scripts/ocean/diagnostic_seaice.py", line 292, in make_polar_map
    linrange = np.linspace(0., 100., 21.)
  File "<__array_function__ internals>", line 5, in linspace
  File "/work/bd0080/b309057/SOFTWARE/miniconda3/envs/esmvaltool/lib/python3.8/site-packages/numpy/core/function_base.py", line 113, in linspace
    num = operator.index(num)
TypeError: 'float' object cannot be interpreted as an integer
```

This PR quickly fixes it.