### PR TITLE
temporary deactivation Github Actions on OSX

### DIFF
--- a/.github/workflows/action-install-from-conda.yml
+++ b/.github/workflows/action-install-from-conda.yml
@@ -47,48 +47,51 @@ jobs:
           name: Conda_Install_Linux_python_${{ matrix.python-version }}
           path: conda_install_linux_artifacts_python_${{ matrix.python-version }}
 
-  osx:
-    runs-on: "macos-latest"
-    strategy:
-      matrix:
-        python-version: [3.6, 3.7]  # 3.8.5 not working as of 07-Sep-2020; serious issues at env solving
-      fail-fast: false
-    name: OSX Python ${{ matrix.python-version }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-          miniconda-version: "latest"
-          channels: esmvalgroup,conda-forge
-      - shell: bash -l {0}
-        run: mkdir -p conda_install_osx_artifacts_python_${{ matrix.python-version }}
-      - shell: bash -l {0}
-        run: conda --version 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/conda_version.txt
-      - shell: bash -l {0}
-        run: which conda 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/conda_path.txt
-      - shell: bash -l {0}
-        run: python -V 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/python_version.txt
-      # ncurses needs to be from conda-forge and not main channel
-      # for now it's turned off since we're not testing R/Julia installs
-      # - shell: bash -l {0}
-      #   run: conda uninstall -y ncurses
-      # - shell: bash -l {0}
-      #   run: conda list ncurses
-      # - shell: bash -l {0}
-      #   run: conda install -y conda-forge::ncurses
-      # - shell: bash -l {0}
-      #   run: conda list ncurses
-      - shell: bash -l {0}
-        #run: conda install esmvaltool --no-update-deps 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/install.txt
-        run: conda install esmvaltool-python esmvaltool-ncl 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/install.txt
-      - shell: bash -l {0}
-        run: esmvaltool --help
-      - shell: bash -l {0}
-        run: esmvaltool version 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/version.txt
-      - name: Upload artifacts
-        if: ${{ always() }}  # upload artifacts even if fail
-        uses: actions/upload-artifact@v2
-        with:
-          name: Conda_Install_OSX_python_${{ matrix.python-version }}
-          path: conda_install_osx_artifacts_python_${{ matrix.python-version }}
+# uncomment from here when we have a testing environment on an OSX machine
+# and we know that this should work
+#
+#  osx:
+#    runs-on: "macos-latest"
+#    strategy:
+#      matrix:
+#        python-version: [3.6, 3.7]  # 3.8.5 not working as of 07-Sep-2020; serious issues at env solving
+#      fail-fast: false
+#    name: OSX Python ${{ matrix.python-version }}
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: conda-incubator/setup-miniconda@v2
+#        with:
+#          python-version: ${{ matrix.python-version }}
+#          miniconda-version: "latest"
+#          channels: esmvalgroup,conda-forge
+#      - shell: bash -l {0}
+#        run: mkdir -p conda_install_osx_artifacts_python_${{ matrix.python-version }}
+#      - shell: bash -l {0}
+#        run: conda --version 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/conda_version.txt
+#      - shell: bash -l {0}
+#        run: which conda 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/conda_path.txt
+#      - shell: bash -l {0}
+#        run: python -V 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/python_version.txt
+#      # ncurses needs to be from conda-forge and not main channel
+#      # for now it's turned off since we're not testing R/Julia installs
+#      # - shell: bash -l {0}
+#      #   run: conda uninstall -y ncurses
+#      # - shell: bash -l {0}
+#      #   run: conda list ncurses
+#      # - shell: bash -l {0}
+#      #   run: conda install -y conda-forge::ncurses
+#      # - shell: bash -l {0}
+#      #   run: conda list ncurses
+#      - shell: bash -l {0}
+#        #run: conda install esmvaltool --no-update-deps 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/install.txt
+#        run: conda install esmvaltool-python esmvaltool-ncl 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/install.txt
+#      - shell: bash -l {0}
+#        run: esmvaltool --help
+#      - shell: bash -l {0}
+#        run: esmvaltool version 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/version.txt
+#      - name: Upload artifacts
+#        if: ${{ always() }}  # upload artifacts even if fail
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: Conda_Install_OSX_python_${{ matrix.python-version }}
+#          path: conda_install_osx_artifacts_python_${{ matrix.python-version }}

--- a/.github/workflows/action-install-from-source.yml
+++ b/.github/workflows/action-install-from-source.yml
@@ -45,37 +45,40 @@ jobs:
           name: Source_Install_Linux_python_${{ matrix.python-version }}
           path: source_install_linux_artifacts_python_${{ matrix.python-version }}
 
-  osx:
-    runs-on: "macos-latest"
-    strategy:
-      matrix:
-        python-version: [3.6, 3.7]  # 3.8.5 poses serious issues at env solving stage
-      fail-fast: false
-    name: OSX Python ${{ matrix.python-version }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: esmvaltool
-          environment-file: environment.yml
-          python-version: ${{ matrix.python-version }}
-          miniconda-version: "latest"
-          channels: conda-forge
-      - shell: bash -l {0}
-        run: mkdir -p source_install_osx_artifacts_python_${{ matrix.python-version }}
-      - shell: bash -l {0}
-        run: conda --version 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/conda_version.txt
-      - shell: bash -l {0}
-        run: python -V 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/python_version.txt
-      - shell: bash -l {0}
-        run: pip install -e .[develop] 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/install.txt
-      - shell: bash -l {0}
-        run: esmvaltool --help
-      - shell: bash -l {0}
-        run: esmvaltool version 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/version.txt
-      - name: Upload artifacts
-        if: ${{ always() }}  # upload artifacts even if fail
-        uses: actions/upload-artifact@v2
-        with:
-          name: Source_Install_OSX_python_${{ matrix.python-version }}
-          path: source_install_osx_artifacts_python_${{ matrix.python-version }}
+# uncomment from here when we have a testing environment on an OSX machine
+# and we know that this should work
+#
+#  osx:
+#    runs-on: "macos-latest"
+#    strategy:
+#      matrix:
+#        python-version: [3.6, 3.7]  # 3.8.5 poses serious issues at env solving stage
+#      fail-fast: false
+#    name: OSX Python ${{ matrix.python-version }}
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: conda-incubator/setup-miniconda@v2
+#        with:
+#          activate-environment: esmvaltool
+#          environment-file: environment.yml
+#          python-version: ${{ matrix.python-version }}
+#          miniconda-version: "latest"
+#          channels: conda-forge
+#      - shell: bash -l {0}
+#        run: mkdir -p source_install_osx_artifacts_python_${{ matrix.python-version }}
+#      - shell: bash -l {0}
+#        run: conda --version 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/conda_version.txt
+#      - shell: bash -l {0}
+#        run: python -V 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/python_version.txt
+#      - shell: bash -l {0}
+#        run: pip install -e .[develop] 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/install.txt
+#      - shell: bash -l {0}
+#        run: esmvaltool --help
+#      - shell: bash -l {0}
+#        run: esmvaltool version 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/version.txt
+#      - name: Upload artifacts
+#        if: ${{ always() }}  # upload artifacts even if fail
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: Source_Install_OSX_python_${{ matrix.python-version }}
+#          path: source_install_osx_artifacts_python_${{ matrix.python-version }}

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -47,43 +47,46 @@ jobs:
           name: Test_Linux_python_${{ matrix.python-version }}
           path: test_linux_artifacts_python_${{ matrix.python-version }}
 
-  osx:
-    runs-on: "macos-latest"
-    strategy:
-      matrix:
-        python-version: [3.6, 3.7]  # 3.8.5 poses serious issues with environment solving
-      fail-fast: false
-    name: OSX Python ${{ matrix.python-version }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: esmvaltool
-          environment-file: environment.yml
-          python-version: ${{ matrix.python-version }}
-          miniconda-version: "latest"
-          channels: conda-forge
-      - shell: bash -l {0}
-        run: mkdir -p test_osx_artifacts_python_${{ matrix.python-version }}
-      - shell: bash -l {0}
-        run: conda --version 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/conda_version.txt
-      - shell: bash -l {0}
-        run: python -V 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/python_version.txt
-      - shell: bash -l {0}
-        run: pip install -e .[develop] --use-feature=2020-resolver 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/install.txt
-      # ncurses needs to be from conda-forge and not main channel
-      # for now it's turned off since we're not testing R/Julia installs
-      # - shell: bash -l {0}
-      #   run: conda install -y conda-forge::ncurses 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/ncurses.txt
-      # - shell: bash -l {0}
-      #   run: esmvaltool install R
-      # - shell: bash -l {0}
-      #   run: esmvaltool install Julia
-      - shell: bash -l {0}
-        run: pytest -n 2 -m "not installation" 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/test_report.txt
-      - name: Upload artifacts
-        if: ${{ always() }}  # upload artifacts even if fail
-        uses: actions/upload-artifact@v2
-        with:
-          name: Test_OSX_python_${{ matrix.python-version }}
-          path: test_osx_artifacts_python_${{ matrix.python-version }}
+# uncomment from here when we have a testing environment on an OSX machine
+# and we know that this should work
+#
+#  osx:
+#    runs-on: "macos-latest"
+#    strategy:
+#      matrix:
+#        python-version: [3.6, 3.7]  # 3.8.5 poses serious issues with environment solving
+#      fail-fast: false
+#    name: OSX Python ${{ matrix.python-version }}
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: conda-incubator/setup-miniconda@v2
+#        with:
+#          activate-environment: esmvaltool
+#          environment-file: environment.yml
+#          python-version: ${{ matrix.python-version }}
+#          miniconda-version: "latest"
+#          channels: conda-forge
+#      - shell: bash -l {0}
+#        run: mkdir -p test_osx_artifacts_python_${{ matrix.python-version }}
+#      - shell: bash -l {0}
+#        run: conda --version 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/conda_version.txt
+#      - shell: bash -l {0}
+#        run: python -V 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/python_version.txt
+#      - shell: bash -l {0}
+#        run: pip install -e .[develop] --use-feature=2020-resolver 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/install.txt
+#      # ncurses needs to be from conda-forge and not main channel
+#      # for now it's turned off since we're not testing R/Julia installs
+#      # - shell: bash -l {0}
+#      #   run: conda install -y conda-forge::ncurses 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/ncurses.txt
+#      # - shell: bash -l {0}
+#      #   run: esmvaltool install R
+#      # - shell: bash -l {0}
+#      #   run: esmvaltool install Julia
+#      - shell: bash -l {0}
+#        run: pytest -n 2 -m "not installation" 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/test_report.txt
+#      - name: Upload artifacts
+#        if: ${{ always() }}  # upload artifacts even if fail
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: Test_OSX_python_${{ matrix.python-version }}
+#          path: test_osx_artifacts_python_${{ matrix.python-version }}


### PR DESCRIPTION
Our GA tests on OSX are a mess, thanks to the peculiar and ever changing nature of OSX and its deps being sometimes left out by devs, other times conflicting massively since they need specific libraries. I will come back and fix these but I still don't have access to an OSX-shod machine and trying to fix these tests only via Github Actions is like fighting Jackie Chan with only a pizza box in blacked-out room :grin: Word of praise to me, these worked fine a couple months ago, but they need more attention than a Labrador dog, and it's hard to do it w/o a Mac.

<!---
Please do not delete this text completely, but read the text below and keep
items that seem relevant.
If in doubt, just keep everything and add your own text at the top, a reviewer
will update the checklist for you.

While the checklist is intended to be filled in by the technical and scientific
reviewers, it is the responsibility of the author of the pull request to make
sure all items on it are properly implemented.
--->
Please discuss your idea with the development team before getting started, to avoid disappointment later. The way to do this is to open a new issue on GitHub.
If you are planning to modify existing functionality, please discuss it with the original author(s) by tagging them in the issue.

Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/en/latest/community/introduction.html).
To understand how we review and merge pull requests, have a look at our [review guidelines](https://docs.esmvaltool.org/en/latest/community/review.html).

<!---
Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
--->
Closes #issue_number


* * *

**Checklist for technical review**

- [ ] [Create an issue](https://github.com/ESMValGroup/ESMValTool/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
- [ ] The pull request has a descriptive title that can be used as a one line summary in the [changelog](https://docs.esmvaltool.org/en/latest/changelog.html)
- [ ] The code is composed of functions of no more than 50 lines and uses meaningful names for variables and follows the [style guide](https://docs.esmvaltool.org/en/latest/community/introduction.html#code-style)
- [ ] [Documentation](https://docs.esmvaltool.org/en/latest/community/introduction.html#documentation) is available
- [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
- [ ] (Only if really necessary) Add any additional dependencies needed for the diagnostic script to setup.py, esmvaltool/install/R/r_requirements.txt or esmvaltool/install/Julia/Project.toml (depending on the language of your script) and also to package/meta.yaml for conda dependencies (includes Python and others, but not R/Julia). Also check that the license of the dependency you want to add and any of its dependencies are compatible with [Apache2.0](https://github.com/ESMValGroup/ESMValTool/blob/master/LICENSE).

New or updated [recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html):

- [ ] Documentation for the recipe/diagnostic is available in the `doc/sphinx/source/recipes` folder and an entry has been added to `index.rst`
- [ ] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added and no warnings related to provenance are generated when running the recipe

New or updated [data reformatting script](https://docs.esmvaltool.org/en/latest/develop/dataset.html):

- [ ] Add a new dataset to the table in the [documentation](https://docs.esmvaltool.org/en/latest/input.html#supported-datasets)
- [ ] Add a test for the CMORized data to recipes/example/recipe_check_obs.yml and run the recipe, to make sure the CMOR checks pass without errors
- [ ] There are clear instructions on how to obtain the data
- [ ] Tag @remi-kazeroni in this pull request, so that the new dataset can be added to the OBS data pool at DKRZ and synchronized with CEDA-Jasmin

Automated checks pass, status can be seen below the pull request:

- [ ] Circle/CI tests pass. If the tests are failing, click the `Details` link to find out why.
- [ ] Preferably Codacy code quality checks pass, however a few remaining hard to solve Codacy issues are still acceptable. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
- [ ] The documentation is building successfully on readthedocs and looks well formatted, click the `Details` link to see it.


**Checklist for scientific review**

New or updated [recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html):

- [ ] [The documentation](https://docs.esmvaltool.org/en/latest/recipes/index.html) for the new/updated recipes/diagnostics clearly describes what the recipe does and how to use it
- [ ] The recipe runs successfully on your own machine/cluster or with the [`@esmvalbot`](https://github.com/apps/esmvalbot) without any modifications to the recipe and with all data specified in the recipe
- [ ] The figure(s) and data look as expected from the literature and/or the paper that is reproduced by the recipe
- [ ] The code contains comments with references to formulas, figures, tables, etc. that are used from papers/online resources

New or updated [data reformatting script](https://docs.esmvaltool.org/en/latest/develop/dataset.html):

- [ ] The numbers and units of the data look physically meaningful


* * *

If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
