### PR TITLE
Refactor the functions in derive_evspsblpot due to new iris

### DIFF
--- a/esmvaltool/diag_scripts/hydrology/derive_evspsblpot.py
+++ b/esmvaltool/diag_scripts/hydrology/derive_evspsblpot.py
@@ -6,8 +6,8 @@ Grass Field Close to FAO Reference, Suitable for Remote Sensing Application,
 American Meteorological Society, 17, 1373-1382, DOI: 10.1175/JHM-D-15-0006.1,
 2016.
 """
-import iris
 import numpy as np
+import iris
 
 
 def tetens_derivative(tas):
@@ -33,7 +33,7 @@ def tetens_derivative(tas):
                                  long_name='Empirical constant b',
                                  units='degC')
     exponent = iris.analysis.maths.exp(emp_a * tas / (tas + emp_b))
-    return  (exponent * e0_const / (tas + emp_b)**2) * (emp_a * emp_b)
+    return (exponent * e0_const / (tas + emp_b)**2) * (emp_a * emp_b)
 
 
 def get_constants(psl):
@@ -82,7 +82,8 @@ def get_constants(psl):
     # source = De Bruin (10.1175/JHM-D-15-0006.1), page 1376
     # gamma = (rv/rd) * (cp*msl/lambda_)
     # iris.exceptions.NotYetImplementedError: coord / coord
-    gamma = (rv_const.points[0] / rd_const.points[0]) * (psl * cp_const / lambda_)
+    rv_rd_const = rv_const.points[0] / rd_const.points[0]
+    gamma = rv_rd_const * (psl * cp_const / lambda_)
     return gamma, cs_const, beta, lambda_
 
 
@@ -98,10 +99,12 @@ def debruin_pet(psl, rsds, rsdt, tas):
     # the definition of the radiation components according to the paper:
     kdown = rsds
     kdown_ext = rsdt
+    # Equation 5
+    rad_factor = np.float32(1 - 0.23)
+    net_radiation = (rad_factor * kdown) - (kdown * cs_const / kdown_ext)
     # Equation 6
-    rad_term = (np.float32(1 - 0.23) * kdown) - (kdown * cs_const / kdown_ext)
     # the unit is W m-2
-    ref_evap = ((delta_svp / (delta_svp + gamma)) * rad_term) + beta
+    ref_evap = ((delta_svp / (delta_svp + gamma)) * net_radiation) + beta
 
     pet = ref_evap / lambda_
     pet.var_name = 'evspsblpot'

--- a/esmvaltool/diag_scripts/hydrology/derive_evspsblpot.py
+++ b/esmvaltool/diag_scripts/hydrology/derive_evspsblpot.py
@@ -33,7 +33,6 @@ def tetens_derivative(tas):
                                  long_name='Empirical constant b',
                                  units='degC')
     exponent = iris.analysis.maths.exp(emp_a * tas / (tas + emp_b))
-
     return  (exponent * e0_const / (tas + emp_b)**2) * (emp_a * emp_b)
 
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this PR makes
    ESMValTool better and what problem it solves.

    Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/en/latest/community/introduction.html).

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
- Closes #2021 
- Link to documentation:

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValTool/issues) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the PR is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

- [x] [🛠][1] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/en/latest/community/introduction.html#branches-pull-requests-and-code-review)
- [x] [🛠][1] Code follows the [style guide](https://docs.esmvaltool.org/en/latest/community/introduction.html#code-style)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/introduction.html#documentation) is available
- [ ] ~~[🛠][1] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/en/latest/community/introduction.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/en/latest/community/introduction.html#yaml) checks~~
- [x] [🛠][1] [Circle/CI tests pass](https://docs.esmvaltool.org/en/latest/community/introduction.html#branches-pull-requests-and-code-review)
- [x] [🛠][1] [Codacy code quality checks pass](https://docs.esmvaltool.org/en/latest/community/introduction.html#branches-pull-requests-and-code-review)
- [ ] ~~[🛠][1] [Documentation builds successfully](https://docs.esmvaltool.org/en/latest/community/introduction.html#branches-pull-requests-and-code-review) on readthedocs~~

### New or updated [recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html):

- [ ]~~[🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added~~
- [ ]~~[🛠][1] New dependencies are added to the [project requirements]~~(https://docs.esmvaltool.org/en/latest/community/diagnostic.html#additional-dependencies)
- [x] [🧪][2] [Documentation](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#documentation) for the recipe/diagnostic clearly describes what it calculates from a scientific point of view
- [x] [🧪][2] Recipe runs successfully on [`@esmvalbot`](https://docs.esmvaltool.org/en/latest/community/introduction.html#running-tests) or some other machine without modification
- [x] [🧪][2] Figure(s)/data [look as expected](https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review)
- [x] [🧪][2] Code is [well documented](https://docs.esmvaltool.org/en/latest/community/introduction.html#what-should-be-documented) and scientifically sound

~~### New or updated [data reformatting script](https://docs.esmvaltool.org/en/latest/develop/dataset.html):~~

- [ ] [🛠][1] Dataset is added to the [table in the documentation](https://docs.esmvaltool.org/en/latest/community/dataset.html#dataset-documentation)
- [ ] [🛠][1] Documentation contains [instructions to obtain the data](https://docs.esmvaltool.org/en/latest/community/dataset.html#dataset-documentation)
- [ ] [🛠][1] [Tests for the CMORized data](https://docs.esmvaltool.org/en/latest/community/dataset.html#dataset-tests) are available
- [ ] [🧪][2] Numbers/units of the data look [physically meaningful](https://docs.esmvaltool.org/en/latest/community/dataset.html#cmorizer-output)
- [ ] [🛠][1] Data set is added to the [OBS data pool](https://docs.esmvaltool.org/en/latest/community/dataset.html#adding-your-dataset-to-the-obs-data-pool)
***

To help with the number pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->

[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review
