### PR TITLE
fix flake8 raised by develop test in cmorize_obs_gpcc.py

### DIFF
--- a/esmvaltool/cmorizers/obs/cmorize_obs_gpcc.py
+++ b/esmvaltool/cmorizers/obs/cmorize_obs_gpcc.py
@@ -160,7 +160,7 @@ def _extract_variable(short_name, var, version, cfg, filepath, out_dir):
 
     # Save variable
     attrs = copy.deepcopy(cfg['attributes'])
-    attrs.update({'comment': 'contrained on gridpoint values beeing based on'\
+    attrs.update({'comment': 'constrained on gridpoint values beeing based on'
                              'at least 1 station',
                   'version': attrs['version'] + '-numgauge1'})
     attrs['mip'] = var['mip']


### PR DESCRIPTION
This thing was not a flake8 error but a Codacy warning in the original PR, but now makes the develop test fail on master, introduced in #1995 