### PR TITLE
Massage Python for conda build of esmvaltool-python

### DIFF
--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -63,7 +63,7 @@ outputs:
     requirements:
       build:
         - git
-        - python>=3.6
+        - python=3.9
         - setuptools_scm
       run:
         - cartopy>=0.18
@@ -92,7 +92,7 @@ outputs:
         - numpy
         - pandas
         - pyproj>=2.1
-        # - python>=3.6  ## this makes the env solver descend into an infinite loop; unpinning doesnt solve this
+        - python=3.9
         - python-cdo
         - pyyaml
         - rasterio  # replaces pynio

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -92,7 +92,7 @@ outputs:
         - numpy
         - pandas
         - pyproj>=2.1
-        - python>=3.6
+        # - python>=3.6  ## this makes the env solver descend into an infinite loop; unpinning doesnt solve this
         - python-cdo
         - pyyaml
         - rasterio  # replaces pynio

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -63,7 +63,7 @@ outputs:
     requirements:
       build:
         - git
-        - python=3.9
+        - python=3.8
         - setuptools_scm
       run:
         - cartopy>=0.18
@@ -92,7 +92,7 @@ outputs:
         - numpy
         - pandas
         - pyproj>=2.1
-        - python=3.9
+        - python=3.8
         - python-cdo
         - pyyaml
         - rasterio  # replaces pynio


### PR DESCRIPTION
Test bench for solving #2016 - the env solving for `esmvaltool-python` is consuming insane amounts of memory and the culprit is `python` from the list of deps for building `esmvaltool-python `as I say in this [comment](https://github.com/ESMValGroup/ESMValTool/issues/2016#issuecomment-777666132) - removing it altogether is no good coz the conda build job just hangs like [here](https://app.circleci.com/pipelines/github/ESMValGroup/ESMValTool/4234/workflows/2db525d4-4bdd-4f41-a6b3-e11a0b443e59/jobs/42277) - so there's gotta be something we can do -  trying stuff here - so far it's fubar:

- pinning python to 3.9 runs out of memory [here](https://app.circleci.com/pipelines/github/ESMValGroup/ESMValTool/4235/workflows/cb38e39a-f27c-41b0-b800-bcb1be890b48/jobs/42284)
- removing it altogether hangs [here](https://app.circleci.com/pipelines/github/ESMValGroup/ESMValTool/4234/workflows/2db525d4-4bdd-4f41-a6b3-e11a0b443e59/jobs/42277)
- pinning python to 3.8 runs out of memory as well [here](https://app.circleci.com/pipelines/github/ESMValGroup/ESMValTool/4236/workflows/a7c074f6-a1e9-4f0e-a08e-1555ff46fb0d/jobs/42286)
- I am all out of missiles