### PR TITLE
Force latest Python in empty environment in conda install CI test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,8 +267,6 @@ workflows:
       - develop
       - documentation
       - conda_build
-      - conda_install  # just for testing now
-
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,8 +221,8 @@ jobs:
             tar xfz julia-*-linux-x86_64.tar.gz
             ln -s $(pwd)/julia-*/bin/julia /usr/bin/julia
             # conda update -y conda > /logs/conda.txt 2>&1
-            # Create and activate conda environment
-            conda create -y --name esmvaltool
+            # Create and activate conda environment; install latest python in it
+            conda create -y --name esmvaltool python=3.9.2 -c conda-forge
             set +x; conda activate esmvaltool; set -x
             # Install
             conda install -y esmvaltool -c conda-forge -c esmvalgroup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,7 +268,6 @@ workflows:
       - develop
       - documentation
       - conda_build
-      - conda_install  # temporary for testing only 
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
             ln -s $(pwd)/julia-*/bin/julia /usr/bin/julia
             # conda update -y conda > /logs/conda.txt 2>&1
             # Create and activate conda environment; install latest python in it
-            conda create -y --name esmvaltool python=3.9.2 -c conda-forge
+            conda create -y --name esmvaltool python=3.9 -c conda-forge
             set +x; conda activate esmvaltool; set -x
             # Install
             conda install -y esmvaltool -c conda-forge -c esmvalgroup
@@ -268,6 +268,7 @@ workflows:
       - develop
       - documentation
       - conda_build
+      - conda_install  # just for testing now
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,6 +268,8 @@ workflows:
       - develop
       - documentation
       - conda_build
+      - conda_install  # temporary for testing only 
+
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,11 +221,10 @@ jobs:
             tar xfz julia-*-linux-x86_64.tar.gz
             ln -s $(pwd)/julia-*/bin/julia /usr/bin/julia
             # conda update -y conda > /logs/conda.txt 2>&1
-            # Create and activate conda environment; install latest python in it
-            conda create -y --name esmvaltool python=3.9 -c conda-forge
+            # Install ESMValTool in a new conda environment
+            conda create -y --name esmvaltool -c esmvalgroup -c conda-forge esmvaltool 'python=3.9'
+            # Activate the environment
             set +x; conda activate esmvaltool; set -x
-            # Install
-            conda install -y esmvaltool -c conda-forge -c esmvalgroup
             # Log versions
             conda env export > /logs/environment.yml
             # Test installation

--- a/doc/sphinx/source/quickstart/installation.rst
+++ b/doc/sphinx/source/quickstart/installation.rst
@@ -90,13 +90,17 @@ Once you have installed the above prerequisites, you can install ESMValTool by r
 
 .. code-block:: bash
 
-    conda create --name esmvaltool -c esmvalgroup -c conda-forge esmvaltool python=3.9
+    conda create --name esmvaltool -c esmvalgroup -c conda-forge esmvaltool 'python=3.9'
 
 Here ``conda`` is the executable calling the Conda package manager to install
 ``esmvaltool`` and the ``-c`` flag specifies the Conda software channels in which the
-``esmvaltool`` package and its dependencies can be found. The reason why we are also installing
-``python=3.9`` is that the environment ``esmvaltool`` is initially created with a very old
-``python=2.7`` and this will either stop or make the environment solving process extremely slow.
+``esmvaltool`` package and its dependencies can be found.
+The reason why we are also specifying ``python=3.9`` is that it will make it
+easier for conda to find a working combination of all required packages, see
+`Conda fails to solve the environment`_ in `common installation issues`_ for an
+in-depth explanation.
+Python 3.7 and 3.8 are also supported, in case you prefer to work with an older
+version of Python.
 
 This will create a new
 `Conda environment <https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-environments>`_

--- a/doc/sphinx/source/quickstart/installation.rst
+++ b/doc/sphinx/source/quickstart/installation.rst
@@ -90,15 +90,13 @@ Once you have installed the above prerequisites, you can install ESMValTool by r
 
 .. code-block:: bash
 
-    conda create --name esmvaltool -c esmvalgroup -c conda-forge esmvaltool python=3.9.2
+    conda create --name esmvaltool -c esmvalgroup -c conda-forge esmvaltool python=3.9
 
 Here ``conda`` is the executable calling the Conda package manager to install
 ``esmvaltool`` and the ``-c`` flag specifies the Conda software channels in which the
 ``esmvaltool`` package and its dependencies can be found. The reason why we are also installing
-``python=3.9.2`` is that the environment ``esmvaltool`` is initially created with a very old
-``python=2.7`` and this will either stop or make the environment solving process extremely slow
-(at the time of this writing Python's latest stable version is 3.9.2, update to the latest stable version
-in the future).
+``python=3.9`` is that the environment ``esmvaltool`` is initially created with a very old
+``python=2.7`` and this will either stop or make the environment solving process extremely slow.
 
 This will create a new
 `Conda environment <https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-environments>`_

--- a/doc/sphinx/source/quickstart/installation.rst
+++ b/doc/sphinx/source/quickstart/installation.rst
@@ -90,11 +90,15 @@ Once you have installed the above prerequisites, you can install ESMValTool by r
 
 .. code-block:: bash
 
-    conda create --name esmvaltool -c esmvalgroup -c conda-forge esmvaltool
+    conda create --name esmvaltool -c esmvalgroup -c conda-forge esmvaltool python=3.9.2
 
 Here ``conda`` is the executable calling the Conda package manager to install
 ``esmvaltool`` and the ``-c`` flag specifies the Conda software channels in which the
-``esmvaltool`` package and its dependencies can be found.
+``esmvaltool`` package and its dependencies can be found. The reason why we are also installing
+``python=3.9.2`` is that the environment ``esmvaltool`` is initially created with a very old
+``python=2.7`` and this will either stop or make the environment solving process extremely slow
+(at the time of this writing Python's latest stable version is 3.9.2, update to the latest stable version
+in the future).
 
 This will create a new
 `Conda environment <https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-environments>`_


### PR DESCRIPTION
Closes #2063 

Currently testing on me machine, env still solving but at least memory doesn't go up the roof anymore and stays stable at ~1.6GB
**UPDATE** after some 12min the darn thing solves and the installation goes ahead!

I think I know why we were getting hit badly - the Python version that comes in the empty environment right before installing esmvaltool is Python=2.7 (really, conda?)