### PR TITLE
bugfix: time weights in time_operations

### DIFF
--- a/esmvaltool/diag_scripts/shared/statistics.ncl
+++ b/esmvaltool/diag_scripts/shared/statistics.ncl
@@ -150,6 +150,7 @@ function time_operations(field:numeric,
 ; References
 ;
 ; Modification history
+;    20201214-lauer_axel:   bugfix time weights
 ;    20190503-righi_mattia: removed obsolete option "mymm" (used only in
 ;                           reformat_obs, now outdated).
 ;    20140703-gottschaldt_klaus-dirk: added option "mymm".
@@ -197,6 +198,11 @@ begin
   date := cd_calendar(field&time, 0)
   year := date(:, 0)
   month := date(:, 1)
+  if (isatt(field&time, "calendar")) then
+    cal = field&time@calendar
+  else
+    cal = "standard"  ; this is the default setting for 'days_in_month'
+  end if
 
   ; Determine indexes for the requested time range
   if (y1.eq.-1) then
@@ -244,7 +250,9 @@ begin
 
   ; Define weights as days-per-month
   if (l_wgt) then
-    weights = days_in_month(toint(year), toint(month))
+    iyear = toint(year)
+    iyear@calendar = cal
+    weights = days_in_month(iyear, toint(month))
   else
     weights = tofloat(subfield&time)
     weights = 1.

--- a/esmvaltool/diag_scripts/shared/statistics.ncl
+++ b/esmvaltool/diag_scripts/shared/statistics.ncl
@@ -200,6 +200,18 @@ begin
   month := date(:, 1)
   cal = field&time@calendar
 
+  ; check that calendar is supported by 'days_in_month'
+
+  valid_cal = (/"standard", "gregorian", "julian", "360_day", "360",  \
+                "365_day", "365", "366_day", "366", "noleap", "no_leap",  \
+                "allleap", "all_leap", "none"/)
+
+  if (ismissing(ind(valid_cal .eq. cal))) then
+    log_info("Warning: unsupported calendar in function " + funcname +  \
+             " (" + scriptname + "): " + cal + ". Using 'standard' instead.")
+    cal = "standard"
+  end if
+
   ; Determine indexes for the requested time range
   if (y1.eq.-1) then
     idx1 = 0

--- a/esmvaltool/diag_scripts/shared/statistics.ncl
+++ b/esmvaltool/diag_scripts/shared/statistics.ncl
@@ -198,11 +198,7 @@ begin
   date := cd_calendar(field&time, 0)
   year := date(:, 0)
   month := date(:, 1)
-  if (isatt(field&time, "calendar")) then
-    cal = field&time@calendar
-  else
-    cal = "standard"  ; this is the default setting for 'days_in_month'
-  end if
+  cal = field&time@calendar
 
   ; Determine indexes for the requested time range
   if (y1.eq.-1) then


### PR DESCRIPTION
The NCL function time_operations (statistics.ncl) optionally calculates weights based on the number of days per month for time averaging. In the current implementation, a possibly present calendar attribute is not taken into account when calculating the number of days per month potentially giving the wrong number of days in case of a leap year. This has now been fixed by preserving the calendar attribute (if present).

Closes #1946 

* * *

**Checklist for technical review**

- [X] [Create an issue](https://github.com/ESMValGroup/ESMValTool/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
- [X] The pull request has a descriptive title that can be used as a one line summary in the [changelog](https://docs.esmvaltool.org/en/latest/changelog.html)
- [x] The code is composed of functions of no more than 50 lines and uses meaningful names for variables and follows the [style guide](https://docs.esmvaltool.org/en/latest/community/introduction.html#code-style)

Automated checks pass, status can be seen below the pull request:

- [x] Circle/CI tests pass. If the tests are failing, click the `Details` link to find out why.
- [x] Preferably Codacy code quality checks pass, however a few remaining hard to solve Codacy issues are still acceptable. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
- [x] The documentation is building successfully on readthedocs and looks well formatted, click the `Details` link to see it.


**Checklist for scientific review**

New or updated [recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html):

- [ ] The recipe runs successfully on your own machine/cluster or with the [`@esmvalbot`](https://github.com/apps/esmvalbot) without any modifications to the recipe and with all data specified in the recipe

* * *