### PR TITLE
Pin eccodes to not use eccodes=2.19.0 for cdo to work fine

### DIFF
--- a/.github/workflows/action-conda-build.yml
+++ b/.github/workflows/action-conda-build.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
     - master
-    - github-actions2  # testing branch
-    - pin_eccodes
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/action-conda-build.yml
+++ b/.github/workflows/action-conda-build.yml
@@ -6,6 +6,7 @@ on:
     branches:
     - master
     - github-actions2  # testing branch
+    - pin_eccodes
   schedule:
     - cron: '0 0 * * *'
 

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - esmvalcore>=2.1.0,<2.2
   # Non-Python dependencies
   - cdo>=1.9.7
+  - eccodes!=2.19.0  # cdo dependency; something messed up with libeccodes.so
   - imagemagick
   - nco
   - pynio

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -51,6 +51,8 @@ test:
     - nclcodestyle --help
     - esmvaltool colortables --help
     - test_recipe --help
+    - ncl -V
+    - cdo -V
 
 outputs:
 
@@ -66,6 +68,7 @@ outputs:
       run:
         - cartopy
         - cdo>=1.9.7
+        - eccodes!=2.19.0  # cdo dependency; something messed up with libeccodes.so
         - cdsapi
         - cf-units
         - cftime


### PR DESCRIPTION
Nightly builds test and local test don't work with eccodes=2.19.0 [nightly](https://app.circleci.com/pipelines/github/ESMValGroup/ESMValTool/3349/workflows/3177ec25-10ea-43ab-94b1-2014727ab85f/jobs/37535)