### PR TITLE
Require at least cartopy 0.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,16 +175,16 @@ jobs:
             set -x
             # Install prerequisites
             mkdir /logs
+            apt update && apt install time
             wget https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.3-linux-x86_64.tar.gz
             tar xfz julia-*-linux-x86_64.tar.gz
             ln -s $(pwd)/julia-*/bin/julia /usr/bin/julia
-            conda update -y conda python > /logs/conda_base.txt 2>&1
-            conda install -y conda-build conda-verify >> /logs/conda_base.txt 2>&1
+            conda create -n build conda-build conda-verify
+            conda activate build
             # Log versions
             dpkg -l > /logs/versions.txt
-            conda env export -n base > /logs/build_environment.yml
+            conda env export > /logs/build_environment.yml
             # Build conda package
-            apt update && apt install time
             \time -v conda build package -c conda-forge -c esmvalgroup > /logs/build_log.txt
           no_output_timeout: 30m
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ jobs:
             wget https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.3-linux-x86_64.tar.gz
             tar xfz julia-*-linux-x86_64.tar.gz
             ln -s $(pwd)/julia-*/bin/julia /usr/bin/julia
-            conda create -n build conda-build conda-verify
+            conda create -y -n build conda-build conda-verify
             conda activate build
             # Log versions
             dpkg -l > /logs/versions.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ jobs:
             wget https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.3-linux-x86_64.tar.gz
             tar xfz julia-*-linux-x86_64.tar.gz
             ln -s $(pwd)/julia-*/bin/julia /usr/bin/julia
-            # conda update -y conda > /logs/conda_base.txt 2>&1
+            conda update -y conda > /logs/conda_base.txt 2>&1
             conda install -y conda-build conda-verify >> /logs/conda_base.txt 2>&1
             # Log versions
             dpkg -l > /logs/versions.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ jobs:
             wget https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.3-linux-x86_64.tar.gz
             tar xfz julia-*-linux-x86_64.tar.gz
             ln -s $(pwd)/julia-*/bin/julia /usr/bin/julia
-            conda update -y conda > /logs/conda_base.txt 2>&1
+            conda update -y conda python > /logs/conda_base.txt 2>&1
             conda install -y conda-build conda-verify >> /logs/conda_base.txt 2>&1
             # Log versions
             dpkg -l > /logs/versions.txt

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ channels:
 
 dependencies:
   # Python packages that cannot be installed from PyPI:
+  - cartopy>=0.18
   - gdal
   - esmpy
   - esmvalcore>=2.1.0,<2.2

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ channels:
 dependencies:
   # Python packages that cannot be installed from PyPI:
   - cartopy>=0.18
+  - compilers
   - gdal
   - esmpy
   - esmvalcore>=2.1.0,<2.2

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -131,6 +131,7 @@ outputs:
     requirements:
       run:
         - cdo>=1.9.7
+        - compilers
         - esmvaltool-python
         - nco
         - r-base>=3.5

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -26,7 +26,6 @@ build:
 
 requirements:
   run:
-    - python>=3.6
     - esmvaltool-julia
     - esmvaltool-ncl
     - esmvaltool-python

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -66,7 +66,7 @@ outputs:
         - python>=3.6
         - setuptools_scm
       run:
-        - cartopy
+        - cartopy>=0.18
         - cdo>=1.9.7
         - eccodes!=2.19.0  # cdo dependency; something messed up with libeccodes.so
         - cdsapi

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -26,6 +26,7 @@ build:
 
 requirements:
   run:
+    - python
     - esmvaltool-julia
     - esmvaltool-ncl
     - esmvaltool-python

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -26,7 +26,7 @@ build:
 
 requirements:
   run:
-    - python
+    - python>=3.6
     - esmvaltool-julia
     - esmvaltool-ncl
     - esmvaltool-python

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ REQUIREMENTS = {
     # Installation dependencies
     # Use with pip install . to install from source
     'install': [
-        'cartopy',
+        'cartopy>=0.18',
         'cdo',
         'cdsapi',
         'cf-units',


### PR DESCRIPTION
Require at least cartopy 0.18, as problems have been encountered when plotting, see https://github.com/SciTools/cartopy/issues/1615