### PR TITLE
Fix yapf-isort import formatting conflict

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,3 +27,7 @@ parallel = true
 
 [pydocstyle]
 convention = numpy
+
+[isort]
+multi_line_output = 3
+include_trailing_comma = true


### PR DESCRIPTION
Add trailing comma in isort config. Yapf respects the trailing comma and will not reformat the imports.
See: https://github.com/ESMValGroup/ESMValCore/issues/777

Related to: https://github.com/ESMValGroup/ESMValCore/pull/784 

* * *

**Tasks**

-   [X] [Create an issue](https://github.com/ESMValGroup/ESMValTool/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [X] Give this pull request a descriptive title that can be used as a one line summary in a changelog
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Preferably Codacy code quality checks pass, however a few remaining hard to solve Codacy issues are still acceptable. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.

