### PR TITLE
Speed up tests on CircleCI and use pytest to run them

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,19 @@
 ---
-version: 2
+version: 2.1
 
-aliases:
-  check_changes: &check_changes
-    name: Check changes
-    command: |
-      if (test "$CIRCLE_BRANCH" = master ||
-          git --no-pager diff --name-only origin/master... |
-          grep -q -E -f .circleci/install_triggers)
-      then
-        echo Running installation tests
-      else
-        echo Skipping installation tests
-        circleci step halt
-      fi
+commands:
+  check_changes:
+    steps:
+      - run: |
+          if (test "$CIRCLE_BRANCH" = master ||
+            git --no-pager diff --name-only origin/master... |
+            grep -q -E -f .circleci/install_triggers)
+          then
+            echo Running installation tests
+          else
+            echo Skipping installation tests
+            circleci step halt
+          fi
 
 jobs:
   test:
@@ -26,12 +26,12 @@ jobs:
       - run:
           # Update/Create Conda environment and run tests
           command: |
-            julia esmvaltool/install/Julia/setup.jl
-            Rscript esmvaltool/install/R/setup.R
-            python setup.py test
-          no_output_timeout: 20m
-      - store_artifacts:
-          path: /logs
+            pip install .[test]
+            esmvaltool install Julia
+            esmvaltool install R
+            # Remove source to test installed software
+            rm -r esmvaltool
+            pytest -n 2
       - store_artifacts:
           path: test-reports/
       - store_test_results:
@@ -55,7 +55,7 @@ jobs:
       - image: continuumio/miniconda3
     steps:
       - checkout
-      - run: *check_changes
+      - check_changes
       - restore_cache:
           key: test-install-{{ .Branch }}
       - run:
@@ -80,7 +80,7 @@ jobs:
             conda env export > /logs/environment.yml
             pip freeze > /logs/requirements.txt
             # Test installation
-            pytest
+            pytest -n 2
             esmvaltool -h
             ncl -V
             # cdo test, check that it supports hdf5
@@ -108,7 +108,7 @@ jobs:
       - image: continuumio/miniconda3
     steps:
       - checkout
-      - run: *check_changes
+      - check_changes
       - run:
           command: |
             . /opt/conda/etc/profile.d/conda.sh
@@ -129,8 +129,8 @@ jobs:
             conda env export > /logs/environment.yml
             pip freeze > /logs/requirements.txt
             # Test installation
+            pytest -n 2
             esmvaltool -h
-            python setup.py test
             ncl -V
             cdo --version
           no_output_timeout: 20m
@@ -171,7 +171,7 @@ jobs:
       - image: continuumio/miniconda3
     steps:
       - checkout
-      - run: *check_changes
+      - check_changes
       - run:
           command: |
             . /opt/conda/etc/profile.d/conda.sh
@@ -220,6 +220,7 @@ jobs:
             esmvaltool -h
             ncl -V
             cdo --version
+          no_output_timeout: 30m
 
   ncl_cdo_test:
     # Test ncl and cdo conda packages
@@ -248,7 +249,6 @@ jobs:
           path: /logs
 
 workflows:
-  version: 2
   commit:
     jobs:
       - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,9 @@
 ---
 version: 2.1
 
+orbs:
+  coverage-reporter: codacy/coverage-reporter@11.1.1
+
 commands:
   check_changes:
     steps:
@@ -36,17 +39,9 @@ jobs:
           path: test-reports/
       - store_test_results:
           path: test-reports/
-      - run:
-          when: always
-          command: |
-            if [[ -v CODACY_PROJECT_TOKEN ]]
-            then
-              echo Uploading coverage report
-              pip install codacy-coverage
-              python-codacy-coverage -r test-reports/coverage.xml
-            else
-              echo Not uploading coverage report
-            fi
+      - coverage-reporter/send_report:
+          coverage-reports: 'test-reports/coverage.xml'
+          project-token: $CODACY_PROJECT_TOKEN
 
   test_installation:
     # Test Python 3 installation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,6 @@ jobs:
     working_directory: /esmvaltool
     docker:
       - image: continuumio/miniconda3
-    resource_class: medium+
     steps:
       - checkout
       - check_changes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,7 @@ jobs:
     working_directory: /esmvaltool
     docker:
       - image: continuumio/miniconda3
+    resource_class: medium+
     steps:
       - checkout
       - check_changes

--- a/doc/sphinx/source/community/introduction.rst
+++ b/doc/sphinx/source/community/introduction.rst
@@ -123,7 +123,7 @@ Running tests
 -------------
 
 Go to the directory where the repository is cloned and run
-``python setup.py test``. Tests will also be run automatically by
+``pytest``. Tests will also be run automatically by
 `CircleCI <https://circleci.com/gh/ESMValGroup/ESMValTool>`__.
 
 Code style

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -42,10 +42,11 @@ test:
     - pytest-flake8
     - pytest-html!=2.1.0
     - pytest-metadata>=1.5.1
+    - pytest-xdist
   imports:
     - esmvaltool
   commands:
-    - pytest --ignore=run_test.py
+    - pytest -n 2 --ignore=run_test.py
     - cmorize_obs --help
     - nclcodestyle --help
     - esmvaltool colortables --help
@@ -60,7 +61,6 @@ outputs:
     requirements:
       build:
         - git
-        - pytest-runner
         - python>=3.6
         - setuptools_scm
       run:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[aliases]
-test=pytest
-
 [build_sphinx]
 source-dir = doc/sphinx/source
 build-dir = doc/sphinx/build

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ addopts =
     --cov-report=xml:test-reports/coverage.xml
     --cov-report=html:test-reports/coverage_html
     --html=test-reports/report.html
+    --numprocesses auto
 env =
     MPLBACKEND = Agg
 flake8-ignore =

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ PACKAGES = [
 REQUIREMENTS = {
     # Installation script (this file) dependencies
     'setup': [
-        'pytest-runner',
         'setuptools_scm',
     ],
     # Installation dependencies
@@ -57,7 +56,7 @@ REQUIREMENTS = {
         'xlsxwriter',
     ],
     # Test dependencies
-    # Execute 'python setup.py test' to run tests
+    # Execute `pip install .[test]` once and the use `pytest` to run tests
     'test': [
         'pytest>=3.9,!=6.0.0rc1,!=6.0.0',
         'pytest-cov',
@@ -65,6 +64,7 @@ REQUIREMENTS = {
         'pytest-flake8',
         'pytest-html!=2.1.0',
         'pytest-metadata>=1.5.1',
+        'pytest-xdist',
     ],
     # Development dependencies
     # Use pip install -e .[develop] to install in development mode

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ REQUIREMENTS = {
         'pytest>=3.9,!=6.0.0rc1,!=6.0.0',
         'pytest-cov>=2.10.1',
         'pytest-env',
-        'pytest-flake8',
+        'pytest-flake8>=1.0.6',
         'pytest-html!=2.1.0',
         'pytest-metadata>=1.5.1',
         'pytest-xdist',

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ REQUIREMENTS = {
     # Execute `pip install .[test]` once and the use `pytest` to run tests
     'test': [
         'pytest>=3.9,!=6.0.0rc1,!=6.0.0',
-        'pytest-cov',
+        'pytest-cov>=2.10.1',
         'pytest-env',
         'pytest-flake8',
         'pytest-html!=2.1.0',


### PR DESCRIPTION
This pull request contains the following changes
- Replace the deprecated `python setup.py test` command with `pytest`
- Use pytest-xdist to run tests in parallel
- Use Codacy orb on CircleCI for uploading test coverage


* * *

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValTool/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] Give this pull request a descriptive title that can be used as a one line summary in a changelog
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Preferably Codacy code quality checks pass, however a few remaining hard to solve Codacy issues are still acceptable. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes


* * *

Closes #1671
