### PR TITLE
Revert "Fix ImportError for `configure_logging`"

### DIFF
--- a/esmvaltool/cmorizers/obs/cmorize_obs.py
+++ b/esmvaltool/cmorizers/obs/cmorize_obs.py
@@ -20,8 +20,7 @@ import subprocess
 from pathlib import Path
 
 import esmvalcore
-from esmvalcore._config import read_config_user_file
-from esmvalcore._logging import configure_logging
+from esmvalcore._config import configure_logging, read_config_user_file
 from esmvalcore._task import write_ncl_settings
 
 from .utilities import read_cmor_config


### PR DESCRIPTION
Reverts ESMValGroup/ESMValTool#1976, because that should only be implemented after the release of ESMValCore v2.2.