### PR TITLE
Fix sispeed in recipe_preprocessor_derive_test

### DIFF
--- a/esmvaltool/recipes/examples/recipe_preprocessor_derive_test.yml
+++ b/esmvaltool/recipes/examples/recipe_preprocessor_derive_test.yml
@@ -107,6 +107,13 @@ diagnostics:
   diag8:
     description: Test sispeed
     variables:
-      clltkisccp:
-        <<: *cloud
+      sispeed:
+        mip: day
+        derive: true
+        force_derivation: false
+        additional_datasets:
+          - {dataset: GFDL-ESM2G, project: CMIP5, exp: historical,
+             ensemble: r1i1p1, start_year: 1979, end_year: 1979}
+          - {dataset: MPI-ESM-LR, project: CMIP5, exp: historical,
+             ensemble: r1i1p1, start_year: 1979, end_year: 1979}
     scripts: null


### PR DESCRIPTION
Fix for the sispeed example in recipe_preprocessor_derive_test

The issue is described in #1697 
