### PR TITLE
Github Actions: change time for cron job that installs from conda

### DIFF
--- a/.github/workflows/action-install-from-conda.yml
+++ b/.github/workflows/action-install-from-conda.yml
@@ -7,7 +7,7 @@ on:
     - master
     - github-actions2  # testing branch
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 4 * * *'
 
 jobs:
   linux:


### PR DESCRIPTION
This is a dumb experiment to try avert CondaHTTP errors (500 and its brothers) as described in #1968 - by no means a fact-based solution but rather, a shot in the dark assuming there are connection issues that happen around midnight UTC at anaconda; this is supported by the fact that tests that run at other times of the day seem to pass much more frequently :beer: 