### PR TITLE
reintroduce basic python test to run at all commit times on CI machine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
             conda env export > /logs/environment.yml
             pip freeze > /logs/requirements.txt
             # Test installation
-            pytest -n 2
+            pytest -n 2 -m "not installation"
             esmvaltool -h
             ncl -V
             cdo --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,6 +297,7 @@ workflows:
       - develop
       - documentation
       - conda_build
+      - python_test
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,35 @@ jobs:
       - store_artifacts:
           path: /logs
 
+  python_test:
+    # Run the basic Python test suite
+    working_directory: /python_test
+    docker:
+      - image: continuumio/miniconda3
+    steps:
+      - checkout
+      - run:
+          command: |
+            . /opt/conda/etc/profile.d/conda.sh
+            set -x
+            mkdir /logs
+            # Install just the Python bit
+            conda env create -n esmvaltool -f environment.yml >> /logs/conda.txt 2>&1
+            set +x; conda activate esmvaltool; set -x
+            pip install -e .[develop] > /logs/install.txt 2>&1
+            # Log versions
+            dpkg -l > /logs/versions.txt
+            conda env export > /logs/environment.yml
+            pip freeze > /logs/requirements.txt
+            # Test installation
+            pytest -n 2
+            esmvaltool -h
+            ncl -V
+            cdo --version
+          no_output_timeout: 30m
+      - store_artifacts:
+          path: /logs
+
   documentation:
     # Test building documentation
     working_directory: /doc


### PR DESCRIPTION
Closes #2049 

I am open for discussion about this but we need to get some basic testing on current branches done before the merge. I would advocate not only the Flake tests but full Python test suite, if the issues are with R or Julia, so be it, but at least the Python bit needs a one-through