### PR TITLE
introduce python 39 in Github Actions tests

### DIFF
--- a/.github/workflows/action-conda-build.yml
+++ b/.github/workflows/action-conda-build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
     - master
+    - ga_python39
   schedule:
     - cron: '0 0 * * *'
 
@@ -13,7 +14,7 @@ jobs:
     runs-on: "ubuntu-latest"  # use only Linux for conda build
     strategy:
       matrix:
-        python-version: [3.8]  # use only the latest for conda build
+        python-version: [3.9]  # use only the latest for conda build
       fail-fast: false
     name: Linux Python ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/action-conda-build.yml
+++ b/.github/workflows/action-conda-build.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
     - master
-    - ga_python39
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/action-conda-publish.yml
+++ b/.github/workflows/action-conda-publish.yml
@@ -7,18 +7,19 @@ on:
   push:
     branches:
       - master
+      - ga_python39
 
 jobs:
 
   publish:
-    name: publish / python-3.8 / ubuntu-latest
+    name: publish / python-3.9 / ubuntu-latest
     runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: "3.8"
+          python-version: "3.9"
           miniconda-version: "latest"
           channels: conda-forge
       - name: Show conda config
@@ -59,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest']  # may extent to osx in the future
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
     runs-on: ${{ matrix.os }}
     needs: publish
     steps:

--- a/.github/workflows/action-conda-publish.yml
+++ b/.github/workflows/action-conda-publish.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - master
-      - ga_python39
 
 jobs:
 

--- a/.github/workflows/action-install-from-conda.yml
+++ b/.github/workflows/action-install-from-conda.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
     - master
-    - ga_python39
   schedule:
     - cron: '0 4 * * *'
 

--- a/.github/workflows/action-install-from-conda.yml
+++ b/.github/workflows/action-install-from-conda.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
     - master
-    - github-actions2  # testing branch
+    - ga_python39
   schedule:
     - cron: '0 4 * * *'
 
@@ -14,7 +14,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
       # fail-fast set to False allows all other tests
       # in the worflow to run regardless of any fail
       fail-fast: false

--- a/.github/workflows/action-install-from-source.yml
+++ b/.github/workflows/action-install-from-source.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
     - master
-    - github-actions2  # testing branch
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/action-install-from-source.yml
+++ b/.github/workflows/action-install-from-source.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
       fail-fast: false
     name: Linux Python ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/action-pypi-build-and-deploy.yml
+++ b/.github/workflows/action-pypi-build-and-deploy.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+      - ga_python39
 
 jobs:
   build-n-publish:
@@ -17,7 +18,7 @@ jobs:
       - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install pep517
         run: >-
           python -m

--- a/.github/workflows/action-pypi-build-and-deploy.yml
+++ b/.github/workflows/action-pypi-build-and-deploy.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - master
-      - ga_python39
 
 jobs:
   build-n-publish:

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
     - master
-    - github-actions2  # testing branch
+    - ga_python39
   schedule:
     - cron: '0 0 * * *'
 
@@ -14,7 +14,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
       fail-fast: false
     name: Linux Python ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
     - master
-    - ga_python39
   schedule:
     - cron: '0 0 * * *'
 


### PR DESCRIPTION
OK gents, moving forward with Python 3.9 - introducing it as base version for them Github Action tests - good news is that the only failing test is the obviously meant to fail one, the one that installs esmvaltool from conda in a Python 3.9 environment (since we've not released and deployed the package with 3.9 yet), so please have a looksee and approve the PR, then I will proceed to removing the test branch from the workflow files and only keep `master` and then merge :+1: 