### PR TITLE
Update iris documentation URL for sphinx

### DIFF
--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -425,7 +425,7 @@ intersphinx_mapping = {
     (f'https://docs.esmvaltool.org/projects/esmvalcore/en/{rtd_version}/',
      None),
     'esmvaltool': (f'https://docs.esmvaltool.org/en/{rtd_version}/', None),
-    'iris': ('https://scitools.org.uk/iris/docs/latest/', None),
+    'iris': ('https://scitools-iris.readthedocs.io/en/latest/', None),
     'lime': ('https://lime-ml.readthedocs.io/en/latest/', None),
     'matplotlib': ('https://matplotlib.org/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),


### PR DESCRIPTION
The URL where the iris documentation lives has changed. This pull request updates it, so the documentation builds successfully again.