### PR TITLE
Github Actions test that runs with the latest ESMValCore master

### DIFF
--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -1,0 +1,64 @@
+name: Full Development Test (Python)
+
+# runs on a push on master and at the end of every day
+on:
+  push:
+    branches:
+    - master
+    - ga_full_develop_test  # testing branch
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  linux:
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+      fail-fast: false
+    name: Linux Python ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: esmvaltool
+          environment-file: environment.yml
+          python-version: ${{ matrix.python-version }}
+          miniconda-version: "latest"
+          channels: conda-forge
+      - shell: bash -l {0}
+        run: mkdir -p develop_test_linux_artifacts_python_${{ matrix.python-version }}
+      - shell: bash -l {0}
+        run: conda --version 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/conda_version.txt
+      - shell: bash -l {0}
+        run: python -V 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/python_version.txt
+      - shell: bash -l {0}
+        run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/install.txt
+      - shell: bash -l {0}
+        run: esmvaltool --help
+      - shell: bash -l {0}
+        run: esmvaltool version 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/version.txt
+      - shell: bash -l {0}
+        run: cd ../..
+      - shell: bash -l {0}
+        run: git clone https://github.com/ESMValGroup/ESMValCore.git
+      - shell: bash -l {0}
+        run: cd ESMValCore
+      - shell: bash -l {0}
+        run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/install_esmvalcore.txt
+      - shell: bash -l {0}
+        run: cd ../ESMValTool/ESMValTool
+      - shell: bash -l {0}
+        run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/install.txt
+      - shell: bash -l {0}
+        run: esmvaltool install R
+      - shell: bash -l {0}
+        run: esmvaltool install Julia
+      - shell: bash -l {0}
+        run: pytest -n 2 -m "not installation" 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/test_report.txt
+      - name: Upload artifacts
+        if: ${{ always() }}  # upload artifacts even if fail
+        uses: actions/upload-artifact@v2
+        with:
+          name: Source_Install_Linux_python_${{ matrix.python-version }}
+          path: develop_test_linux_artifacts_python_${{ matrix.python-version }}

--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -24,7 +24,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           miniconda-version: "latest"
       - name: Setup esmvalcore and esmvaltool in dev mode
-        working-directory: ./esmval
         run: |
           conda --version
           git clone https://github.com/ESMValGroup/ESMValCore.git

--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -25,17 +25,14 @@ jobs:
           miniconda-version: "latest"
       - shell: bash -l {0}
         run: mkdir -p develop_test_linux_artifacts_python_${{ matrix.python-version }}
-        working-directory: ./esmval
       - shell: bash -l {0}
         run: conda --version 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/conda_version.txt
       - shell: bash -l {0}
         run: python -V 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/python_version.txt
       - shell: bash -l {0}
         run: git clone https://github.com/ESMValGroup/ESMValCore.git
-        working-directory: ./esmval
       - shell: bash -l {0}
         run: cd ESMValCore
-        working-directory: ./esmval
       - shell: bash -l {0}
         run: conda env create -n esmvaltool -f environment.yml 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/env_create_esmvalcore.txt
       - shell: bash -l {0}

--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -51,10 +51,6 @@ jobs:
       - shell: bash -l {0}
         run: cd ..
       - shell: bash -l {0}
-        run: ls -la
-      - shell: bash -l {0}
-        run: cd ESMValTool
-      - shell: bash -l {0}
         run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/install.txt
       - shell: bash -l {0}
         run: esmvaltool install R

--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup esmvalcore and esmvaltool in dev mode
         working-directory: ./esmval
         run: |
-          conda --version 2>&1
+          conda --version
           git clone https://github.com/ESMValGroup/ESMValCore.git
           cd ESMValCore
           conda env create -n esmvaltool -f environment.yml

--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -45,9 +45,15 @@ jobs:
       - shell: bash -l {0}
         run: cd ESMValCore
       - shell: bash -l {0}
+        run: conda env update -n esmvaltool -f environment.yml 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/env_update_esmvalcore.txt
+      - shell: bash -l {0}
         run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/install_esmvalcore.txt
       - shell: bash -l {0}
-        run: cd ../ESMValTool/ESMValTool
+        run: cd ..
+      - shell: bash -l {0}
+        run: ls -la
+      - shell: bash -l {0}
+        run: cd ESMValTool
       - shell: bash -l {0}
         run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/install.txt
       - shell: bash -l {0}

--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -39,13 +39,15 @@ jobs:
       - shell: bash -l {0}
         run: esmvaltool install Julia
       - shell: bash -l {0}
+        run: cd ..
+      - shell: bash -l {0}
         run: git clone https://github.com/ESMValGroup/ESMValCore.git
       - shell: bash -l {0}
         run: cd ESMValCore
       - shell: bash -l {0}
         run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/esmvalcore_install.txt
       - shell: bash -l {0}
-        run: cd ..
+        run: cd ../ESMValTool
       - shell: bash -l {0}
         run: pytest -n 2 -m "not installation" 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/test_report.txt
       - name: Upload artifacts

--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   linux:
     runs-on: "ubuntu-latest"
+    defaults:
+      run:
+        working-directory: ./esmval
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
@@ -21,11 +24,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          activate-environment: esmvaltool
-          environment-file: environment.yml
           python-version: ${{ matrix.python-version }}
           miniconda-version: "latest"
-          channels: conda-forge
       - shell: bash -l {0}
         run: mkdir -p develop_test_linux_artifacts_python_${{ matrix.python-version }}
       - shell: bash -l {0}
@@ -33,31 +33,33 @@ jobs:
       - shell: bash -l {0}
         run: python -V 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/python_version.txt
       - shell: bash -l {0}
-        run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/install.txt
-      - shell: bash -l {0}
-        run: esmvaltool --help
-      - shell: bash -l {0}
-        run: esmvaltool version 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/version.txt
-      - shell: bash -l {0}
-        run: cd ../..
-      - shell: bash -l {0}
         run: git clone https://github.com/ESMValGroup/ESMValCore.git
       - shell: bash -l {0}
         run: cd ESMValCore
       - shell: bash -l {0}
-        run: conda env update -n esmvaltool -f environment.yml 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/env_update_esmvalcore.txt
+        run: conda env create -n esmvaltool -f environment.yml 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/env_create_esmvalcore.txt
+      - shell: bash -l {0}
+        run: conda activate esmvaltool
       - shell: bash -l {0}
         run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/install_esmvalcore.txt
       - shell: bash -l {0}
+        run: pytest -n 2 -m "not installation" 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/test_report_esmvalcore.txt
+      - shell: bash -l {0}
         run: cd ..
       - shell: bash -l {0}
-        run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/install.txt
+        run: git clone https://github.com/ESMValGroup/ESMValTool.git
+      - shell: bash -l {0}
+        run: cd ESMValTool
+      - shell: bash -l {0}
+        run: conda env update -n esmvaltool -f environment.yml 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/env_update_esmvaltool.txt
+      - shell: bash -l {0}
+        run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/install_esmvaltool.txt
       - shell: bash -l {0}
         run: esmvaltool install R
       - shell: bash -l {0}
         run: esmvaltool install Julia
       - shell: bash -l {0}
-        run: pytest -n 2 -m "not installation" 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/test_report.txt
+        run: pytest -n 2 -m "not installation" 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/test_report_esmvaltool.txt
       - name: Upload artifacts
         if: ${{ always() }}  # upload artifacts even if fail
         uses: actions/upload-artifact@v2

--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -43,11 +43,9 @@ jobs:
       - shell: bash -l {0}
         run: git clone https://github.com/ESMValGroup/ESMValCore.git
       - shell: bash -l {0}
-        run: cd ESMValCore
-      - shell: bash -l {0}
-        run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/esmvalcore_install.txt
-      - shell: bash -l {0}
-        run: cd ../ESMValTool
+        run: |
+          cd ESMValCore
+          pip install -e .[develop]
       - shell: bash -l {0}
         run: pytest -n 2 -m "not installation" 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/test_report.txt
       - name: Upload artifacts

--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -21,15 +21,16 @@ jobs:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          environment-file: environment.yml
           python-version: ${{ matrix.python-version }}
           miniconda-version: "latest"
+          channels: conda-forge
       - name: Setup esmvalcore and esmvaltool in dev mode
         run: |
           conda --version
           git clone https://github.com/ESMValGroup/ESMValCore.git
           cd ESMValCore
-          conda env create -n esmvaltool -f environment.yml
-          conda activate esmvaltool
+          conda env update -n esmvaltool -f environment.yml
           pip install -e .[develop]
           pytest -n 2 -m "not installation"
           cd ..

--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
     - master
-    - github-actions2  # testing branch
+    - ga_full_develop_test  # testing branch
   schedule:
     - cron: '0 0 * * *'
 
@@ -40,7 +40,7 @@ jobs:
         run: esmvaltool install Julia
       - shell: bash -l {0}
         run: git clone https://github.com/ESMValGroup/ESMValCore.git
-      - shell: bash -l {0}:
+      - shell: bash -l {0}
         run: cd ESMValCore
       - shell: bash -l {0}
         run: run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/esmvalcore_install.txt

--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -30,13 +30,11 @@ jobs:
           conda --version
           git clone https://github.com/ESMValGroup/ESMValCore.git
           cd ESMValCore
-          conda env update -n esmvaltool -f environment.yml
           pip install -e .[develop]
           pytest -n 2 -m "not installation"
           cd ..
           git clone https://github.com/ESMValGroup/ESMValTool.git
           cd ESMValTool
-          conda env update -n esmvaltool -f environment.yml
           pip install -e .[develop]
           esmvaltool install R
           esmvaltool install Julia

--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
     - master
-    - ga_full_develop_test  # testing branch
   schedule:
     - cron: '0 0 * * *'
 
@@ -14,7 +13,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
       fail-fast: false
     name: Linux Python ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -39,11 +39,9 @@ jobs:
       - shell: bash -l {0}
         run: esmvaltool install Julia
       - shell: bash -l {0}
-        run: cd ..
-      - shell: bash -l {0}
-        run: git clone https://github.com/ESMValGroup/ESMValCore.git
-      - shell: bash -l {0}
         run: |
+          cd ..
+          git clone https://github.com/ESMValGroup/ESMValCore.git
           cd ESMValCore
           pip install -e .[develop]
       - shell: bash -l {0}

--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -43,7 +43,7 @@ jobs:
       - shell: bash -l {0}
         run: cd ESMValCore
       - shell: bash -l {0}
-        run: run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/esmvalcore_install.txt
+        run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/esmvalcore_install.txt
       - shell: bash -l {0}
         run: cd ..
       - shell: bash -l {0}

--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -1,11 +1,11 @@
-name: Full Development Test (Python)
+name: Develop Test
 
 # runs on a push on master and at the end of every day
 on:
   push:
     branches:
     - master
-    - ga_full_develop_test  # testing branch
+    - github-actions2  # testing branch
   schedule:
     - cron: '0 0 * * *'
 
@@ -14,28 +14,43 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: [3.8]  # latest stable for both esmvaltool and core
+        python-version: [3.6, 3.7, 3.8]
       fail-fast: false
     name: Linux Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          activate-environment: esmvaltool
           environment-file: environment.yml
           python-version: ${{ matrix.python-version }}
           miniconda-version: "latest"
           channels: conda-forge
-      - name: Setup esmvalcore and esmvaltool in dev mode
-        run: |
-          conda --version
-          git clone https://github.com/ESMValGroup/ESMValCore.git
-          cd ESMValCore
-          pip install -e .[develop]
-          pytest -n 2 -m "not installation"
-          cd ..
-          git clone https://github.com/ESMValGroup/ESMValTool.git
-          cd ESMValTool
-          pip install -e .[develop]
-          esmvaltool install R
-          esmvaltool install Julia
-          pytest -n 2 -m "not installation"
+      - shell: bash -l {0}
+        run: mkdir -p develop_test_linux_artifacts_python_${{ matrix.python-version }}
+      - shell: bash -l {0}
+        run: conda --version 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/conda_version.txt
+      - shell: bash -l {0}
+        run: python -V 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/python_version.txt
+      - shell: bash -l {0}
+        run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/install.txt
+      - shell: bash -l {0}
+        run: esmvaltool install R
+      - shell: bash -l {0}
+        run: esmvaltool install Julia
+      - shell: bash -l {0}
+        run: git clone https://github.com/ESMValGroup/ESMValCore.git
+      - shell: bash -l {0}:
+        run: cd ESMValCore
+      - shell: bash -l {0}
+        run: run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/esmvalcore_install.txt
+      - shell: bash -l {0}
+        run: cd ..
+      - shell: bash -l {0}
+        run: pytest -n 2 -m "not installation" 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/test_report.txt
+      - name: Upload artifacts
+        if: ${{ always() }}  # upload artifacts even if fail
+        uses: actions/upload-artifact@v2
+        with:
+          name: Develop_Test_Linux_python_${{ matrix.python-version }}
+          path: develop_test_linux_artifacts_python_${{ matrix.python-version }}

--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8]  # latest stable for both esmvaltool and core
       fail-fast: false
     name: Linux Python ${{ matrix.python-version }}
     steps:
@@ -23,43 +23,21 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           miniconda-version: "latest"
-      - shell: bash -l {0}
-        run: mkdir -p develop_test_linux_artifacts_python_${{ matrix.python-version }}
-      - shell: bash -l {0}
-        run: conda --version 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/conda_version.txt
-      - shell: bash -l {0}
-        run: python -V 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/python_version.txt
-      - shell: bash -l {0}
-        run: git clone https://github.com/ESMValGroup/ESMValCore.git
-      - shell: bash -l {0}
-        run: cd ESMValCore
-      - shell: bash -l {0}
-        run: conda env create -n esmvaltool -f environment.yml 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/env_create_esmvalcore.txt
-      - shell: bash -l {0}
-        run: conda activate esmvaltool
-      - shell: bash -l {0}
-        run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/install_esmvalcore.txt
-      - shell: bash -l {0}
-        run: pytest -n 2 -m "not installation" 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/test_report_esmvalcore.txt
-      - shell: bash -l {0}
-        run: cd ..
-      - shell: bash -l {0}
-        run: git clone https://github.com/ESMValGroup/ESMValTool.git
-      - shell: bash -l {0}
-        run: cd ESMValTool
-      - shell: bash -l {0}
-        run: conda env update -n esmvaltool -f environment.yml 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/env_update_esmvaltool.txt
-      - shell: bash -l {0}
-        run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/install_esmvaltool.txt
-      - shell: bash -l {0}
-        run: esmvaltool install R
-      - shell: bash -l {0}
-        run: esmvaltool install Julia
-      - shell: bash -l {0}
-        run: pytest -n 2 -m "not installation" 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/test_report_esmvaltool.txt
-      - name: Upload artifacts
-        if: ${{ always() }}  # upload artifacts even if fail
-        uses: actions/upload-artifact@v2
-        with:
-          name: Source_Install_Linux_python_${{ matrix.python-version }}
-          path: develop_test_linux_artifacts_python_${{ matrix.python-version }}
+      - name: Setup esmvalcore and esmvaltool in dev mode
+        working-directory: ./esmval
+        run: |
+          conda --version 2>&1
+          git clone https://github.com/ESMValGroup/ESMValCore.git
+          cd ESMValCore
+          conda env create -n esmvaltool -f environment.yml
+          conda activate esmvaltool
+          pip install -e .[develop]
+          pytest -n 2 -m "not installation"
+          cd ..
+          git clone https://github.com/ESMValGroup/ESMValTool.git
+          cd ESMValTool
+          conda env update -n esmvaltool -f environment.yml
+          pip install -e .[develop]
+          esmvaltool install R
+          esmvaltool install Julia
+          pytest -n 2 -m "not installation"

--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -12,9 +12,6 @@ on:
 jobs:
   linux:
     runs-on: "ubuntu-latest"
-    defaults:
-      run:
-        working-directory: ./esmval
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
@@ -28,14 +25,17 @@ jobs:
           miniconda-version: "latest"
       - shell: bash -l {0}
         run: mkdir -p develop_test_linux_artifacts_python_${{ matrix.python-version }}
+        working-directory: ./esmval
       - shell: bash -l {0}
         run: conda --version 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/conda_version.txt
       - shell: bash -l {0}
         run: python -V 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/python_version.txt
       - shell: bash -l {0}
         run: git clone https://github.com/ESMValGroup/ESMValCore.git
+        working-directory: ./esmval
       - shell: bash -l {0}
         run: cd ESMValCore
+        working-directory: ./esmval
       - shell: bash -l {0}
         run: conda env create -n esmvaltool -f environment.yml 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/env_create_esmvalcore.txt
       - shell: bash -l {0}

--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -1,3 +1,10 @@
+# Action that runs the full development stack:
+# Steps (Python-only):
+# - creates esmvaltool conda environment and pip-installs esmvaltool
+# - downloads latest master of esmvalcore and installs it in development mode
+# - runs tests of esmvaltool
+# Triggered by a push to master and nightly
+
 name: Develop Test
 
 # runs on a push on master and at the end of every day


### PR DESCRIPTION
Python 3.6, 3.7 and 3.8 pass with the latest ESMValCore master picked up nightly, see [results](https://github.com/ESMValGroup/ESMValTool/actions/runs/488625706) - we'll have to add Python 3.9 when we have a functional environment for ESMValTool too (we have it for Core)

**EDIT**: I have added Python 3.9 anyway, worst case it'll fail until we sort out the environment;
**NOTE**: the reason why there are so many commits is that it took me a day to realize that once you jump from one step to another, in GA, directory presence is not preserved (ie it always gets you back to the main test directory), so I tried with the new `working-directory` option they implemented, but that's total pish and very buggy :grin: 