### PR TITLE
Fix import of esmvalcore _logging module in cmorize_obs.py

### DIFF
--- a/esmvaltool/cmorizers/obs/cmorize_obs.py
+++ b/esmvaltool/cmorizers/obs/cmorize_obs.py
@@ -20,7 +20,8 @@ import subprocess
 from pathlib import Path
 
 import esmvalcore
-from esmvalcore._config import configure_logging, read_config_user_file
+from esmvalcore._config import read_config_user_file
+from esmvalcore._logging import configure_logging
 from esmvalcore._task import write_ncl_settings
 
 from .utilities import read_cmor_config


### PR DESCRIPTION
the [Github Actions](https://github.com/ESMValGroup/ESMValTool/runs/1883776349?check_suite_focus=true) are crashing with module not found error because of bad import of the new logging module in esmvalcore