### PR TITLE
Avoid importing private ESMValCore functions in CMORizer

### DIFF
--- a/esmvaltool/cmorizers/obs/cmorize_obs.py
+++ b/esmvaltool/cmorizers/obs/cmorize_obs.py
@@ -21,8 +21,9 @@ import subprocess
 import time
 from pathlib import Path
 
-import esmvalcore.cmor
 import yaml
+
+import esmvalcore.cmor
 
 from .utilities import read_cmor_config
 

--- a/esmvaltool/cmorizers/obs/cmorize_obs.py
+++ b/esmvaltool/cmorizers/obs/cmorize_obs.py
@@ -15,14 +15,14 @@ import argparse
 import datetime
 import importlib
 import logging
+import numbers
 import os
 import subprocess
+import time
 from pathlib import Path
 
-import esmvalcore
-from esmvalcore._config import read_config_user_file
-from esmvalcore._config._logging import configure_logging
-from esmvalcore._task import write_ncl_settings
+import esmvalcore.cmor
+import yaml
 
 from .utilities import read_cmor_config
 
@@ -38,6 +38,179 @@ ______________________________________________________________________
 ______________________________________________________________________
 
 """ + __doc__
+
+
+def _normalize_path(path):
+    """Normalize paths.
+
+    Expand ~ character and environment variables and convert path to absolute.
+
+    Parameters
+    ----------
+    path: str
+        Original path
+
+    Returns
+    -------
+    str:
+        Normalized path
+    """
+    return os.path.abspath(os.path.expanduser(os.path.expandvars(path)))
+
+
+def read_config_user_file(config_file):
+    """Read config user file and store settings in a dictionary."""
+    config_file = _normalize_path(config_file)
+
+    # Check user config file
+    if not os.path.exists(config_file):
+        print(f"Config file {config_file} does not exist")
+
+    with open(config_file, 'r') as file:
+        cfg = yaml.safe_load(file)
+
+    for key in cfg['rootpath']:
+        root = cfg['rootpath'][key]
+        if isinstance(root, str):
+            cfg['rootpath'][key] = [_normalize_path(root)]
+        else:
+            cfg['rootpath'][key] = [_normalize_path(path) for path in root]
+
+    # insert a directory date_time_recipe_usertag in the output paths
+    now = datetime.datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    new_subdir = '_'.join(('cmorize_obs', now))
+    output_dir = _normalize_path(cfg.get('output_dir', 'esmvaltool_output'))
+
+    # set up create subdirectories
+    cfg['output_dir'] = os.path.join(output_dir, new_subdir)
+    cfg['work_dir'] = os.path.join(cfg['output_dir'], 'work')
+    cfg['run_dir'] = os.path.join(cfg['output_dir'], 'run')
+
+    return cfg
+
+
+def configure_logging(output_dir, log_level='INFO'):
+    """Configure logging.
+
+    Parameters
+    ----------
+    output_dir : str, optional
+        Output directory for the log files.
+    log_level : str, optional
+        If `None`, use the default (INFO).
+
+    """
+    fmt = '%(asctime)s UTC [%(process)d] %(levelname)-7s %(message)s'
+    debugfmt = ('%(asctime)s UTC [%(process)d] %(levelname)-7s '
+                '%(name)s:%(lineno)s %(message)s')
+
+    logging.Formatter.converter = time.gmtime
+    logging.captureWarnings(True)
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.DEBUG)
+
+    # Configure stdout
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(logging.Formatter(fmt))
+    console_handler.setLevel(log_level.upper())
+    root_logger.addHandler(console_handler)
+
+    # Create directory for log files
+    if not os.path.isdir(output_dir):
+        os.makedirs(output_dir)
+
+    # Configure main_log.txt
+    log_file = Path(output_dir) / 'main_log.txt'
+    log_handler = logging.FileHandler(log_file)
+    log_handler.setFormatter(logging.Formatter(fmt))
+    log_handler.setLevel(log_level.upper())
+    root_logger.addHandler(log_handler)
+
+    # Configure main_log_debug.txt
+    debug_file = Path(output_dir) / 'main_log_debug.txt'
+    debug_handler = logging.FileHandler(debug_file)
+    debug_handler.setFormatter(logging.Formatter(debugfmt))
+    debug_handler.setLevel(logging.DEBUG)
+    root_logger.addHandler(debug_handler)
+
+    # print header and info
+    logger.info(HEADER)
+    logger.info("Writing program log to:\n%s", log_file)
+    logger.info("Writing debug program log to:\n%s", debug_file)
+
+
+def _py2ncl(value, var_name=''):
+    """Format a structure of Python list/dict/etc items as NCL."""
+    txt = var_name + ' = ' if var_name else ''
+    if value is None:
+        txt += '_Missing'
+    elif isinstance(value, str):
+        txt += '"{}"'.format(value)
+    elif isinstance(value, (list, tuple)):
+        if not value:
+            txt += '_Missing'
+        else:
+            if isinstance(value[0], numbers.Real):
+                type_ = numbers.Real
+            else:
+                type_ = type(value[0])
+            if any(not isinstance(v, type_) for v in value):
+                raise ValueError(
+                    "NCL array cannot be mixed type: {}".format(value))
+            txt += '(/{}/)'.format(', '.join(_py2ncl(v) for v in value))
+    elif isinstance(value, dict):
+        if not var_name:
+            raise ValueError(
+                "NCL does not support nested dicts: {}".format(value))
+        txt += 'True\n'
+        for key in value:
+            txt += '{}@{} = {}\n'.format(var_name, key, _py2ncl(value[key]))
+    else:
+        txt += str(value)
+    return txt
+
+
+def write_ncl_settings(settings, filename, mode='wt'):
+    """Write a dictionary with generic settings to NCL file."""
+    logger.debug("Writing NCL configuration file %s", filename)
+
+    def _ncl_type(value):
+        """Convert some Python types to NCL types."""
+        typemap = {
+            bool: 'logical',
+            str: 'string',
+            float: 'double',
+            int: 'int64',
+            dict: 'logical',
+        }
+        for type_ in typemap:
+            if isinstance(value, type_):
+                return typemap[type_]
+        raise ValueError("Unable to map {} to an NCL type".format(type(value)))
+
+    lines = []
+    for var_name, value in sorted(settings.items()):
+        if isinstance(value, (list, tuple)):
+            # Create an NCL list that can span multiple files
+            lines.append('if (.not. isdefined("{var_name}")) then\n'
+                         '  {var_name} = NewList("fifo")\n'
+                         'end if\n'.format(var_name=var_name))
+            for item in value:
+                lines.append('ListAppend({var_name}, new(1, {type}))\n'
+                             'i = ListCount({var_name}) - 1'.format(
+                                 var_name=var_name, type=_ncl_type(item)))
+                lines.append(_py2ncl(item, var_name + '[i]'))
+        else:
+            # Create an NCL variable that overwrites previous variables
+            lines.append('if (isvar("{var_name}")) then\n'
+                         '  delete({var_name})\n'
+                         'end if\n'.format(var_name=var_name))
+            lines.append(_py2ncl(value, var_name))
+
+    with open(filename, mode) as file:
+        file.write('\n'.join(lines))
+        file.write('\n')
 
 
 def _assemble_datasets(raw_obs, obs_list):
@@ -95,8 +268,8 @@ def _write_ncl_settings(project_info, dataset, run_dir, reformat_script,
 def _run_ncl_script(in_dir, out_dir, run_dir, dataset, reformat_script,
                     log_level):
     """Run the NCL cmorization mechanism."""
-    logger.info("CMORizing dataset %s using NCL script %s",
-                dataset, reformat_script)
+    logger.info("CMORizing dataset %s using NCL script %s", dataset,
+                reformat_script)
     project = {}
     project[dataset] = {}
     project[dataset]['indir'] = in_dir
@@ -131,8 +304,8 @@ def _run_pyt_script(in_dir, out_dir, dataset, user_cfg):
     module_name = 'esmvaltool.cmorizers.obs.cmorize_obs_{}'.format(
         dataset.lower().replace("-", "_"))
     module = importlib.import_module(module_name)
-    logger.info("CMORizing dataset %s using Python script %s",
-                dataset, module.__file__)
+    logger.info("CMORizing dataset %s using Python script %s", dataset,
+                module.__file__)
     cmor_cfg = read_cmor_config(dataset)
     module.cmorization(in_dir, out_dir, cmor_cfg, user_cfg)
 
@@ -140,44 +313,28 @@ def _run_pyt_script(in_dir, out_dir, dataset, user_cfg):
 def main():
     """Run it as executable."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('-o',
-                        '--obs-list-cmorize',
-                        type=str,
-                        help='List of obs datasets to cmorize. \
-              If no list provided: CMORization of \
-              all datasets in RAWOBS; \
-              -o DATASET1,DATASET2... : \
-              for CMORization of select datasets.')
-    parser.add_argument('-c',
-                        '--config-file',
-                        default=os.path.join(os.path.dirname(__file__),
-                                             'config-user.yml'),
-                        help='Config file')
+    parser.add_argument(
+        '-o',
+        '--obs-list-cmorize',
+        type=str,
+        help=('List of obs datasets to cmorize. If no list provided: '
+              'CMORization of all datasets in RAWOBS; '
+              '-o DATASET1,DATASET2... : for CMORization of select datasets.'),
+    )
+    parser.add_argument(
+        '-c',
+        '--config-file',
+        default=str(Path.home() / '.esmvaltool' / 'config-user.yml'),
+        help=('ESMValTool configuration file '
+              '(default: ~/.esmvaltool/config-user.yml).'),
+    )
     args = parser.parse_args()
 
-    # get and read config file
-    config_file = os.path.abspath(
-        os.path.expandvars(os.path.expanduser(args.config_file)))
-
-    # Read user config file
-    if not os.path.exists(config_file):
-        logger.error("Config file %s does not exist", config_file)
-
     # read the file in
-    config_user = read_config_user_file(config_file, 'cmorize_obs', options={})
-
-    # set the run dir to hold the settings and log files
-    run_dir = os.path.join(config_user['output_dir'], 'run')
-    if not os.path.isdir(run_dir):
-        os.makedirs(run_dir)
+    config_user = read_config_user_file(args.config_file)
 
     # configure logging
-    log_files = configure_logging(
-        output_dir=run_dir, console_log_level=config_user['log_level'])
-    logger.info("Writing program log files to:\n%s", "\n".join(log_files))
-
-    # print header
-    logger.info(HEADER)
+    configure_logging(config_user['run_dir'], config_user['log_level'])
 
     # run
     timestamp1 = datetime.datetime.utcnow()
@@ -221,8 +378,7 @@ def _cmor_reformat(config, obs_list):
     # set the reformat scripts dir
     reformat_scripts = os.path.dirname(os.path.abspath(__file__))
     logger.info("Using cmorizer scripts repository: %s", reformat_scripts)
-    run_dir = os.path.join(config['output_dir'], 'run')
-    # datsets dictionary of Tier keys
+    # datasets dictionary of Tier keys
     datasets = _assemble_datasets(raw_obs, obs_list)
     if not datasets:
         logger.warning("Check input: could not find required %s in %s",
@@ -255,7 +411,7 @@ def _cmor_reformat(config, obs_list):
                 _run_ncl_script(
                     in_data_dir,
                     out_data_dir,
-                    run_dir,
+                    config['run_dir'],
                     dataset,
                     reformat_script,
                     config['log_level'],
@@ -265,10 +421,8 @@ def _cmor_reformat(config, obs_list):
             else:
                 logger.error('Could not find cmorizer for %s', dataset)
                 failed_datasets.append(dataset)
-                raise Exception(
-                    'Could not find cmorizers for %s datasets ' %
-                    ' '.join(failed_datasets)
-                )
+                raise Exception('Could not find cmorizers for %s datasets ' %
+                                ' '.join(failed_datasets))
 
 
 if __name__ == '__main__':

--- a/esmvaltool/cmorizers/obs/cmorize_obs_esacci_sst.py
+++ b/esmvaltool/cmorizers/obs/cmorize_obs_esacci_sst.py
@@ -38,7 +38,7 @@ import os
 
 import iris
 
-from esmvalcore.preprocessor._io import concatenate
+from esmvalcore.preprocessor import concatenate
 from .utilities import (convert_timeunits, fix_coords, fix_var_metadata,
                         save_variable, set_global_atts)
 

--- a/esmvaltool/diag_scripts/autoassess/land_surface_soilmoisture/soilmoisture.py
+++ b/esmvaltool/diag_scripts/autoassess/land_surface_soilmoisture/soilmoisture.py
@@ -4,7 +4,7 @@ import os
 import logging
 import numpy as np
 import iris
-from esmvalcore.preprocessor._regrid import regrid
+from esmvalcore.preprocessor import regrid
 from esmvaltool.diag_scripts.shared._supermeans import get_supermean
 
 

--- a/esmvaltool/diag_scripts/autoassess/land_surface_surfrad/surfrad.py
+++ b/esmvaltool/diag_scripts/autoassess/land_surface_surfrad/surfrad.py
@@ -6,7 +6,7 @@ import numpy as np
 
 import iris
 
-from esmvalcore.preprocessor._regrid import regrid
+from esmvalcore.preprocessor import regrid
 from esmvaltool.diag_scripts.shared._supermeans import get_supermean
 
 

--- a/esmvaltool/diag_scripts/cvdp/cvdp_wrapper.py
+++ b/esmvaltool/diag_scripts/cvdp/cvdp_wrapper.py
@@ -5,11 +5,14 @@ import re
 import shutil
 import subprocess
 
-from esmvalcore._task import DiagnosticError
 from esmvaltool.diag_scripts.shared import (group_metadata, run_diagnostic)
 from esmvaltool.diag_scripts.shared import ProvenanceLogger
 
 logger = logging.getLogger(os.path.basename(__file__))
+
+
+class DiagnosticError(Exception):
+    """Error in diagnostic."""
 
 
 def setup_driver(cfg):


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this PR makes
    ESMValTool better and what problem it solves.

    Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/en/latest/community/introduction.html).

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

This pull requests avoids importing private `esmvalcore` functions which have been moved and renamed recently. This fixes problems with running the CMORizer being unable to find the `read_config_user` and `configure_logging` functions.

- Fixes part of #1975

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValTool/issues) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the PR is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

- [x] [🛠][1] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/en/latest/community/introduction.html#branches-pull-requests-and-code-review)
- [ ] [🛠][1] Code follows the [style guide](https://docs.esmvaltool.org/en/latest/community/introduction.html#code-style)
- [ ] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/introduction.html#documentation) is available
- [ ] [🛠][1] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/en/latest/community/introduction.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/en/latest/community/introduction.html#yaml) checks
- [ ] [🛠][1] [Circle/CI tests pass](https://docs.esmvaltool.org/en/latest/community/introduction.html#branches-pull-requests-and-code-review)
- [ ] [🛠][1] [Codacy code quality checks pass](https://docs.esmvaltool.org/en/latest/community/introduction.html#branches-pull-requests-and-code-review)
- [ ] [🛠][1] [Documentation builds successfully](https://docs.esmvaltool.org/en/latest/community/introduction.html#branches-pull-requests-and-code-review) on readthedocs

***

To help with the number pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->

[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review
