### PR TITLE
Python 3.9: remove pynio as dependency and replace with rasterio and pin Matplotlib>3.3.1 and pin cartopy>=0.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - checkout
       - check_changes
       - restore_cache:
-          key: test-install-{{ .Branch }}
+          key: test-install-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "environment.yml" }}
       - run:
           command: |
             . /opt/conda/etc/profile.d/conda.sh
@@ -87,7 +87,7 @@ jobs:
             cdo -f nc copy tmp.nc tmp2.nc
           no_output_timeout: 30m
       - save_cache:
-          key: test-install-{{ .Branch }}
+          key: test-install-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "environment.yml" }}
           paths:
             - "/opt/conda/pkgs"
             - ".eggs"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
             tar xfz julia-*-linux-x86_64.tar.gz
             ln -s $(pwd)/julia-*/bin/julia /usr/bin/julia
             # conda update -y conda > /logs/conda.txt 2>&1
-            conda env update >> /logs/conda.txt 2>&1
+            # conda env update >> /logs/conda.txt 2>&1
             set +x; conda activate esmvaltool; set -x
             pip install .[test] > /logs/install.txt 2>&1
             esmvaltool install R
@@ -116,7 +116,7 @@ jobs:
             tar xfz julia-*-linux-x86_64.tar.gz
             ln -s $(pwd)/julia-*/bin/julia /usr/bin/julia
             # conda update -y conda > /logs/conda.txt 2>&1
-            conda env update >> /logs/conda.txt 2>&1
+            # conda env update >> /logs/conda.txt 2>&1
             set +x; conda activate esmvaltool; set -x
             pip install -e .[develop] > /logs/install.txt 2>&1
             esmvaltool install R

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,16 +179,16 @@ jobs:
             set -x
             # Install prerequisites
             mkdir /logs
+            apt update && apt install time
             wget https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.3-linux-x86_64.tar.gz
             tar xfz julia-*-linux-x86_64.tar.gz
             ln -s $(pwd)/julia-*/bin/julia /usr/bin/julia
-            # conda update -y conda > /logs/conda_base.txt 2>&1
-            conda install -y conda-build conda-verify >> /logs/conda_base.txt 2>&1
+            conda create -y -n build conda-build conda-verify
+            conda activate build
             # Log versions
             dpkg -l > /logs/versions.txt
-            conda env export -n base > /logs/build_environment.yml
+            conda env export > /logs/build_environment.yml
             # Build conda package
-            apt update && apt install time
             \time -v conda build package -c conda-forge -c esmvalgroup > /logs/build_log.txt
           no_output_timeout: 30m
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
             ln -s $(pwd)/julia-*/bin/julia /usr/bin/julia
             # conda update -y conda > /logs/conda.txt 2>&1
             # conda env update >> /logs/conda.txt 2>&1
+            conda env create -n esmvaltool -f environment.yml >> /logs/conda.txt 2>&1
             set +x; conda activate esmvaltool; set -x
             pip install .[test] > /logs/install.txt 2>&1
             esmvaltool install R
@@ -117,6 +118,7 @@ jobs:
             ln -s $(pwd)/julia-*/bin/julia /usr/bin/julia
             # conda update -y conda > /logs/conda.txt 2>&1
             # conda env update >> /logs/conda.txt 2>&1
+            conda env create -n esmvaltool -f environment.yml >> /logs/conda.txt 2>&1
             set +x; conda activate esmvaltool; set -x
             pip install -e .[develop] > /logs/install.txt 2>&1
             esmvaltool install R

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - checkout
       - check_changes
       - restore_cache:
-          key: test-install-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "environment.yml" }}
+          key: test-install-{{ .Branch }}
       - run:
           command: |
             . /opt/conda/etc/profile.d/conda.sh
@@ -88,7 +88,7 @@ jobs:
             cdo -f nc copy tmp.nc tmp2.nc
           no_output_timeout: 30m
       - save_cache:
-          key: test-install-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "environment.yml" }}
+          key: test-install-{{ .Branch }}
           paths:
             - "/opt/conda/pkgs"
             - ".eggs"

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -79,6 +79,7 @@ autodoc_mock_imports = [
     'GDAL',
     'iris',
     'psutil',
+    'rasterio',
     'scipy',
     'sklearn',
     'xesmf',

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -79,7 +79,6 @@ autodoc_mock_imports = [
     'GDAL',
     'iris',
     'psutil',
-    'pynio',
     'scipy',
     'sklearn',
     'xesmf',

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - esmvalcore>=2.1.0,<2.2
   - iris>=2.2.1,<3
   - matplotlib  # bug in 3.3.1 but 3.3.3 gets installed automatically
+  - rasterio  # replaces pynio
   # Non-Python dependencies
   - cdo>=1.9.7
   - eccodes!=2.19.0  # cdo dependency; something messed up with libeccodes.so

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ channels:
 
 dependencies:
   # Python packages that cannot be installed from PyPI:
+  - cartopy>=0.18
   - compilers
   - gdal
   - esmpy

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,6 @@ dependencies:
   - eccodes!=2.19.0  # cdo dependency; something messed up with libeccodes.so
   - imagemagick
   - nco
-  - pynio
   - scikit-learn  # may hit hw-specific issue if from pypi https://github.com/scikit-learn/scikit-learn/issues/14485
 
   # Multi language support:

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,6 @@ dependencies:
   - esmvalcore>=2.1.0,<2.2
   - iris>=2.2.1,<3
   - matplotlib  # bug in 3.3.1 but 3.3.3 gets installed automatically
-  - rasterio  # replaces pynio
   # Non-Python dependencies
   - cdo>=1.9.7
   - eccodes!=2.19.0  # cdo dependency; something messed up with libeccodes.so

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - esmpy
   - esmvalcore>=2.1.0,<2.2
   - iris>=2.2.1,<3
-  - matplotlib>=3,<3.3
+  - matplotlib  # bug in 3.3.1 but 3.3.3 gets installed automatically
   # Non-Python dependencies
   - cdo>=1.9.7
   - eccodes!=2.19.0  # cdo dependency; something messed up with libeccodes.so

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - esmpy
   - esmvalcore>=2.1.0,<2.2
   - iris>=2.2.1,<3
-  - matplotlib  # bug in 3.3.1 but 3.3.3 gets installed automatically
+  - matplotlib>3.3.1  # bug in 3.3.1 but 3.3.3 gets installed automatically
   # Non-Python dependencies
   - cdo>=1.9.7
   - eccodes!=2.19.0  # cdo dependency; something messed up with libeccodes.so

--- a/esmvaltool/cmorizers/obs/cmorize_obs_eppley_vgpm_modis.py
+++ b/esmvaltool/cmorizers/obs/cmorize_obs_eppley_vgpm_modis.py
@@ -70,7 +70,7 @@ def merge_data(in_dir, out_dir, raw_info):
     var = raw_info['name']
     filelist = sorted(glob.glob(in_dir + '/' + raw_info['file'] + '*.hdf'))
     for filename in filelist:
-        ds = xr.open_dataset(filename).rename({
+        ds = xr.open_dataset(filename, engine='rasterio').rename({
             'fakeDim0': 'lat',
             'fakeDim1': 'lon'
         })

--- a/esmvaltool/cmorizers/obs/cmorize_obs_eppley_vgpm_modis.py
+++ b/esmvaltool/cmorizers/obs/cmorize_obs_eppley_vgpm_modis.py
@@ -70,7 +70,7 @@ def merge_data(in_dir, out_dir, raw_info):
     var = raw_info['name']
     filelist = sorted(glob.glob(in_dir + '/' + raw_info['file'] + '*.hdf'))
     for filename in filelist:
-        ds = xr.open_dataset(filename, engine='pynio').rename({
+        ds = xr.open_dataset(filename).rename({
             'fakeDim0': 'lat',
             'fakeDim1': 'lon'
         })

--- a/esmvaltool/cmorizers/obs/cmorize_obs_eppley_vgpm_modis.py
+++ b/esmvaltool/cmorizers/obs/cmorize_obs_eppley_vgpm_modis.py
@@ -21,9 +21,9 @@ Modification history
 import logging
 import os
 import glob
-from datetime import datetime as dt
 import xarray as xr
 import numpy as np
+import pandas as pd
 
 import iris
 
@@ -70,24 +70,23 @@ def merge_data(in_dir, out_dir, raw_info):
     var = raw_info['name']
     filelist = sorted(glob.glob(in_dir + '/' + raw_info['file'] + '*.hdf'))
     for filename in filelist:
-        ds = xr.open_dataset(filename, engine='rasterio').rename({
-            'fakeDim0': 'lat',
-            'fakeDim1': 'lon'
-        })
+        ds = xr.open_rasterio(filename).rename({
+            'y': 'lat',
+            'x': 'lon'
+        }).squeeze().drop('band')
         # create coordinates
         ds = ds.assign_coords(
-            time=dt.strptime(ds.attrs['Start_Time_String'],
-                             '%m/%d/%Y %H:%M:%S'))
+            time=pd.to_datetime(filename[-11:-4], format='%Y%j'))
         ds = ds.expand_dims(dim='time', axis=0)
-        dx = 90. / ds.dims['lat']
-        ds = ds.assign_coords(
-            lat=np.linspace(-90. + dx, 90. - dx, ds.dims['lat']))
+        dx = 90. / ds.lat.size
+        ds = ds.assign_coords(lat=np.linspace(-90. + dx, 90. -
+                                              dx, ds.lat.size))
         ds.lat.attrs = {'long_name': 'Latitude', 'units': 'degrees_north'}
-        ds = ds.assign_coords(
-            lon=np.linspace(-180. + dx, 180. - dx, ds.dims['lon']))
+        ds = ds.assign_coords(lon=np.linspace(-180. + dx, 180. -
+                                              dx, ds.lon.size))
         ds.lon.attrs = {'long_name': 'Longitude', 'units': 'degrees_east'}
         # get current file data
-        da.append(ds[var])
+        da.append(ds)
     damerge = xr.concat(da, dim='time')
 
     # need data flip to match coordinates
@@ -106,7 +105,7 @@ def merge_data(in_dir, out_dir, raw_info):
             'calendar': 'gregorian'
         },
         var: {
-            '_FillValue': ds[var].attrs['Hole_Value']
+            '_FillValue': -9999.0
         }
     }
     filename = os.path.join(out_dir, raw_info['file'] + '_merged.nc')
@@ -128,7 +127,7 @@ def cmorization(in_dir, out_dir, cfg, _):
         glob_attrs['mip'] = vals['mip']
         raw_info = {'name': vals['raw'], 'file': vals['file']}
 
-        # merge yearly data and apply binning
+        # merge data
         inpfile = merge_data(in_dir, out_dir, raw_info)
 
         logger.info("CMORizing var %s from file %s", var, inpfile)

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -90,7 +90,6 @@ outputs:
         - netCDF4
         - numpy
         - pandas
-        - pynio
         - pyproj>=2.1
         - python>=3.6
         - python-cdo

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -84,7 +84,7 @@ outputs:
         - jinja2
         - joblib
         - lime
-        - matplotlib
+        - matplotlib>3.3.1  # bug in 3.3.1
         - natsort
         - nc-time-axis
         - netCDF4

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -66,7 +66,7 @@ outputs:
         - python>=3.6
         - setuptools_scm
       run:
-        - cartopy
+        - cartopy>=0.18
         - cdo>=1.9.7
         - eccodes!=2.19.0  # cdo dependency; something messed up with libeccodes.so
         - cdsapi

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -84,7 +84,7 @@ outputs:
         - jinja2
         - joblib
         - lime
-        - matplotlib>=3,<3.3
+        - matplotlib
         - natsort
         - nc-time-axis
         - netCDF4

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -94,6 +94,7 @@ outputs:
         - python>=3.6
         - python-cdo
         - pyyaml
+        - rasterio  # replaces pynio
         - scikit-image
         - scikit-learn
         - seaborn

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ REQUIREMENTS = {
         'pandas',
         'pyproj>=2.1'
         'pyyaml',
+        'rasterio',  # replaces pynio
         'scikit-image',
         'scikit-learn',
         'scipy',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ REQUIREMENTS = {
     # Installation dependencies
     # Use with pip install . to install from source
     'install': [
-        'cartopy',
+        'cartopy>=0.18',
         'cdo',
         'cdsapi',
         'cf-units',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ REQUIREMENTS = {
         'jinja2',
         'joblib',
         'lime',
-        'matplotlib>=3,<3.3',
+        'matplotlib',  # bug in 3.3.1, 3.3.3 fine
         'natsort',
         'nc-time-axis',  # needed by iris.plot
         'netCDF4',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ REQUIREMENTS = {
         'jinja2',
         'joblib',
         'lime',
-        'matplotlib',  # bug in 3.3.1, 3.3.3 fine
+        'matplotlib>3.3.1',  # bug in 3.3.1, 3.3.2 and 3 fine
         'natsort',
         'nc-time-axis',  # needed by iris.plot
         'netCDF4',

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ REQUIREMENTS = {
         'netCDF4',
         'numpy',
         'pandas',
-        'pynio',
         'pyproj>=2.1'
         'pyyaml',
         'scikit-image',


### PR DESCRIPTION
**Pynio removal**
`pynio` is no longer maintained and is an obsolete package preventing us to support Python 3.9 as described in #1996 and a general nuisance as described in #1935 
As far as the functionality in ESMValTool goes, it is used as a file loader engine for `xarray` in the cmorizer `esmvaltool/cmorizers/obs/cmorize_obs_eppley_vgpm_modis.py` script, but according to the [xarray function documentation](http://xarray.pydata.org/en/stable/generated/xarray.open_dataset.html) the `engine` arg is optional, and if not specified, the defaults `netcdf4` is used and preferred. ~Any reason why the `pynio` engine is explicitly used? I don't have the rawOBS data so I can't test but if there is no particular reason for `pynio` use, please approve this PR; if there is a proper reason for `pynio` please mention it here and provide a usable and viable alternative.~ see below for `rasterio`

**pynio -> rasterio**

@tomaslovato examined the situation and recommended `rasterio` for an engine; `rasterio` is supported and on both `conda-forge` and `PyPi` (see [pypi package](https://pypi.org/project/rasterio/)). I have added it to the environment to be installed from PyPi and the environment builds well (without ESMValCore from PyPi, but installed in development mode, to test the Python 3.9 compatibility). `rasterio` wheel builds fine in a Python 3.9 environment and ESMValTool installs fine. @tomaslovato promised to include code for its use in the cmorizer script :+1: 

**pin Matplotlib>3.3.1**
I unpinned Matplotlib since we are not wanting Matplotlib 3.3.1 (the bug reported in Nikolay's [comment](https://github.com/ESMValGroup/ESMValTool/issues/1875#issuecomment-714799629)) but 3.3.1 is already very old and 3.3.3 will be installed automatically. ~If we really are paranoid, we can force a condition `!=3.3.1` but I don't think it's necessary.~ I have now pinned the lower bound to `>3.3.1` to help the environment solve faster.

**pin cartopy>=0.18**
since Matplotlib 3 don't work with lower versions of cartopy

**Replace conda env update with conda env create**
In the Circle CI script I replaced calls to `conda env update` with full blown env creation `conda env create`, conda update is a bit hit and miss.

**Changes from** #1893 
Fully ported here

**Functionality for Python 3.9 use**
Solves the env with esmvalcore out for full development installation (since the esmvalcore conda package is Python 3.8), installs OK and tests OK (Python 3.9.1 for conda=4.9.2)

Closes: #1935 #1996 #1998 #1893 