### PR TITLE
Move pre-commit excludes to top-level and correct order of lintr and styler

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 ---
-exclude: 'esmvaltool/diag_scripts/extreme_events/climdex.pcic.ncdf'
+exclude: '(esmvaltool/diag_scripts/extreme_events/climdex.pcic.ncdf|esmvaltool/diag_scripts/cvdp)'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,10 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 ---
-exclude: '(esmvaltool/diag_scripts/extreme_events/climdex.pcic.ncdf|esmvaltool/diag_scripts/cvdp)'
+exclude: |
+  (?x)
+  ^esmvaltool/diag_scripts/extreme_events/climdex.pcic.ncdf/|
+  ^esmvaltool/diag_scripts/cvdp/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0
@@ -25,7 +28,6 @@ repos:
         entry: nclcodestyle
         language: system
         files: '\.(ncl|NCL)$'
-        exclude: 'esmvaltool/diag_scripts/cvdp'
   - repo: https://github.com/lorenzwalthert/precommit/  # Checks for R
     rev: ''
     hooks:
@@ -35,7 +37,6 @@ repos:
     rev: ''
     hooks:
       - id: codespell
-        exclude: 'esmvaltool/diag_scripts/cvdp'
   - repo: https://github.com/PyCQA/isort
     rev: ''
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 ---
+exclude: 'esmvaltool/diag_scripts/extreme_events/climdex.pcic.ncdf'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0
@@ -29,9 +30,7 @@ repos:
     rev: ''
     hooks:
       - id: lintr
-        exclude: 'esmvaltool/diag_scripts/extreme_events/climdex.pcic.ncdf'
       - id: style-files  # styler
-        exclude: 'esmvaltool/diag_scripts/extreme_events/climdex.pcic.ncdf'
   - repo: https://github.com/codespell-project/codespell
     rev: ''
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,8 +31,8 @@ repos:
   - repo: https://github.com/lorenzwalthert/precommit/  # Checks for R
     rev: ''
     hooks:
-      - id: lintr
       - id: style-files  # styler
+      - id: lintr
   - repo: https://github.com/codespell-project/codespell
     rev: ''
     hooks:


### PR DESCRIPTION
This patch makes the excludes in the pre-commit config global instead of per repo and runs `styler` before `lintr`.

* * *

**Tasks**

-   [x] Give this pull request a descriptive title that can be used as a one line summary in a changelog
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Preferably Codacy code quality checks pass, however a few remaining hard to solve Codacy issues are still acceptable. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes

* * *


