### PR TITLE
Fix style issue

### DIFF
--- a/esmvaltool/diag_scripts/weighting/plot_utilities.py
+++ b/esmvaltool/diag_scripts/weighting/plot_utilities.py
@@ -1,7 +1,6 @@
 """A collection of utility functions for dealing with weights."""
 from collections import defaultdict
 
-import numpy as np
 import xarray as xr
 
 from climwip.core_functions import weighted_quantile


### PR DESCRIPTION
The tests are failing for `master` on CircleCI because of an unused import, leading to a flake8 error. This pull request removes the unused import.