### PR TITLE
Add option to calculate mean weight for ensemble members

### DIFF
--- a/esmvaltool/recipes/recipe_climwip.yml
+++ b/esmvaltool/recipes/recipe_climwip.yml
@@ -107,6 +107,7 @@ diagnostics:
         obs_data: native6
         sigma_performance: 0.588
         sigma_independence: 0.704
+	combine_ensemble_members: False
 
   weighted_temperature_graph:
     variables:


### PR DESCRIPTION
@Peter9192: I've tried myself at adding a functionality which we included to our processing following the work from Merrifield et al. (2020) and Brunner et al. (2020, in review). The main idea here is that each initial-condition members of a model should receive the same weight. In addition, for initial-condition ensemble members from the same model we do not need to calculate the dependence, since we know that they are from the same model, the scaling should be 1/nr_of_members. 

I solved this here very similar to our code by combining the distance matrix/vector in the last step before calculating the weights and then expanding the weights again after calculating them. Feel free to change this in case my implementation is more complicated than it needs to be but I hope the idea becomes clear. 

The theoretical background is briefly described, e.g., in the discussion version of Brunner et al (2020) on page 4-5 (lines 113-124) [here](https://doi.org/10.5194/esd-2020-23). 
