### PR TITLE
Pin matplotlib to <3.3 and add compilers

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,10 +6,12 @@ channels:
 
 dependencies:
   # Python packages that cannot be installed from PyPI:
+  - compilers
   - gdal
   - esmpy
   - esmvalcore>=2.1.0,<2.2
   - iris>=2.2.1,<3
+  - matplotlib>=3,<3.3
   # Non-Python dependencies
   - cdo>=1.9.7
   - eccodes!=2.19.0  # cdo dependency; something messed up with libeccodes.so
@@ -21,5 +23,3 @@ dependencies:
   # Multi language support:
   - ncl>=6.5.0  # this should always install 6.6.0 though
   - r-base>=3.5
-  - r-curl  # Dependency of lintr, but fails to compile because it cannot find libcurl installed from conda.
-  - r-udunits2  # Fails to compile because it cannot find udunits2 installed from conda.

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -84,7 +84,7 @@ outputs:
         - jinja2
         - joblib
         - lime
-        - matplotlib>=3
+        - matplotlib>=3,<3.3
         - natsort
         - nc-time-axis
         - netCDF4
@@ -131,11 +131,10 @@ outputs:
     requirements:
       run:
         - cdo>=1.9.7
+        - compilers
         - esmvaltool-python
         - nco
         - r-base>=3.5
-        - r-curl  # Dependency of lintr, but fails to compile because it cannot find libcurl installed from conda.
-        - r-udunits2  # Fails to compile because it cannot find udunits2 installed from conda.
 
 about:
   home: https://www.esmvaltool.org

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ REQUIREMENTS = {
         'jinja2',
         'joblib',
         'lime',
-        'matplotlib',
+        'matplotlib>=3,<3.3',
         'natsort',
         'nc-time-axis',  # needed by iris.plot
         'netCDF4',


### PR DESCRIPTION
Cartopy 0.17 does not work with matplotlib > 3.2 https://github.com/SciTools/cartopy/issues/1615 and pinning Cartopy to > 0.17 seems to result in an environment that is very difficult to solve (see my attempts in https://github.com/ESMValGroup/ESMValTool/pull/1893).

Therefore I think it would be best to pin matplotlib to <3.3 for now and try to upgrade again in a month or so.

I also added the `compilers` package to make sure the conda compilers are always used. This solves an issue I was having in #1893 because cartopy failed to compile when trying to install a newer version of it with pip on top of environment.yml and it also makes sure all R packages are compiling with the correct compilers, the r-base package does have some compiler dependencies, but not all (possibly related to #1816).

This should fix #1894.