### PR TITLE
Fix conda installation test on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,6 +197,8 @@ jobs:
       - image: continuumio/miniconda3
     steps:
       - run:
+          environment:
+            R_INSTALL_N_CPUS: 2
           command: |
             . /opt/conda/etc/profile.d/conda.sh
             set -x

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,7 +255,6 @@ workflows:
       - develop
       - documentation
       - conda_build
-      - conda_install
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,6 +255,7 @@ workflows:
       - develop
       - documentation
       - conda_build
+      - conda_install
   nightly:
     triggers:
       - schedule:


### PR DESCRIPTION
The conda installation test on CircleCI is failing, this pull request solves the problem. This extends #1883 to the installation test.

[This test run](https://app.circleci.com/pipelines/github/ESMValGroup/ESMValTool/3880/workflows/d8fb5846-75e3-4249-a861-58f10746f725/jobs/40314) shows that this pull request works.