### PR TITLE
Adding tutorial links to documentation

### DIFF
--- a/doc/sphinx/source/develop/recipe.rst
+++ b/doc/sphinx/source/develop/recipe.rst
@@ -16,7 +16,7 @@ the specific parameters needed by a recipe that runs a personal diagnostic are:
 
 i.e. the full path to the personal diagnostic that the user needs to run.
 
-There is also an episode available in the 
+There is also a lesson available in the 
 `ESMValTool tutorial <https://esmvalgroup.github.io/ESMValTool_Tutorial/>`_
 that describes in a step-by-step procedure how to write your own recipe. It can be found
 `here <https://esmvalgroup.github.io/ESMValTool_Tutorial/05-preprocessor/index.html>`_.

--- a/doc/sphinx/source/develop/recipe.rst
+++ b/doc/sphinx/source/develop/recipe.rst
@@ -15,3 +15,8 @@ the specific parameters needed by a recipe that runs a personal diagnostic are:
     script: /path/to/your/my_little_diagnostic.py
 
 i.e. the full path to the personal diagnostic that the user needs to run.
+
+There is also an episode available in the 
+`ESMValTool tutorial <https://esmvalgroup.github.io/ESMValTool_Tutorial/>`_
+that describes in a step-by-step procedure how to write your own recipe. It can be found
+`here <https://esmvalgroup.github.io/ESMValTool_Tutorial/05-preprocessor/index.html>`_.

--- a/doc/sphinx/source/quickstart/configuration.rst
+++ b/doc/sphinx/source/quickstart/configuration.rst
@@ -22,7 +22,7 @@ Note that this file needs to be customized using the instructions above, so
 the ``esmvaltool`` command can find the data on your system, before it can run
 a recipe.
 
-There is an episode available in the 
+There is a lesson available in the 
 `ESMValTool tutorial <https://esmvalgroup.github.io/ESMValTool_Tutorial/>`_
 that describes how to personalize the configuration file. It can be found
 `at this site <https://esmvalgroup.github.io/ESMValTool_Tutorial/03-configuration/index.html>`_.

--- a/doc/sphinx/source/quickstart/configuration.rst
+++ b/doc/sphinx/source/quickstart/configuration.rst
@@ -22,7 +22,7 @@ Note that this file needs to be customized using the instructions above, so
 the ``esmvaltool`` command can find the data on your system, before it can run
 a recipe.
 
-There is an episode in the 
+There is an episode available in the 
 `ESMValTool tutorial <https://esmvalgroup.github.io/ESMValTool_Tutorial/>`_
-available that describes how to personalize the configuration file. It can be found
+that describes how to personalize the configuration file. It can be found
 `here <https://esmvalgroup.github.io/ESMValTool_Tutorial/03-configuration/index.html>`_.

--- a/doc/sphinx/source/quickstart/configuration.rst
+++ b/doc/sphinx/source/quickstart/configuration.rst
@@ -21,3 +21,8 @@ To install the default configuration file in the default location, run
 Note that this file needs to be customized using the instructions above, so
 the ``esmvaltool`` command can find the data on your system, before it can run
 a recipe.
+
+There is an episode in the 
+`ESMValTool tutorial <https://esmvalgroup.github.io/ESMValTool_Tutorial/>`_
+available that describes how to personalize the configuration file. It can be found
+`here <https://esmvalgroup.github.io/ESMValTool_Tutorial/03-configuration/index.html>`_.

--- a/doc/sphinx/source/quickstart/configuration.rst
+++ b/doc/sphinx/source/quickstart/configuration.rst
@@ -25,4 +25,4 @@ a recipe.
 There is an episode available in the 
 `ESMValTool tutorial <https://esmvalgroup.github.io/ESMValTool_Tutorial/>`_
 that describes how to personalize the configuration file. It can be found
-`here <https://esmvalgroup.github.io/ESMValTool_Tutorial/03-configuration/index.html>`_.
+`at this site <https://esmvalgroup.github.io/ESMValTool_Tutorial/03-configuration/index.html>`_.

--- a/doc/sphinx/source/quickstart/installation.rst
+++ b/doc/sphinx/source/quickstart/installation.rst
@@ -93,6 +93,11 @@ Note that it is only necessary to install Julia prior to the conda installation 
 
 Note that the ESMValTool source code is contained in the ``esmvaltool-python`` package, so this package will always be installed as a dependency if you install one or more of the packages for other languages.
 
+There is also a lesson available in the 
+`ESMValTool tutorial <https://esmvalgroup.github.io/ESMValTool_Tutorial/>`_
+that describes the installation of the ESMValTool in more detail. It can be found
+`here <https://esmvalgroup.github.io/ESMValTool_Tutorial/02-installation/index.html>`_.
+
 Pip installation
 ================
 

--- a/doc/sphinx/source/quickstart/running.rst
+++ b/doc/sphinx/source/quickstart/running.rst
@@ -64,7 +64,7 @@ will display the help message with all options for the ``run`` command.
 There is a step by step description available in the 
 `ESMValTool tutorial <https://esmvalgroup.github.io/ESMValTool_Tutorial/>`_
 on how to run your first recipe. It can be found
-`here <https://esmvalgroup.github.io/ESMValTool_Tutorial/03-configuration/index.html>`_.
+`here <https://esmvalgroup.github.io/ESMValTool_Tutorial/04-recipe/index.html>`_.
 
 Available diagnostics and metrics
 =================================

--- a/doc/sphinx/source/quickstart/running.rst
+++ b/doc/sphinx/source/quickstart/running.rst
@@ -61,6 +61,11 @@ It is also possible to get help on specific commands, e.g.
 
 will display the help message with all options for the ``run`` command.
 
+There is a step by step description available in the 
+`ESMValTool tutorial <https://esmvalgroup.github.io/ESMValTool_Tutorial/>`_
+on how to run your first recipe. It can be found
+`here <https://esmvalgroup.github.io/ESMValTool_Tutorial/03-configuration/index.html>`_.
+
 Available diagnostics and metrics
 =================================
 

--- a/doc/sphinx/source/quickstart/running.rst
+++ b/doc/sphinx/source/quickstart/running.rst
@@ -61,7 +61,7 @@ It is also possible to get help on specific commands, e.g.
 
 will display the help message with all options for the ``run`` command.
 
-There is a step by step description available in the 
+There is a step-by-step description available in the 
 `ESMValTool tutorial <https://esmvalgroup.github.io/ESMValTool_Tutorial/>`_
 on how to run your first recipe. It can be found
 `here <https://esmvalgroup.github.io/ESMValTool_Tutorial/04-recipe/index.html>`_.


### PR DESCRIPTION
With this pull request some links to the ESMValTool tutorial are added to the documentation.

Closes #1926 


* * *

Automated checks pass, status can be seen below the pull request:

- [x] Circle/CI tests pass. If the tests are failing, click the `Details` link to find out why.
- [ ] Preferably Codacy code quality checks pass, however a few remaining hard to solve Codacy issues are still acceptable. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
- [x] The documentation is building successfully on readthedocs and looks well formatted, click the `Details` link to see it.


* * *

If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
