### PR TITLE
Fix import of `configure_logging`

### DIFF
--- a/esmvaltool/cmorizers/obs/cmorize_obs.py
+++ b/esmvaltool/cmorizers/obs/cmorize_obs.py
@@ -20,7 +20,8 @@ import subprocess
 from pathlib import Path
 
 import esmvalcore
-from esmvalcore._config import configure_logging, read_config_user_file
+from esmvalcore._config import read_config_user_file
+from esmvalcore._logging import configure_logging
 from esmvalcore._task import write_ncl_settings
 
 from .utilities import read_cmor_config


### PR DESCRIPTION
## Description

We recently moved the logging configuration to its own submodule in `esmvalcore`. This PR fixes a potential `ImportError` in `esmvaltool`.

- Addresses: #1975

* * *

## Before you get started

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValTool/issues) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the PR is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

- [x] [🛠][1] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/en/latest/community/introduction.html#branches-pull-requests-and-code-review)
- [x] [🛠][1] Code follows the [style guide](https://docs.esmvaltool.org/en/latest/community/introduction.html#code-style)
- [ ] [🛠][1] [Circle/CI tests pass](https://docs.esmvaltool.org/en/latest/community/introduction.html#branches-pull-requests-and-code-review)
- [x] [🛠][1] [Codacy code quality checks pass](https://docs.esmvaltool.org/en/latest/community/introduction.html#branches-pull-requests-and-code-review)
- [x] [🛠][1] [Documentation builds successfully](https://docs.esmvaltool.org/en/latest/community/introduction.html#branches-pull-requests-and-code-review) on readthedocs


To help with the number pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->

[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review
