### PR TITLE
Removed imports from private sklearn modules and improved test coverage of custom_sklearn.py

### DIFF
--- a/esmvaltool/diag_scripts/mlr/custom_sklearn.py
+++ b/esmvaltool/diag_scripts/mlr/custom_sklearn.py
@@ -1065,6 +1065,6 @@ class FeatureSelectionTransformer(BaseEstimator, SelectorMixin):
 
     def _more_tags(self):
         """Additional estimator tags."""
-        more_tags = _DEFAULT_TAGS
+        more_tags = deepcopy(_DEFAULT_TAGS)
         more_tags['allow_nan'] = True
         return more_tags

--- a/esmvaltool/diag_scripts/mlr/custom_sklearn.py
+++ b/esmvaltool/diag_scripts/mlr/custom_sklearn.py
@@ -731,9 +731,9 @@ class AdvancedRFE(RFE):
             except (AttributeError, KeyError):
                 coefs = getattr(estimator, 'feature_importances_', None)
             if coefs is None:
-                raise RuntimeError('The classifier does not expose '
-                                   '"coef_" or "feature_importances_" '
-                                   'attributes')
+                raise RuntimeError("The classifier does not expose "
+                                   "'coef_' or 'feature_importances_' "
+                                   "attributes")
 
             # Get ranks
             if coefs.ndim > 1:

--- a/esmvaltool/diag_scripts/mlr/custom_sklearn.py
+++ b/esmvaltool/diag_scripts/mlr/custom_sklearn.py
@@ -814,7 +814,8 @@ class AdvancedRFECV(AdvancedRFE):
             force_all_finite=False)
 
         # Initialization
-        cv = check_cv(self.cv, y_data, is_classifier(self.estimator))
+        cv = check_cv(self.cv, y_data,
+                      classifier=is_classifier(self.estimator))
         scorer = check_scoring(self.estimator, scoring=self.scoring)
         n_features = x_data.shape[1]
 

--- a/esmvaltool/diag_scripts/mlr/custom_sklearn.py
+++ b/esmvaltool/diag_scripts/mlr/custom_sklearn.py
@@ -8,8 +8,39 @@ functionalities of the :ref:`MLR module <api.esmvaltool.diag_scripts.mlr>`. As
 long-term goal we would like to include these functionalities to the
 :mod:`sklearn` package since we believe these additions might be helpful for
 everyone. This module serves as interim solution. To ensure that all features
-are properly working this module is also covered by tests, which will also be
-expanded in the future.
+are properly working this module is also covered by extensive tests.
+
+Parts of this code have been copied from :mod:`sklearn`.
+
+License: BSD 3-Clause License
+
+Copyright (c) 2007-2020 The scikit-learn developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """
 
@@ -20,61 +51,320 @@ expanded in the future.
 # pylint: disable=too-many-arguments
 # pylint: disable=too-many-instance-attributes
 # pylint: disable=too-many-locals
+# pylint: disable=too-many-return-statements
 
 import itertools
 import logging
 import numbers
 import os
-import time
 import warnings
 from contextlib import suppress
 from copy import deepcopy
 from inspect import getfullargspec
-from traceback import format_exception_only
+from traceback import format_exc
 
 import numpy as np
+import scipy.sparse as sp
 from joblib import Parallel, delayed, effective_n_jobs
 from sklearn.base import BaseEstimator, clone, is_classifier
 from sklearn.compose import ColumnTransformer, TransformedTargetRegressor
 from sklearn.exceptions import FitFailedWarning, NotFittedError
-from sklearn.feature_selection import RFE
-from sklearn.feature_selection._base import SelectorMixin
+from sklearn.feature_selection import RFE, SelectorMixin
 from sklearn.linear_model import LinearRegression
 from sklearn.metrics import check_scoring
-from sklearn.metrics._scorer import (
-    _check_multimetric_scoring,
-    _MultimetricScorer,
-)
 from sklearn.model_selection import check_cv
-from sklearn.model_selection._validation import _aggregate_score_dicts, _score
 from sklearn.pipeline import Pipeline
-from sklearn.utils import (
-    _message_with_time,
-    check_array,
-    check_X_y,
-    indexable,
-    safe_sqr,
-)
-from sklearn.utils.metaestimators import _safe_split, if_delegate_has_method
-from sklearn.utils.validation import _check_fit_params, check_is_fitted
+from sklearn.preprocessing import FunctionTransformer
+from sklearn.utils import check_array, check_X_y, indexable, safe_sqr
+from sklearn.utils.fixes import np_version, parse_version
+from sklearn.utils.metaestimators import if_delegate_has_method
+from sklearn.utils.validation import check_is_fitted
 
 from esmvaltool.diag_scripts import mlr
 
 logger = logging.getLogger(os.path.basename(__file__))
 
 
-def _fit_and_score_weighted(estimator, x_data, y_data, scorer, train, test,
-                            verbose, parameters, fit_params,
-                            error_score=np.nan, sample_weights=None):
-    """Expand :func:`sklearn.model_selection._validation._fit_and_score`."""
-    if verbose > 1:
-        if parameters is None:
-            msg = ''
-        else:
-            msg = '%s' % (', '.join('%s=%s' % (k, v)
-                                    for k, v in parameters.items()))
-        print("[CV] %s %s" % (msg, (64 - len(msg)) * '.'))
+_DEFAULT_TAGS = {
+    'non_deterministic': False,
+    'requires_positive_X': False,
+    'requires_positive_y': False,
+    'X_types': ['2darray'],
+    'poor_score': False,
+    'no_validation': False,
+    'multioutput': False,
+    "allow_nan": False,
+    'stateless': False,
+    'multilabel': False,
+    '_skip_test': False,
+    '_xfail_checks': False,
+    'multioutput_only': False,
+    'binary_only': False,
+    'requires_fit': True,
+    'preserves_dtype': [np.float64],
+    'requires_y': False,
+    'pairwise': False,
+}
 
+
+def _determine_key_type(key, accept_slice=True):
+    """Determine the data type of key."""
+    err_msg = ("No valid specification of the columns. Only a scalar, list or "
+               "slice of all integers or all strings, or boolean mask is "
+               "allowed")
+
+    dtype_to_str = {int: 'int', str: 'str', bool: 'bool', np.bool_: 'bool'}
+    array_dtype_to_str = {'i': 'int', 'u': 'int', 'b': 'bool', 'O': 'str',
+                          'U': 'str', 'S': 'str'}
+
+    if key is None:
+        return None
+    if isinstance(key, tuple(dtype_to_str.keys())):
+        try:
+            return dtype_to_str[type(key)]
+        except KeyError:
+            raise ValueError(err_msg)
+    if isinstance(key, slice):
+        if not accept_slice:
+            raise TypeError(
+                'Only array-like or scalar are supported. '
+                'A Python slice was given.'
+            )
+        if key.start is None and key.stop is None:
+            return None
+        key_start_type = _determine_key_type(key.start)
+        key_stop_type = _determine_key_type(key.stop)
+        if key_start_type is not None and key_stop_type is not None:
+            if key_start_type != key_stop_type:
+                raise ValueError(err_msg)
+        if key_start_type is not None:
+            return key_start_type
+        return key_stop_type
+    if isinstance(key, (list, tuple)):
+        unique_key = set(key)
+        key_type = {_determine_key_type(elt) for elt in unique_key}
+        if not key_type:
+            return None
+        if len(key_type) != 1:
+            raise ValueError(err_msg)
+        return key_type.pop()
+    if hasattr(key, 'dtype'):
+        try:
+            return array_dtype_to_str[key.dtype.kind]
+        except KeyError:
+            raise ValueError(err_msg)
+    raise ValueError(err_msg)
+
+
+def _array_indexing(array, key, key_dtype, axis):
+    """Index an array or scipy.sparse consistently across numpy version."""
+    if np_version < parse_version('1.12') or sp.issparse(array):
+        if key_dtype == 'bool':
+            key = np.asarray(key)
+    if isinstance(key, tuple):
+        key = list(key)
+    return array[key] if axis == 0 else array[:, key]
+
+
+def _list_indexing(x_data, key, key_dtype):
+    """Index a python list."""
+    if np.isscalar(key) or isinstance(key, slice):
+        # key is a slice or a scalar
+        return x_data[key]
+    if key_dtype == 'bool':
+        # key is a boolean array-like
+        return list(itertools.compress(x_data, key))
+    # key is a integer array-like of key
+    return [x_data[idx] for idx in key]
+
+
+def _pandas_indexing(x_data, key, key_dtype, axis):
+    """Index a pandas dataframe or a series."""
+    if hasattr(key, 'shape'):
+        key = np.asarray(key)
+        key = key if key.flags.writeable else key.copy()
+    elif isinstance(key, tuple):
+        key = list(key)
+    # check whether we should index with loc or iloc
+    indexer = x_data.iloc if key_dtype == 'int' else x_data.loc
+    return indexer[:, key] if axis else indexer[key]
+
+
+def _safe_indexing(x_data, indices, *_, axis=0):
+    """Return rows, items or columns of x_data using indices."""
+    if indices is None:
+        return x_data
+
+    if axis not in (0, 1):
+        raise ValueError(
+            "'axis' should be either 0 (to index rows) or 1 (to index "
+            "column). Got {} instead.".format(axis)
+        )
+
+    indices_dtype = _determine_key_type(indices)
+
+    if axis == 0 and indices_dtype == 'str':
+        raise ValueError(
+            "String indexing is not supported with 'axis=0'"
+        )
+
+    if axis == 1 and x_data.ndim != 2:
+        raise ValueError(
+            "'x_data' should be a 2D NumPy array, 2D sparse matrix or pandas "
+            "dataframe when indexing the columns (i.e. 'axis=1'). "
+            "Got {} instead with {} dimension(s).".format(type(x_data),
+                                                          x_data.ndim)
+        )
+
+    if axis == 1 and indices_dtype == 'str' and not hasattr(x_data, 'loc'):
+        raise ValueError(
+            "Specifying the columns using strings is only supported for "
+            "pandas DataFrames"
+        )
+
+    if hasattr(x_data, "iloc"):
+        return _pandas_indexing(x_data, indices, indices_dtype, axis=axis)
+    if hasattr(x_data, "shape"):
+        return _array_indexing(x_data, indices, indices_dtype, axis=axis)
+    return _list_indexing(x_data, indices, indices_dtype)
+
+
+def _is_arraylike(input_array):
+    """Check whether the input is array-like."""
+    return (hasattr(input_array, '__len__') or
+            hasattr(input_array, 'shape') or
+            hasattr(input_array, '__array__'))
+
+
+def _make_indexable(iterable):
+    """Ensure iterable supports indexing or convert to an indexable variant."""
+    if sp.issparse(iterable):
+        return iterable.tocsr()
+    if hasattr(iterable, "__getitem__") or hasattr(iterable, "iloc"):
+        return iterable
+    if iterable is None:
+        return iterable
+    return np.array(iterable)
+
+
+def _num_samples(x_data):
+    """Return number of samples in array-like x_data."""
+    message = 'Expected sequence or array-like, got %s' % type(x_data)
+    if hasattr(x_data, 'fit') and callable(x_data.fit):
+        # Don't get num_samples from an ensembles length!
+        raise TypeError(message)
+
+    if not hasattr(x_data, '__len__') and not hasattr(x_data, 'shape'):
+        if hasattr(x_data, '__array__'):
+            x_data = np.asarray(x_data)
+        else:
+            raise TypeError(message)
+
+    if hasattr(x_data, 'shape') and x_data.shape is not None:
+        if len(x_data.shape) == 0:
+            raise TypeError("Singleton array %r cannot be considered a valid "
+                            "collection." % x_data)
+        # Check that shape is returning an integer or default to len
+        # Dask dataframes may not return numeric shape[0] value
+        if isinstance(x_data.shape[0], numbers.Integral):
+            return x_data.shape[0]
+
+    try:
+        return len(x_data)
+    except TypeError as type_error:
+        raise TypeError(message) from type_error
+
+
+def _check_fit_params(x_data, fit_params, indices=None):
+    """Check and validate the parameters passed during ``fit``."""
+    fit_params_validated = {}
+    for param_key, param_value in fit_params.items():
+        if (not _is_arraylike(param_value) or
+                _num_samples(param_value) != _num_samples(x_data)):
+            # Non-indexable pass-through (for now for backward-compatibility).
+            # https://github.com/scikit-learn/scikit-learn/issues/15805
+            fit_params_validated[param_key] = param_value
+        else:
+            # Any other fit_params should support indexing
+            # (e.g. for cross-validation).
+            fit_params_validated[param_key] = _make_indexable(param_value)
+            fit_params_validated[param_key] = _safe_indexing(
+                fit_params_validated[param_key], indices
+            )
+
+    return fit_params_validated
+
+
+def _safe_tags(estimator, key=None):
+    """Safely get estimator tags."""
+    if hasattr(estimator, "_get_tags"):
+        tags_provider = "_get_tags()"
+        tags = estimator._get_tags()
+    elif hasattr(estimator, "_more_tags"):
+        tags_provider = "_more_tags()"
+        tags = {**_DEFAULT_TAGS, **estimator._more_tags()}
+    else:
+        tags_provider = "_DEFAULT_TAGS"
+        tags = _DEFAULT_TAGS
+
+    if key is not None:
+        if key not in tags:
+            raise ValueError(
+                f"The key {key} is not defined in {tags_provider} for the "
+                f"class {estimator.__class__.__name__}."
+            )
+        return tags[key]
+    return tags
+
+
+def _is_pairwise(estimator):
+    """Return ``True`` if estimator is pairwise."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', category=FutureWarning)
+        has_pairwise_attribute = hasattr(estimator, '_pairwise')
+        pairwise_attribute = getattr(estimator, '_pairwise', False)
+    pairwise_tag = _safe_tags(estimator, key="pairwise")
+
+    if has_pairwise_attribute:
+        if pairwise_attribute != pairwise_tag:
+            warnings.warn(
+                "_pairwise attribute is inconsistent with tags. Set the "
+                "estimator tags of your estimator instead", FutureWarning,
+            )
+        return pairwise_attribute
+
+    # Use pairwise tag when the attribute is not present
+    return pairwise_tag
+
+
+def _safe_split(estimator, x_data, y_data, indices, train_indices=None):
+    """Create subset of dataset and properly handle kernels."""
+    if _is_pairwise(estimator):
+        if not hasattr(x_data, "shape"):
+            raise ValueError("Precomputed kernels or affinity matrices have "
+                             "to be passed as arrays or sparse matrices.")
+        # x_data is a precomputed square kernel matrix
+        if x_data.shape[0] != x_data.shape[1]:
+            raise ValueError("x_data should be a square kernel matrix")
+        if train_indices is None:
+            x_subset = x_data[np.ix_(indices, indices)]
+        else:
+            x_subset = x_data[np.ix_(indices, train_indices)]
+    else:
+        x_subset = _safe_indexing(x_data, indices)
+
+    if y_data is not None:
+        y_subset = _safe_indexing(y_data, indices)
+    else:
+        y_subset = None
+
+    return (x_subset, y_subset)
+
+
+def _fit_and_score_weighted(estimator, x_data, y_data, scorer, train, test,
+                            parameters, fit_params, error_score=np.nan,
+                            sample_weights=None):
+    """Expand :func:`sklearn.model_selection._validation._fit_and_score`."""
     # Adjust length of sample weights
     fit_params = fit_params if fit_params is not None else {}
     fit_params = _check_fit_params(x_data, fit_params, train)
@@ -89,10 +379,8 @@ def _fit_and_score_weighted(estimator, x_data, y_data, scorer, train, test,
 
         estimator = estimator.set_params(**cloned_parameters)
 
-    start_time = time.time()
-
-    x_train, y_train = _safe_split(estimator, x_data, y_data, train)
-    x_test, y_test = _safe_split(estimator, x_data, y_data, test, train)
+    (x_train, y_train) = _safe_split(estimator, x_data, y_data, train)
+    (x_test, y_test) = _safe_split(estimator, x_data, y_data, test, train)
     if sample_weights is not None:
         sample_weights_test = sample_weights[test]
     else:
@@ -103,48 +391,24 @@ def _fit_and_score_weighted(estimator, x_data, y_data, scorer, train, test,
             estimator.fit(x_train, **fit_params)
         else:
             estimator.fit(x_train, y_train, **fit_params)
-
-    except Exception as exc:
-        # Note fit time as time until error
-        fit_time = time.time() - start_time
-        score_time = 0.0
+    except Exception:
         if error_score == 'raise':
             raise
         if isinstance(error_score, numbers.Number):
-            if isinstance(scorer, dict):
-                test_scores = {name: error_score for name in scorer}
-            else:
-                test_scores = error_score
-            warnings.warn("Estimator fit failed. The score on this train-test"
-                          " partition for these parameters will be set to %f. "
-                          "Details: \n%s" %
-                          (error_score, format_exception_only(type(exc),
-                                                              exc)[0]),
+            test_score = error_score
+            warnings.warn("Estimator fit failed. The score on this train-test "
+                          "partition for these parameters will be set to %f. "
+                          "Details: \n%s" % (error_score, format_exc()),
                           FitFailedWarning)
         else:
-            raise ValueError("error_score must be the string 'raise' or a"
-                             " numeric value. (Hint: if using 'raise', please"
-                             " make sure that it has been spelled correctly.)")
-
+            raise ValueError("error_score must be the string 'raise' or a "
+                             "numeric value. (Hint: if using 'raise', please "
+                             "make sure that it has been spelled correctly.)")
     else:
-        fit_time = time.time() - start_time
-        test_scores = _score_weighted(estimator, x_test, y_test, scorer,
-                                      sample_weights=sample_weights_test)
-        score_time = time.time() - start_time - fit_time
-    if verbose > 2:
-        if isinstance(test_scores, dict):
-            for scorer_name in sorted(test_scores):
-                msg += ", %s=" % scorer_name
-                msg += "%.3f" % test_scores[scorer_name]
-        else:
-            msg += ", score="
-            msg += "%.3f" % test_scores
+        test_score = _score_weighted(estimator, x_test, y_test, scorer,
+                                     sample_weights=sample_weights_test)
 
-    if verbose > 1:
-        total_time = score_time + fit_time
-        print(_message_with_time('CV', msg, total_time))
-
-    return [test_scores]
+    return test_score
 
 
 def _get_fit_parameters(fit_kwargs, steps, cls):
@@ -167,6 +431,53 @@ def _get_fit_parameters(fit_kwargs, steps, cls):
     return params
 
 
+def _score_weighted(estimator, x_test, y_test, scorer, sample_weights=None):
+    """Expand :func:`sklearn.model_selection._validation._score`."""
+    if y_test is None:
+        score = scorer(estimator, x_test, sample_weight=sample_weights)
+    else:
+        score = scorer(estimator, x_test, y_test, sample_weight=sample_weights)
+
+    error_msg = ("Scoring must return a number, got %s (%s) instead. "
+                 "(scorer=%s)")
+    if hasattr(score, 'item'):
+        with suppress(ValueError):
+            # e.g. unwrap memmapped scalars
+            score = score.item()
+    if not isinstance(score, numbers.Number):
+        raise ValueError(error_msg % (score, type(score), scorer))
+    return score
+
+
+def _split_fit_kwargs(fit_kwargs, train_idx, test_idx):
+    """Get split fit kwargs for single CV step."""
+    fit_kwargs_train = {}
+    fit_kwargs_test = {}
+    for (key, val) in fit_kwargs.items():
+        if 'sample_weight' in key and 'sample_weight_eval_set' not in key:
+            fit_kwargs_train[key] = deepcopy(val)[train_idx]
+            fit_kwargs_test[key] = deepcopy(val)[test_idx]
+        else:
+            fit_kwargs_train[key] = deepcopy(val)
+            fit_kwargs_test[key] = deepcopy(val)
+    return (fit_kwargs_train, fit_kwargs_test)
+
+
+def _rfe_single_fit(rfe, estimator, x_data, y_data, train, test, scorer,
+                    **fit_kwargs):
+    """Return the score for a fit across one fold."""
+    (x_train, y_train) = _safe_split(estimator, x_data, y_data, train)
+    (x_test, y_test) = _safe_split(estimator, x_data, y_data, test, train)
+    (fit_kwargs_train, _) = _split_fit_kwargs(fit_kwargs, train, test)
+
+    def step_score(estimator, features):
+        """Score for a single step in the recursive feature elimination."""
+        return _score_weighted(estimator, x_test[:, features], y_test, scorer)
+
+    return rfe._fit(x_train, y_train, step_score=step_score,
+                    **fit_kwargs_train).scores_
+
+
 def _map_features(features, support):
     """Map old features indices to new ones using boolean mask."""
     feature_mapping = {}
@@ -184,67 +495,6 @@ def _map_features(features, support):
         if new_feature is not None:
             new_features.append(new_feature)
     return new_features
-
-
-def _rfe_single_fit(rfe, estimator, x_data, y_data, train, test, scorer,
-                    **fit_kwargs):
-    """Return the score for a fit across one fold."""
-    (x_train, y_train) = _safe_split(estimator, x_data, y_data, train)
-    (x_test, y_test) = _safe_split(estimator, x_data, y_data, test, train)
-    (fit_kwargs_train, _) = _split_fit_kwargs(fit_kwargs, train, test)
-
-    def step_score(estimator, features):
-        """Score for a single step in the recursive feature elimination."""
-        return _score(estimator, x_test[:, features], y_test, scorer)
-
-    return rfe._fit(x_train, y_train, step_score=step_score,
-                    **fit_kwargs_train).scores_
-
-
-def _score_weighted(estimator, x_test, y_test, scorer, sample_weights=None):
-    """Expand :func:`sklearn.model_selection._validation._score`."""
-    if isinstance(scorer, dict):
-        # will cache method calls if needed. scorer() returns a dict
-        scorer = _MultimetricScorer(**scorer)
-    if y_test is None:
-        scores = scorer(estimator, x_test, sample_weight=sample_weights)
-    else:
-        scores = scorer(estimator, x_test, y_test,
-                        sample_weight=sample_weights)
-
-    error_msg = ("scoring must return a number, got %s (%s) "
-                 "instead. (scorer=%s)")
-    if isinstance(scores, dict):
-        for name, score in scores.items():
-            if hasattr(score, 'item'):
-                with suppress(ValueError):
-                    # e.g. unwrap memmapped scalars
-                    score = score.item()
-            if not isinstance(score, numbers.Number):
-                raise ValueError(error_msg % (score, type(score), name))
-            scores[name] = score
-    else:  # scalar
-        if hasattr(scores, 'item'):
-            with suppress(ValueError):
-                # e.g. unwrap memmapped scalars
-                scores = scores.item()
-        if not isinstance(scores, numbers.Number):
-            raise ValueError(error_msg % (scores, type(scores), scorer))
-    return scores
-
-
-def _split_fit_kwargs(fit_kwargs, train_idx, test_idx):
-    """Get split fit kwargs for single CV step."""
-    fit_kwargs_train = {}
-    fit_kwargs_test = {}
-    for (key, val) in fit_kwargs.items():
-        if 'sample_weight' in key and 'sample_weight_eval_set' not in key:
-            fit_kwargs_train[key] = deepcopy(val)[train_idx]
-            fit_kwargs_test[key] = deepcopy(val)[test_idx]
-        else:
-            fit_kwargs_train[key] = deepcopy(val)
-            fit_kwargs_test[key] = deepcopy(val)
-    return (fit_kwargs_train, fit_kwargs_test)
 
 
 def _update_transformers_param(estimator, support):
@@ -283,12 +533,9 @@ def cross_val_score_weighted(estimator, x_data, y_data=None, groups=None,
                              error_score=np.nan, sample_weights=None):
     """Expand :func:`sklearn.model_selection.cross_val_score`."""
     scorer = check_scoring(estimator, scoring=scoring)
-    scorer_name = 'score'
-    scoring = {scorer_name: scorer}
-    x_data, y_data, groups = indexable(x_data, y_data, groups)
+    (x_data, y_data, groups) = indexable(x_data, y_data, groups)
 
     cv = check_cv(cv, y_data, classifier=is_classifier(estimator))
-    scorers, _ = _check_multimetric_scoring(estimator, scoring=scoring)
 
     # We clone the estimator to make sure that all the folds are
     # independent, and that it is pickle-able.
@@ -296,15 +543,10 @@ def cross_val_score_weighted(estimator, x_data, y_data=None, groups=None,
                         pre_dispatch=pre_dispatch)
     scores = parallel(
         delayed(_fit_and_score_weighted)(
-            clone(estimator), x_data, y_data, scorers, train, test, verbose,
-            None, fit_params, error_score=error_score,
-            sample_weights=sample_weights)
+            clone(estimator), x_data, y_data, scorer, train, test, None,
+            fit_params, error_score=error_score, sample_weights=sample_weights)
         for train, test in cv.split(x_data, y_data, groups))
-
-    test_scores = list(zip(*scores))[0]
-    test_scores = _aggregate_score_dicts(test_scores)
-
-    return np.array(test_scores[scorer_name])
+    return np.array(scores)
 
 
 def get_rfecv_transformer(rfecv_estimator):
@@ -445,10 +687,9 @@ class AdvancedRFE(RFE):
         # step_score is not exposed to users
         # and is used when implementing AdvancedRFECV
         # self.scores_ will not be calculated when calling _fit through fit
-        tags = self._get_tags()
-        x_data, y_data = check_X_y(
-            x_data, y_data, "csc", ensure_min_features=2,
-            force_all_finite=not tags.get('allow_nan', True))
+        x_data, y_data = check_X_y(x_data, y_data, "csc",
+                                   ensure_min_features=2,
+                                   force_all_finite=False)
 
         # Initialization
         n_features = x_data.shape[1]
@@ -464,8 +705,8 @@ class AdvancedRFE(RFE):
         if step <= 0:
             raise ValueError("Step must be >0")
 
-        support_ = np.ones(n_features, dtype=np.bool)
-        ranking_ = np.ones(n_features, dtype=np.int)
+        support_ = np.ones(n_features, dtype=bool)
+        ranking_ = np.ones(n_features, dtype=int)
 
         if step_score:
             self.scores_ = []
@@ -499,6 +740,16 @@ class AdvancedRFE(RFE):
                 ranks = np.argsort(safe_sqr(coefs).sum(axis=0))
             else:
                 ranks = np.argsort(safe_sqr(coefs))
+
+            # Transformer steps that reduce number of features is not supported
+            if len(ranks) != len(features):
+                raise NotImplementedError(
+                    f"Estimators that contain transforming steps that reduce "
+                    f"the number of features are not supported in "
+                    f"{self.__class__}, got {len(features):d} features for ",
+                    f"fit(), but only {len(ranks):d} elements for 'coefs_' / "
+                    f"'feature_importances_' are provided. Estimator:\n"
+                    f"{estimator}")
 
             # for sparse case ranks is matrix
             ranks = np.ravel(ranks)
@@ -741,6 +992,8 @@ class AdvancedTransformedTargetRegressor(TransformedTargetRegressor):
             ('regressor', self.regressor),
         ]
         fit_params = _get_fit_parameters(fit_kwargs, steps, self.__class__)
+        fit_params.setdefault('transformer', {})
+        fit_params.setdefault('regressor', {})
 
         # FIXME
         if fit_params['transformer']:
@@ -750,6 +1003,34 @@ class AdvancedTransformedTargetRegressor(TransformedTargetRegressor):
                 f"supported at the moment")
 
         return (fit_params['transformer'], fit_params['regressor'])
+
+    def _fit_transformer(self, y_data):
+        """Check transformer and fit transformer."""
+        if (self.transformer is not None and
+                (self.func is not None or self.inverse_func is not None)):
+            raise ValueError("'transformer' and functions 'func'/"
+                             "'inverse_func' cannot both be set.")
+        if self.transformer is not None:
+            self.transformer_ = clone(self.transformer)
+        else:
+            if self.func is not None and self.inverse_func is None:
+                raise ValueError(
+                    "When 'func' is provided, 'inverse_func' must also be "
+                    "provided")
+            self.transformer_ = FunctionTransformer(
+                func=self.func, inverse_func=self.inverse_func, validate=True,
+                check_inverse=self.check_inverse)
+        self.transformer_.fit(y_data)
+        if self.check_inverse:
+            idx_selected = slice(None, None, max(1, y_data.shape[0] // 10))
+            y_sel = _safe_indexing(y_data, idx_selected)
+            y_sel_t = self.transformer_.transform(y_sel)
+            if not np.allclose(y_sel,
+                               self.transformer_.inverse_transform(y_sel_t)):
+                warnings.warn("The provided functions or transformer are "
+                              "not strictly inverse of each other. If "
+                              "you are sure you want to proceed regardless, "
+                              "set 'check_inverse=False'", UserWarning)
 
     def _to_be_squeezed(self, array, always_return_1d=True):
         """Check if ``array`` should be squeezed or not."""
@@ -779,6 +1060,6 @@ class FeatureSelectionTransformer(BaseEstimator, SelectorMixin):
 
     def _more_tags(self):
         """Additional estimator tags."""
-        more_tags = super()._more_tags()
+        more_tags = _DEFAULT_TAGS
         more_tags['allow_nan'] = True
         return more_tags

--- a/tests/integration/diag_scripts/mlr/_sklearn_utils.py
+++ b/tests/integration/diag_scripts/mlr/_sklearn_utils.py
@@ -1,0 +1,295 @@
+"""Testing utilities for custom :mod:`sklearn` functionalities.
+
+Parts of this code have been copied from :mod:`sklearn`.
+
+License: BSD 3-Clause License
+
+Copyright (c) 2007-2020 The scikit-learn developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+import scipy as sp
+from numpy.testing import assert_allclose, assert_array_equal
+from sklearn.base import BaseEstimator
+
+
+class FailingClassifier(BaseEstimator):
+    """Classifier that deliberately fails when using fit()."""
+
+    FAILING_PARAMETER = 42
+
+    def __init__(self, parameter=None):
+        """Initialize class instance."""
+        self.parameter = parameter
+
+    def fit(self, *_, **__):
+        """Fit."""
+        if self.parameter == FailingClassifier.FAILING_PARAMETER:
+            raise ValueError("Failing classifier failed as required")
+
+    @staticmethod
+    def predict(x_data):
+        """Predict."""
+        return np.zeros(x_data.shape[0])
+
+    @staticmethod
+    def score(*_, **__):
+        """Score."""
+        return 0.0
+
+
+def assert_warns(warning_class, func, *args, **kw):
+    """Test that a certain warning occurs.
+
+    Parameters
+    ----------
+    warning_class : the warning class
+        The class to test for, e.g. UserWarning.
+
+    func : callable
+        Callable object to trigger warnings.
+
+    *args : the positional arguments to `func`.
+
+    **kw : the keyword arguments to `func`
+
+    Returns
+    -------
+    result : the return value of `func`
+
+    """
+    with warnings.catch_warnings(record=True) as warn:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter("always")
+        # Trigger a warning.
+        result = func(*args, **kw)
+        if hasattr(np, 'FutureWarning'):
+            # Filter out numpy-specific warnings in numpy >= 1.9
+            warn = [e for e in warn
+                    if e.category is not np.VisibleDeprecationWarning]
+
+        # Verify some things
+        if not len(warn) > 0:
+            raise AssertionError("No warning raised when calling %s"
+                                 % func.__name__)
+
+        found = any(warning.category is warning_class for warning in warn)
+        if not found:
+            raise AssertionError("%s did not give warning: %s( is %s)"
+                                 % (func.__name__, warning_class, warn))
+    return result
+
+
+def assert_warns_message(warning_class, message, func, *args, **kw):
+    # very important to avoid uncontrolled state propagation
+    """Test that a certain warning occurs and with a certain message.
+
+    Parameters
+    ----------
+    warning_class : the warning class
+        The class to test for, e.g. UserWarning.
+
+    message : str or callable
+        The message or a substring of the message to test for. If callable,
+        it takes a string as the argument and will trigger an AssertionError
+        if the callable returns `False`.
+
+    func : callable
+        Callable object to trigger warnings.
+
+    *args : the positional arguments to `func`.
+
+    **kw : the keyword arguments to `func`.
+
+    Returns
+    -------
+    result : the return value of `func`
+
+    """
+    with warnings.catch_warnings(record=True) as warn:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter("always")
+        if hasattr(np, 'FutureWarning'):
+            # Let's not catch the numpy internal DeprecationWarnings
+            warnings.simplefilter('ignore', np.VisibleDeprecationWarning)
+        # Trigger a warning.
+        result = func(*args, **kw)
+        # Verify some things
+        if not len(warn) > 0:
+            raise AssertionError("No warning raised when calling %s"
+                                 % func.__name__)
+
+        found = [issubclass(warning.category, warning_class) for warning in
+                 warn]
+        if not any(found):
+            raise AssertionError("No warning raised for %s with class "
+                                 "%s"
+                                 % (func.__name__, warning_class))
+
+        message_found = False
+        # Checks the message of all warnings belong to warning_class
+        for index in [i for i, x in enumerate(found) if x]:
+            # substring will match, the entire message with typo won't
+            msg = warn[index].message  # For Python 3 compatibility
+            msg = str(msg.args[0] if hasattr(msg, 'args') else msg)
+            if callable(message):  # add support for certain tests
+                check_in_message = message
+            else:
+                def check_in_message(msg):
+                    return message in msg
+
+            if check_in_message(msg):
+                message_found = True
+                break
+
+        if not message_found:
+            raise AssertionError("Did not receive the message you expected "
+                                 "('%s') for <%s>, got: '%s'"
+                                 % (message, func.__name__, msg))
+
+    return result
+
+
+def assert_raise_message(exceptions, message, function, *args, **kwargs):
+    """Test whether the message is in an exception.
+
+    Given an exception, a callable to raise the exception, and
+    a message string, tests that the correct exception is raised and
+    that the message is a substring of the error thrown. Used to test
+    that the specific message thrown during an exception is correct.
+
+    Parameters
+    ----------
+    exceptions : exception or tuple of exception
+        An Exception object.
+
+    message : str
+        The error message or a substring of the error message.
+
+    function : callable
+        Callable object to raise error.
+
+    *args : the positional arguments to `function`.
+
+    **kwargs : the keyword arguments to `function`.
+
+    """
+    try:
+        function(*args, **kwargs)
+    except exceptions as exc:
+        error_message = str(exc)
+        if message not in error_message:
+            raise AssertionError("Error message does not include the expected "
+                                 "string: %r. Observed error message: %r" %
+                                 (message, error_message))
+    else:
+        # concatenate exception names
+        if isinstance(exceptions, tuple):
+            names = " or ".join(e.__name__ for e in exceptions)
+        else:
+            names = exceptions.__name__
+
+        raise AssertionError("%s not raised by %s" %
+                             (names, function.__name__))
+
+
+def assert_allclose_dense_sparse(x_arr, y_arr, rtol=1e-07, atol=1e-9,
+                                 err_msg=''):
+    """Assert allclose for sparse and dense data.
+
+    Both x_arr and y_arr need to be either sparse or dense, they
+    can't be mixed.
+
+    Parameters
+    ----------
+    x_arr : {array-like, sparse matrix}
+        First array to compare.
+
+    y_arr : {array-like, sparse matrix}
+        Second array to compare.
+
+    rtol : float, default=1e-07
+        relative tolerance; see numpy.allclose.
+
+    atol : float, default=1e-9
+        absolute tolerance; see numpy.allclose. Note that the default here is
+        more tolerant than the default for numpy.testing.assert_allclose, where
+        atol=0.
+
+    err_msg : str, default=''
+        Error message to raise.
+
+    """
+    if sp.sparse.issparse(x_arr) and sp.sparse.issparse(y_arr):
+        x_arr = x_arr.tocsr()
+        y_arr = y_arr.tocsr()
+        x_arr.sum_duplicates()
+        y_arr.sum_duplicates()
+        assert_array_equal(x_arr.indices, y_arr.indices, err_msg=err_msg)
+        assert_array_equal(x_arr.indptr, y_arr.indptr, err_msg=err_msg)
+        assert_allclose(x_arr.data, y_arr.data, rtol=rtol, atol=atol,
+                        err_msg=err_msg)
+    elif not sp.sparse.issparse(x_arr) and not sp.sparse.issparse(y_arr):
+        # both dense
+        assert_allclose(x_arr, y_arr, rtol=rtol, atol=atol, err_msg=err_msg)
+    else:
+        raise ValueError("Can only compare two sparse matrices, not a sparse "
+                         "matrix and an array.")
+
+
+def _convert_container(container, constructor_name, columns_name=None):
+    """Convert container."""
+    if constructor_name == 'list':
+        return list(container)
+    if constructor_name == 'tuple':
+        return tuple(container)
+    if constructor_name == 'array':
+        return np.asarray(container)
+    if constructor_name == 'sparse':
+        return sp.sparse.csr_matrix(container)
+    if constructor_name == 'dataframe':
+        pandas = pytest.importorskip('pandas')
+        return pandas.DataFrame(container, columns=columns_name)
+    if constructor_name == 'series':
+        pandas = pytest.importorskip('pandas')
+        return pandas.Series(container)
+    if constructor_name == 'index':
+        pandas = pytest.importorskip('pandas')
+        return pandas.Index(container)
+    if constructor_name == 'slice':
+        return slice(container[0], container[1])
+    if constructor_name == 'sparse_csr':
+        return sp.sparse.csr_matrix(container)
+    if constructor_name == 'sparse_csc':
+        return sp.sparse.csc_matrix(container)
+    raise TypeError(f"Constructor name '{constructor_name}' not supported")

--- a/tests/integration/diag_scripts/mlr/test_custom_sklearn_classes.py
+++ b/tests/integration/diag_scripts/mlr/test_custom_sklearn_classes.py
@@ -539,19 +539,16 @@ class TestAdvancedRFECV():
 
     X_DATA = np.array([
         [0, 0, 0],
-        [0, 0, 10],
         [1, 1, 0],
-        [1, 1, 10],
-        [2, 0, 2],
-        [0, 3, 3],
+        [2, 0, 0],
         [0, 3, 0],
-        [4, 4, 4],
+        [0, 3, 0],
         [4, 4, 0],
-        [1000.0, 2000.0, 3000.0],
+        [4, 4, 0],
+        [1000.0, 2000.0, 0.0],
     ])
-    Y_DATA = np.array([1, 1, 0, 0, 3, -5, -5, -3, -3, -4])
-    SAMPLE_WEIGHTS = np.array(
-        [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0])
+    Y_DATA = np.array([1, 0, 3, -5, -5, -3, -3, -4])
+    SAMPLE_WEIGHTS = np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0])
 
     def test_fail(self, lin):
         """Test ``AdvancedRFECV`` expected fail."""
@@ -565,12 +562,11 @@ class TestAdvancedRFECV():
         rfecv = AdvancedRFECV(estimator=lin, step=1, min_features_to_select=1,
                               cv=2, verbose=1000, n_jobs=2)
         rfecv.fit(self.X_DATA, self.Y_DATA, sample_weight=self.SAMPLE_WEIGHTS)
-
         assert rfecv.n_features_ == 2
         np.testing.assert_array_equal(rfecv.support_, [True, True, False])
         np.testing.assert_array_equal(rfecv.ranking_, [1, 1, 2])
         np.testing.assert_allclose(rfecv.grid_scores_,
-                                   [-14.152778, -14.088235, -14.088235])
+                                   [-7.28912807, -0.69779194, -0.69779194])
 
         est = rfecv.estimator_
         assert isinstance(est, LinearRegression)
@@ -582,18 +578,17 @@ class TestAdvancedRFECV():
         rfecv = AdvancedRFECV(estimator=lin, step=0.1, cv=2)
         rfecv.fit(self.X_DATA, self.Y_DATA)
 
-        assert rfecv.n_features_ == 3
-        np.testing.assert_array_equal(rfecv.support_, [True, True, True])
-        np.testing.assert_array_equal(rfecv.ranking_, [1, 1, 1])
+        assert rfecv.n_features_ == 2
+        np.testing.assert_array_equal(rfecv.support_, [True, True, False])
+        np.testing.assert_array_equal(rfecv.ranking_, [1, 1, 2])
         np.testing.assert_allclose(
             rfecv.grid_scores_,
-            [-1384182.300065, -1121262.013698, -1121262.013698])
+            [-3949286.19763361, -1630913.74908173, -1630913.74908173])
 
         est = rfecv.estimator_
         assert isinstance(est, LinearRegression)
-        np.testing.assert_allclose(est.coef_,
-                                   [0.94909893, -0.9647902, 0.32609818])
-        np.testing.assert_allclose(est.intercept_, -1.8222458070628846)
+        np.testing.assert_allclose(est.coef_, [0.99952835, -0.5006662])
+        np.testing.assert_allclose(est.intercept_, -2.21009561525743)
 
 
 # AdvancedTransformedTargetRegressor
@@ -1098,6 +1093,7 @@ class TestFeatureSelectionTransformer():
         """Test ``_more_tags``."""
         tags = fst._more_tags()
         assert tags['allow_nan'] is True
+        assert tags is not _DEFAULT_TAGS
         new_tags = deepcopy(_DEFAULT_TAGS)
         new_tags['allow_nan'] = True
         assert tags == new_tags

--- a/tests/integration/diag_scripts/mlr/test_custom_sklearn_classes.py
+++ b/tests/integration/diag_scripts/mlr/test_custom_sklearn_classes.py
@@ -526,9 +526,9 @@ class TestAdvancedRFECV():
 
     def test_init(self, lin):
         """Test ``__init__``."""
-        rfecv = AdvancedRFECV(lin, step=2, min_features_to_select=3, cv=5,
-                              scoring='neg_mean_absolute_error', verbose=42,
-                              n_jobs=32)
+        rfecv = AdvancedRFECV(estimator=lin, step=2, min_features_to_select=3,
+                              cv=5, scoring='neg_mean_absolute_error',
+                              verbose=42, n_jobs=32)
         assert rfecv.estimator is lin
         assert rfecv.step == 2
         assert rfecv.min_features_to_select == 3
@@ -541,6 +541,7 @@ class TestAdvancedRFECV():
         [0, 0, 0],
         [0, 0, 10],
         [1, 1, 0],
+        [1, 1, 10],
         [2, 0, 2],
         [0, 3, 3],
         [0, 3, 0],
@@ -548,27 +549,28 @@ class TestAdvancedRFECV():
         [4, 4, 0],
         [1000.0, 2000.0, 3000.0],
     ])
-    Y_DATA = np.array([1, 1, 0, 3, -5, -5, -3, -3, -4])
-    SAMPLE_WEIGHTS = np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0])
+    Y_DATA = np.array([1, 1, 0, 0, 3, -5, -5, -3, -3, -4])
+    SAMPLE_WEIGHTS = np.array(
+        [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0])
 
     def test_fail(self, lin):
         """Test ``AdvancedRFECV`` expected fail."""
         msg = 'Step must be >0'
-        rfecv = AdvancedRFECV(lin, step=-1)
+        rfecv = AdvancedRFECV(estimator=lin, step=-1)
         with pytest.raises(ValueError, match=msg):
             rfecv.fit(self.X_DATA, self.Y_DATA)
 
     def test_fit(self, lin):
         """Test ``fit``."""
-        rfecv = AdvancedRFECV(lin, step=1, min_features_to_select=1, cv=2,
-                              verbose=1000, n_jobs=2)
+        rfecv = AdvancedRFECV(estimator=lin, step=1, min_features_to_select=1,
+                              cv=2, verbose=1000, n_jobs=2)
         rfecv.fit(self.X_DATA, self.Y_DATA, sample_weight=self.SAMPLE_WEIGHTS)
 
         assert rfecv.n_features_ == 2
         np.testing.assert_array_equal(rfecv.support_, [True, True, False])
         np.testing.assert_array_equal(rfecv.ranking_, [1, 1, 2])
         np.testing.assert_allclose(rfecv.grid_scores_,
-                                   [-7.14362865, -1.19939446, -1.19939446])
+                                   [-14.152778, -14.088235, -14.088235])
 
         est = rfecv.estimator_
         assert isinstance(est, LinearRegression)
@@ -577,20 +579,21 @@ class TestAdvancedRFECV():
 
     def test_step_float(self, lin):
         """Test float for ``step``."""
-        rfecv = AdvancedRFECV(lin, step=0.1, cv=2)
+        rfecv = AdvancedRFECV(estimator=lin, step=0.1, cv=2)
         rfecv.fit(self.X_DATA, self.Y_DATA)
 
-        assert rfecv.n_features_ == 2
-        np.testing.assert_array_equal(rfecv.support_, [True, True, False])
-        np.testing.assert_array_equal(rfecv.ranking_, [1, 1, 2])
+        assert rfecv.n_features_ == 3
+        np.testing.assert_array_equal(rfecv.support_, [True, True, True])
+        np.testing.assert_array_equal(rfecv.ranking_, [1, 1, 1])
         np.testing.assert_allclose(
             rfecv.grid_scores_,
-            [-3529612.97421038, -1630914.07782768, -1630914.07782768])
+            [-1384182.300065, -1121262.013698, -1121262.013698])
 
         est = rfecv.estimator_
         assert isinstance(est, LinearRegression)
-        np.testing.assert_allclose(est.coef_, [0.90717478, -0.45471213])
-        np.testing.assert_allclose(est.intercept_, -1.7676405943575968)
+        np.testing.assert_allclose(est.coef_,
+                                   [0.94909893, -0.9647902, 0.32609818])
+        np.testing.assert_allclose(est.intercept_, -1.8222458070628846)
 
 
 # AdvancedTransformedTargetRegressor

--- a/tests/integration/diag_scripts/mlr/test_custom_sklearn_functions.py
+++ b/tests/integration/diag_scripts/mlr/test_custom_sklearn_functions.py
@@ -1025,7 +1025,7 @@ def test_perform_efecv():
                                             cv=2)
 
     assert isinstance(best_est, LinearRegression)
-    np.testing.assert_allclose(best_est.coef_, [1, -2])
+    np.testing.assert_allclose(best_est.coef_, [1.0, -2.0])
     np.testing.assert_allclose(best_est.intercept_, 1.0)
 
     assert isinstance(transformer, FeatureSelectionTransformer)

--- a/tests/integration/diag_scripts/mlr/test_custom_sklearn_functions.py
+++ b/tests/integration/diag_scripts/mlr/test_custom_sklearn_functions.py
@@ -1,0 +1,978 @@
+"""Integration tests for functions of custom :mod:`sklearn` functionalities.
+
+Parts of this code have been copied from :mod:`sklearn`.
+
+License: BSD 3-Clause License
+
+Copyright (c) 2007-2020 The scikit-learn developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+
+# pylint: disable=arguments-differ
+# pylint: disable=invalid-name
+# pylint: disable=no-self-use
+# pylint: disable=protected-access
+# pylint: disable=too-few-public-methods
+# pylint: disable=too-many-arguments
+
+from copy import copy, deepcopy
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+from sklearn import datasets
+from sklearn.base import BaseEstimator
+from sklearn.compose import ColumnTransformer
+from sklearn.decomposition import KernelPCA
+from sklearn.exceptions import FitFailedWarning, NotFittedError
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import (
+    explained_variance_score,
+    make_scorer,
+    mean_absolute_error,
+    mean_squared_error,
+)
+from sklearn.model_selection import LeaveOneGroupOut, ShuffleSplit
+from sklearn.svm import SVC
+
+from esmvaltool.diag_scripts.mlr.custom_sklearn import (
+    _DEFAULT_TAGS,
+    AdvancedPipeline,
+    AdvancedRFE,
+    AdvancedRFECV,
+    FeatureSelectionTransformer,
+    _check_fit_params,
+    _determine_key_type,
+    _fit_and_score_weighted,
+    _get_fit_parameters,
+    _is_pairwise,
+    _map_features,
+    _num_samples,
+    _rfe_single_fit,
+    _safe_indexing,
+    _safe_split,
+    _safe_tags,
+    _score_weighted,
+    _update_transformers_param,
+    cross_val_score_weighted,
+    get_rfecv_transformer,
+    perform_efecv,
+)
+
+from ._sklearn_utils import (
+    FailingClassifier,
+    _convert_container,
+    assert_allclose_dense_sparse,
+    assert_raise_message,
+    assert_warns,
+    assert_warns_message,
+)
+
+# _determine_key_type
+
+
+TEST_DETERMINE_KEY_TYPE = [
+    (0, 'int'),
+    ('0', 'str'),
+    (True, 'bool'),
+    (np.bool_(True), 'bool'),
+    ([0, 1, 2], 'int'),
+    (['0', '1', '2'], 'str'),
+    ((0, 1, 2), 'int'),
+    (('0', '1', '2'), 'str'),
+    (slice(None, None), None),
+    (slice(0, 2), 'int'),
+    (np.array([0, 1, 2], dtype=np.int32), 'int'),
+    (np.array([0, 1, 2], dtype=np.int64), 'int'),
+    (np.array([0, 1, 2], dtype=np.uint8), 'int'),
+    ([True, False], 'bool'),
+    ((True, False), 'bool'),
+    (np.array([True, False]), 'bool'),
+    ('col_0', 'str'),
+    (['col_0', 'col_1', 'col_2'], 'str'),
+    (('col_0', 'col_1', 'col_2'), 'str'),
+    (slice('begin', 'end'), 'str'),
+    (np.array(['col_0', 'col_1', 'col_2']), 'str'),
+    (np.array(['col_0', 'col_1', 'col_2'], dtype=object), 'str'),
+]
+
+
+@pytest.mark.parametrize('key,dtype', TEST_DETERMINE_KEY_TYPE)
+def test_determine_key_type(key, dtype):
+    """Test working ``_determine_key_type``."""
+    assert _determine_key_type(key) == dtype
+
+
+def test_determine_key_type_error():
+    """Test failing ``_determine_key_type``."""
+    with pytest.raises(ValueError, match="No valid specification of the"):
+        _determine_key_type(1.0)
+
+
+def test_determine_key_type_slice_error():
+    """Test failing ``_determine_key_type``."""
+    with pytest.raises(TypeError, match="Only array-like or scalar are"):
+        _determine_key_type(slice(0, 2, 1), accept_slice=False)
+
+
+# _safe_indexing
+
+
+@pytest.mark.parametrize(
+    'array_type', ['list', 'array', 'sparse', 'dataframe'],
+)
+@pytest.mark.parametrize(
+    'indices_type', ['list', 'tuple', 'array', 'series', 'slice'],
+)
+def test_safe_indexing_2d_container_axis_0(array_type, indices_type):
+    """Test ``_safe_indexing`` with 2D container."""
+    indices = [1, 2]
+    if indices_type == 'slice' and isinstance(indices[1], int):
+        indices[1] += 1
+    array = _convert_container([[1, 2, 3], [4, 5, 6], [7, 8, 9]], array_type)
+    indices = _convert_container(indices, indices_type)
+    subset = _safe_indexing(array, indices, axis=0)
+    assert_allclose_dense_sparse(
+        subset, _convert_container([[4, 5, 6], [7, 8, 9]], array_type)
+    )
+
+
+X_DATA_TOY = np.arange(9).reshape((3, 3))
+
+
+@pytest.mark.parametrize('array_type', ['list', 'array', 'series'])
+@pytest.mark.parametrize(
+    'indices_type', ['list', 'tuple', 'array', 'series', 'slice'],
+)
+def test_safe_indexing_1d_container(array_type, indices_type):
+    """Test ``_safe_indexing`` with 1D container."""
+    indices = [1, 2]
+    if indices_type == 'slice' and isinstance(indices[1], int):
+        indices[1] += 1
+    array = _convert_container([1, 2, 3, 4, 5, 6, 7, 8, 9], array_type)
+    indices = _convert_container(indices, indices_type)
+    subset = _safe_indexing(array, indices, axis=0)
+    assert_allclose_dense_sparse(
+        subset, _convert_container([2, 3], array_type)
+    )
+
+
+@pytest.mark.parametrize('array_type', ['array', 'sparse', 'dataframe'])
+@pytest.mark.parametrize(
+    'indices_type', ['list', 'tuple', 'array', 'series', 'slice'],
+)
+@pytest.mark.parametrize('indices', [[1, 2], ['col_1', 'col_2']])
+def test_safe_indexing_2d_container_axis_1(array_type, indices_type, indices):
+    """Test ``_safe_indexing`` with 2D container."""
+    # validation of the indices
+    # we make a copy because indices is mutable and shared between tests
+    indices_converted = copy(indices)
+    if indices_type == 'slice' and isinstance(indices[1], int):
+        indices_converted[1] += 1
+
+    columns_name = ['col_0', 'col_1', 'col_2']
+    array = _convert_container(
+        [[1, 2, 3], [4, 5, 6], [7, 8, 9]], array_type, columns_name
+    )
+    indices_converted = _convert_container(indices_converted, indices_type)
+
+    if isinstance(indices[0], str) and array_type != 'dataframe':
+        err_msg = ("Specifying the columns using strings is only supported "
+                   "for pandas DataFrames")
+        with pytest.raises(ValueError, match=err_msg):
+            _safe_indexing(array, indices_converted, axis=1)
+    else:
+        subset = _safe_indexing(array, indices_converted, axis=1)
+        assert_allclose_dense_sparse(
+            subset, _convert_container([[2, 3], [5, 6], [8, 9]], array_type)
+        )
+
+
+@pytest.mark.parametrize('array_read_only', [True, False])
+@pytest.mark.parametrize('indices_read_only', [True, False])
+@pytest.mark.parametrize('array_type', ['array', 'sparse', 'dataframe'])
+@pytest.mark.parametrize('indices_type', ['array', 'series'])
+@pytest.mark.parametrize(
+    'axis, expected_array',
+    [(0, [[4, 5, 6], [7, 8, 9]]), (1, [[2, 3], [5, 6], [8, 9]])],
+)
+def test_safe_indexing_2d_read_only_axis_1(array_read_only, indices_read_only,
+                                           array_type, indices_type, axis,
+                                           expected_array):
+    """Test ``_safe_indexing`` with 2D container."""
+    array = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    if array_read_only:
+        array.setflags(write=False)
+    array = _convert_container(array, array_type)
+    indices = np.array([1, 2])
+    if indices_read_only:
+        indices.setflags(write=False)
+    indices = _convert_container(indices, indices_type)
+    subset = _safe_indexing(array, indices, axis=axis)
+    assert_allclose_dense_sparse(
+        subset, _convert_container(expected_array, array_type)
+    )
+
+
+@pytest.mark.parametrize('array_type', ['list', 'array', 'series'])
+@pytest.mark.parametrize('indices_type', ['list', 'tuple', 'array', 'series'])
+def test_safe_indexing_1d_container_mask(array_type, indices_type):
+    """Test ``_safe_indexing`` with 1D container."""
+    indices = [False] + [True] * 2 + [False] * 6
+    array = _convert_container([1, 2, 3, 4, 5, 6, 7, 8, 9], array_type)
+    indices = _convert_container(indices, indices_type)
+    subset = _safe_indexing(array, indices, axis=0)
+    assert_allclose_dense_sparse(
+        subset, _convert_container([2, 3], array_type)
+    )
+
+
+@pytest.mark.parametrize('array_type', ['array', 'sparse', 'dataframe'])
+@pytest.mark.parametrize('indices_type', ['list', 'tuple', 'array', 'series'])
+@pytest.mark.parametrize(
+    'axis, expected_subset',
+    [(0, [[4, 5, 6], [7, 8, 9]]),
+     (1, [[2, 3], [5, 6], [8, 9]])],
+)
+def test_safe_indexing_2d_mask(array_type, indices_type, axis,
+                               expected_subset):
+    """Test ``_safe_indexing`` with 2D container."""
+    columns_name = ['col_0', 'col_1', 'col_2']
+    array = _convert_container(
+        [[1, 2, 3], [4, 5, 6], [7, 8, 9]], array_type, columns_name
+    )
+    indices = [False, True, True]
+    indices = _convert_container(indices, indices_type)
+
+    subset = _safe_indexing(array, indices, axis=axis)
+    assert_allclose_dense_sparse(
+        subset, _convert_container(expected_subset, array_type)
+    )
+
+
+@pytest.mark.parametrize(
+    'array_type, expected_output_type',
+    [('list', 'list'), ('array', 'array'),
+     ('sparse', 'sparse'), ('dataframe', 'series')],
+)
+def test_safe_indexing_2d_scalar_axis_0(array_type, expected_output_type):
+    """Test ``_safe_indexing`` with 2D container."""
+    array = _convert_container([[1, 2, 3], [4, 5, 6], [7, 8, 9]], array_type)
+    indices = 2
+    subset = _safe_indexing(array, indices, axis=0)
+    expected_array = _convert_container([7, 8, 9], expected_output_type)
+    assert_allclose_dense_sparse(subset, expected_array)
+
+
+@pytest.mark.parametrize('array_type', ['list', 'array', 'series'])
+def test_safe_indexing_1d_scalar(array_type):
+    """Test ``_safe_indexing`` with 1D container."""
+    array = _convert_container([1, 2, 3, 4, 5, 6, 7, 8, 9], array_type)
+    indices = 2
+    subset = _safe_indexing(array, indices, axis=0)
+    assert subset == 3
+
+
+@pytest.mark.parametrize(
+    'array_type, expected_output_type',
+    [('array', 'array'), ('sparse', 'sparse'), ('dataframe', 'series')],
+)
+@pytest.mark.parametrize('indices', [2, 'col_2'])
+def test_safe_indexing_2d_scalar_axis_1(array_type, expected_output_type,
+                                        indices):
+    """Test ``_safe_indexing`` with 1D container."""
+    columns_name = ['col_0', 'col_1', 'col_2']
+    array = _convert_container(
+        [[1, 2, 3], [4, 5, 6], [7, 8, 9]], array_type, columns_name
+    )
+
+    if isinstance(indices, str) and array_type != 'dataframe':
+        err_msg = ("Specifying the columns using strings is only supported "
+                   "for pandas DataFrames")
+        with pytest.raises(ValueError, match=err_msg):
+            _safe_indexing(array, indices, axis=1)
+    else:
+        subset = _safe_indexing(array, indices, axis=1)
+        expected_output = [3, 6, 9]
+        if expected_output_type == 'sparse':
+            # sparse matrix are keeping the 2D shape
+            expected_output = [[3], [6], [9]]
+        expected_array = _convert_container(
+            expected_output, expected_output_type
+        )
+        assert_allclose_dense_sparse(subset, expected_array)
+
+
+@pytest.mark.parametrize('array_type', ['list', 'array', 'sparse'])
+def test_safe_indexing_none_axis_0(array_type):
+    """Test ``_safe_indexing`` with None."""
+    x_data = _convert_container([[1, 2, 3], [4, 5, 6], [7, 8, 9]], array_type)
+    x_data_subset = _safe_indexing(x_data, None, axis=0)
+    assert_allclose_dense_sparse(x_data_subset, x_data)
+
+
+def test_safe_indexing_pandas_no_matching_cols_error():
+    """Test ``_safe_indexing`` with pandas."""
+    pd = pytest.importorskip('pandas')
+    err_msg = "No valid specification of the columns."
+    x_data = pd.DataFrame(X_DATA_TOY)
+    with pytest.raises(ValueError, match=err_msg):
+        _safe_indexing(x_data, [1.0], axis=1)
+
+
+@pytest.mark.parametrize('axis', [None, 3])
+def test_safe_indexing_error_axis(axis):
+    """Test ``_safe_indexing`` error."""
+    with pytest.raises(ValueError, match="'axis' should be either 0"):
+        _safe_indexing(X_DATA_TOY, [0, 1], axis=axis)
+
+
+@pytest.mark.parametrize('x_constructor', ['array', 'series'])
+def test_safe_indexing_1d_array_error(x_constructor):
+    """Test ``_safe_indexing`` error."""
+    # check that we are raising an error if the array-like passed is 1D and
+    # we try to index on the 2nd dimension
+    x_data = list(range(5))
+    if x_constructor == 'array':
+        x_constructor = np.asarray(x_data)
+    elif x_constructor == 'series':
+        pd = pytest.importorskip("pandas")
+        x_constructor = pd.Series(x_data)
+
+    err_msg = "'x_data' should be a 2D NumPy array, 2D sparse matrix or pandas"
+    with pytest.raises(ValueError, match=err_msg):
+        _safe_indexing(x_constructor, [0, 1], axis=1)
+
+
+def test_safe_indexing_container_axis_0_unsupported_type():
+    """Test ``_safe_indexing`` error."""
+    indices = ["col_1", "col_2"]
+    array = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    err_msg = "String indexing is not supported with 'axis=0'"
+    with pytest.raises(ValueError, match=err_msg):
+        _safe_indexing(array, indices, axis=0)
+
+
+# _num_samples
+
+
+def test_retrieve_samples_from_non_standard_shape():
+    """Test ``_num_samples``."""
+    class TestNonNumericShape:
+        """Non-numeric shape."""
+
+        def __init__(self):
+            """Init."""
+            self.shape = ("not numeric",)
+
+        def __len__(self):
+            """Length."""
+            return len([1, 2, 3])
+
+    x_data = TestNonNumericShape()
+    assert _num_samples(x_data) == len(x_data)
+
+    # Check that it gives a good error if there's no __len__
+    class TestNoLenWeirdShape:
+        """Weird shape with no length."""
+
+        def __init__(self):
+            """Init."""
+            self.shape = ("not numeric",)
+
+    with pytest.raises(TypeError, match="Expected sequence or array-like"):
+        _num_samples(TestNoLenWeirdShape())
+
+
+# _check_fit_params
+
+
+@pytest.mark.parametrize('indices', [None, [1, 3]])
+def test_check_fit_params(indices):
+    """Test ``_check_fit_params``."""
+    x_data = np.random.randn(4, 2)
+    fit_params = {
+        'list': [1, 2, 3, 4],
+        'array': np.array([1, 2, 3, 4]),
+        'sparse-col': sp.csc_matrix([1, 2, 3, 4]).T,
+        'sparse-row': sp.csc_matrix([1, 2, 3, 4]),
+        'scalar-int': 1,
+        'scalar-str': 'xxx',
+        'None': None,
+    }
+    result = _check_fit_params(x_data, fit_params, indices)
+    indices_ = indices if indices is not None else list(range(x_data.shape[0]))
+
+    for key in ['sparse-row', 'scalar-int', 'scalar-str', 'None']:
+        assert result[key] is fit_params[key]
+
+    assert result['list'] == _safe_indexing(fit_params['list'], indices_)
+    np.testing.assert_array_equal(
+        result['array'], _safe_indexing(fit_params['array'], indices_)
+    )
+    assert_allclose_dense_sparse(
+        result['sparse-col'],
+        _safe_indexing(fit_params['sparse-col'], indices_)
+    )
+
+
+# _safe_tags
+
+
+class NoTagsEstimator:
+    """Estimators with no tags."""
+
+
+class MoreTagsEstimator:
+    """Estimator with ``_more_tags``."""
+
+    def _more_tags(self):
+        """Return more tags."""
+        return {"allow_nan": True}
+
+
+@pytest.mark.parametrize(
+    'estimator,err_msg',
+    [
+        (BaseEstimator(), 'The key xxx is not defined in _get_tags'),
+        (NoTagsEstimator(), 'The key xxx is not defined in _DEFAULT_TAGS'),
+    ],
+)
+def test_safe_tags_error(estimator, err_msg):
+    """Test ``_safe_tags`` with error."""
+    # Check that safe_tags raises error in ambiguous case.
+    with pytest.raises(ValueError, match=err_msg):
+        _safe_tags(estimator, key="xxx")
+
+
+@pytest.mark.parametrize(
+    'estimator,key,expected_results',
+    [
+        (NoTagsEstimator(), None, _DEFAULT_TAGS),
+        (NoTagsEstimator(), 'allow_nan', _DEFAULT_TAGS['allow_nan']),
+        (MoreTagsEstimator(), None, {**_DEFAULT_TAGS, **{'allow_nan': True}}),
+        (MoreTagsEstimator(), 'allow_nan', True),
+        (BaseEstimator(), None, _DEFAULT_TAGS),
+        (BaseEstimator(), 'allow_nan', _DEFAULT_TAGS['allow_nan']),
+        (BaseEstimator(), 'allow_nan', _DEFAULT_TAGS['allow_nan']),
+    ],
+)
+def test_safe_tags_no_get_tags(estimator, key, expected_results):
+    """Test ``_safe_tags`` without ``_get_tags``."""
+    assert _safe_tags(estimator, key=key) == expected_results
+
+
+# _is_pairwise
+
+
+def test_is_pairwise():
+    """Test ``_is_pairwise``."""
+    # Simple checks for _is_pairwise
+    pca = KernelPCA(kernel='precomputed')
+    with pytest.warns(None) as record:
+        assert _is_pairwise(pca)
+    assert not record
+
+    # Pairwise attribute that is not consistent with the pairwise tag
+    class IncorrectTagPCA(KernelPCA):
+        """Class with incorrect _pairwise attribute."""
+
+        _pairwise = False
+
+    pca = IncorrectTagPCA(kernel='precomputed')
+    msg = "_pairwise attribute is inconsistent with tags."
+    with pytest.warns(FutureWarning, match=msg):
+        assert not _is_pairwise(pca)
+
+    # The _pairwise attribute is present and set to True while pairwise tag is
+    # not present
+    class TruePairwise(BaseEstimator):
+        """Class without pairwise tag."""
+
+        _pairwise = True
+
+    true_pairwise = TruePairwise()
+    with pytest.warns(FutureWarning, match=msg):
+        assert _is_pairwise(true_pairwise)
+
+    # Pairwise attribute is not defined thus tag is used
+    est = BaseEstimator()
+    with pytest.warns(None) as record:
+        assert not _is_pairwise(est)
+    assert not record
+
+
+# _safe_split
+
+
+def test_safe_split():
+    """Test ``_safe_split``."""
+    clf = SVC()
+    clfp = SVC(kernel="precomputed")
+
+    iris = datasets.load_iris()
+    (x_data, y_data) = (iris.data, iris.target)
+    kernel = np.dot(x_data, x_data.T)
+
+    cv = ShuffleSplit(test_size=0.25, random_state=0)
+    train, test = list(cv.split(x_data))[0]
+
+    x_train, y_train = _safe_split(clf, x_data, y_data, train)
+    kernel_train, y_train2 = _safe_split(clfp, kernel, y_data, train)
+    np.testing.assert_array_almost_equal(kernel_train, np.dot(x_train,
+                                                              x_train.T))
+    np.testing.assert_array_almost_equal(y_train, y_train2)
+
+    x_test, y_test = _safe_split(clf, x_data, y_data, test, train)
+    kernel_test, y_test2 = _safe_split(clfp, kernel, y_data, test, train)
+    np.testing.assert_array_almost_equal(kernel_test, np.dot(x_test,
+                                                             x_train.T))
+    np.testing.assert_array_almost_equal(y_test, y_test2)
+
+
+# _fit_and_score_weighted
+
+
+def test_fit_and_score_weighted_failing():
+    """Test if ``_fit_and_score_weighted`` fails as expected."""
+    # Create a failing classifier to deliberately fail
+    failing_clf = FailingClassifier(FailingClassifier.FAILING_PARAMETER)
+
+    # Dummy X data
+    x_data = np.arange(1, 10)
+    scorer = make_scorer(mean_squared_error)
+    fit_and_score_args = [failing_clf, x_data, None, scorer, None, None, None,
+                          None]
+
+    # Passing error score to trigger the warning message
+    fit_and_score_kwargs = {'error_score': 42}
+
+    # Check if the warning message type is as expected
+    assert_warns(FitFailedWarning, _fit_and_score_weighted,
+                 *fit_and_score_args, **fit_and_score_kwargs)
+
+    # Since we're using FailingClassifier, our error will be the following
+    error_message = "ValueError: Failing classifier failed as required"
+
+    # The warning message we're expecting to see
+    warning_message = ("Estimator fit failed. The score on this train-test "
+                       "partition for these parameters will be set to %f. "
+                       "Details: \n%s" % (fit_and_score_kwargs['error_score'],
+                                          error_message))
+
+    def test_warn_trace(msg):
+        """Traceback in warning message."""
+        assert 'Traceback (most recent call last):\n' in msg
+        split = msg.splitlines()  # note: handles more than '\n'
+        mtb = split[0] + '\n' + split[-1]
+        return warning_message in mtb
+
+    # Check traceback is included
+    assert_warns_message(FitFailedWarning, test_warn_trace,
+                         _fit_and_score_weighted, *fit_and_score_args,
+                         **fit_and_score_kwargs)
+
+    # Check return of error_score in case of failed fit
+    result = _fit_and_score_weighted(*fit_and_score_args,
+                                     **fit_and_score_kwargs)
+    assert isinstance(result, int)
+    assert result == fit_and_score_kwargs['error_score']
+
+    # Check if exception was raised, with default error_score='raise'
+    fit_and_score_kwargs = {'error_score': 'raise'}
+    assert_raise_message(ValueError, "Failing classifier failed as required",
+                         _fit_and_score_weighted, *fit_and_score_args,
+                         **fit_and_score_kwargs)
+    assert failing_clf.score() == 0.0
+
+
+X_DATA = np.arange(5).reshape(5, 1)
+Y_DATA = np.array([0, 1, 2, 3, -1])
+TRAIN = np.array([1, 2, 3, 4])
+TEST = np.array([0])
+
+
+TEST_FIT_AND_SCORE_WEIGHTED_NO_WEIGHTS = [
+    (make_scorer(mean_absolute_error), 2.5),
+    (make_scorer(mean_squared_error), 6.25),
+    (make_scorer(explained_variance_score), 1.0),
+]
+
+
+@pytest.mark.parametrize('scorer,output',
+                         TEST_FIT_AND_SCORE_WEIGHTED_NO_WEIGHTS)
+def test_fit_and_score_weighted_no_weights(scorer, output):
+    """Test ``_fit_and_score_weighted`` without weights."""
+    clf = LinearRegression()
+    fit_and_score_weighted_args = [clf, X_DATA, Y_DATA, scorer, TRAIN, TEST]
+    fit_and_score_weighted_kwargs = {
+        'parameters': {'normalize': False},
+        'fit_params': None,
+    }
+
+    result = _fit_and_score_weighted(*fit_and_score_weighted_args,
+                                     **fit_and_score_weighted_kwargs)
+    np.testing.assert_allclose(clf.coef_, [-0.5])
+    np.testing.assert_allclose(clf.intercept_, 2.5)
+    assert isinstance(result, float)
+    np.testing.assert_allclose(result, output)
+
+
+SAMPLE_WEIGHTS = np.array([1.0, 1.0, 1.0, 1.0, 0.0])
+TEST_FIT_AND_SCORE_WEIGHTED_WEIGHTS = [
+    (make_scorer(mean_absolute_error), 0.0),
+    (make_scorer(mean_squared_error), 0.0),
+    (make_scorer(explained_variance_score), 1.0),
+]
+
+
+@pytest.mark.parametrize('scorer,output', TEST_FIT_AND_SCORE_WEIGHTED_WEIGHTS)
+def test_fit_and_score_weighted_weights(scorer, output):
+    """Test ``_fit_and_score_weighted`` with weights."""
+    clf = LinearRegression()
+    fit_and_score_weighted_args = [clf, X_DATA, Y_DATA, scorer, TRAIN, TEST]
+    fit_and_score_weighted_kwargs = {
+        'parameters': {'normalize': False},
+        'fit_params': {'sample_weight': SAMPLE_WEIGHTS},
+        'sample_weights': SAMPLE_WEIGHTS,
+    }
+
+    result = _fit_and_score_weighted(*fit_and_score_weighted_args,
+                                     **fit_and_score_weighted_kwargs)
+    np.testing.assert_allclose(clf.coef_, [1.0])
+    np.testing.assert_allclose(clf.intercept_, 0.0, atol=1e-10)
+    assert isinstance(result, float)
+    np.testing.assert_allclose(result, output, atol=1e-10)
+
+
+# _get_fit_parameters
+
+
+STEPS_1 = [('a', 1)]
+STEPS_2 = [('a', 1), ('b', 0)]
+TEST_GET_FIT_PARAMETERS = [
+    ({'a': 1}, STEPS_1, ValueError),
+    ({'a': 1, 'a__b': 1}, STEPS_1, ValueError),
+    ({'a__x': 1}, [], ValueError),
+    ({'a__x': 1}, STEPS_1, {'a': {'x': 1}}),
+    ({'a__x': 1, 'a__y': 2}, STEPS_1, {'a': {'x': 1, 'y': 2}}),
+    ({'a__x': 1, 'a__y__z': 2}, STEPS_1, {'a': {'x': 1, 'y__z': 2}}),
+    ({'a__x': 1, 'b__y': 2}, STEPS_1, ValueError),
+    ({'a__x': 1, 'b__y': 2}, STEPS_2, {'a': {'x': 1}, 'b': {'y': 2}}),
+]
+
+
+@pytest.mark.parametrize('kwargs,steps,output', TEST_GET_FIT_PARAMETERS)
+def test_get_fit_parameters(kwargs, steps, output):
+    """Test retrieving of fit parameters."""
+    if isinstance(output, type):
+        with pytest.raises(output):
+            _get_fit_parameters(kwargs, steps, 'x')
+        return
+    params = _get_fit_parameters(kwargs, steps, 'x')
+    assert params == output
+
+
+# _score_weighted
+
+
+def test_score_weighted_failing():
+    """Test if ``_score_weighted`` fails as expected."""
+    error_message = "Scoring must return a number, got None"
+
+    def two_params_scorer(*_, **__):
+        """Scorer function."""
+        return None
+
+    score_args = [None, None, None, two_params_scorer]
+    assert_raise_message(ValueError, error_message, _score_weighted,
+                         *score_args)
+
+
+TEST_SCORE_WEIGHTED_NO_WEIGHTS = [
+    (make_scorer(mean_absolute_error), 1.2),
+    (make_scorer(mean_squared_error), 2.0),
+    (make_scorer(explained_variance_score), 0.0),
+]
+
+
+@pytest.mark.parametrize('scorer,output', TEST_SCORE_WEIGHTED_NO_WEIGHTS)
+def test_score_weighted_no_weights(scorer, output):
+    """Test ``_score_weighted`` without weights."""
+    clf = LinearRegression()
+    clf.fit(X_DATA, Y_DATA)
+    np.testing.assert_allclose(clf.coef_, [0.0], atol=1e-10)
+    np.testing.assert_allclose(clf.intercept_, 1.0)
+    result = _score_weighted(clf, X_DATA, Y_DATA, scorer)
+    assert isinstance(result, float)
+    np.testing.assert_allclose(result, output, atol=1e-10)
+
+
+TEST_SCORE_WEIGHTED_WEIGHTS = [
+    (make_scorer(mean_absolute_error), 0.0),
+    (make_scorer(mean_squared_error), 0.0),
+    (make_scorer(explained_variance_score), 1.0),
+]
+
+
+@pytest.mark.parametrize('scorer,output', TEST_SCORE_WEIGHTED_WEIGHTS)
+def test_score_weighted_weights(scorer, output):
+    """Test ``_score_weighted`` with weights."""
+    clf = LinearRegression()
+    clf.fit(X_DATA, Y_DATA, sample_weight=SAMPLE_WEIGHTS)
+    np.testing.assert_allclose(clf.coef_, [1.0])
+    np.testing.assert_allclose(clf.intercept_, 0.0, atol=1e-10)
+    result = _score_weighted(clf, X_DATA, Y_DATA, scorer,
+                             sample_weights=SAMPLE_WEIGHTS)
+    assert isinstance(result, float)
+    np.testing.assert_allclose(result, output, atol=1e-10)
+
+
+# _rfe_single_fit
+
+
+@pytest.fixture
+def advanced_rfe():
+    """``AdvancedRFE`` object."""
+    rfe_kwargs = {
+        'estimator': LinearRegression(),
+        'n_features_to_select': 1,
+    }
+    return AdvancedRFE(**rfe_kwargs)
+
+
+def test_rfe_single_fit(advanced_rfe):
+    """Test ``_rfe_single_fit``."""
+    x_data = np.array(
+        [[0.0, 0.0, 0.0],
+         [2.0, 0.0, 1.0],
+         [3.0, 0.0, -2.0],
+         [4.0, 0.0, -4.0]],
+    )
+    y_data = np.array([0.0, 1.0, -2.0, -4.0])
+    sample_weights = np.array([1.0, 1.0, 0.0, 1.0])
+    train = np.array([0, 1, 2])
+    test = np.array([3])
+    scorer = make_scorer(mean_absolute_error)
+
+    # No weights
+    scores = _rfe_single_fit(advanced_rfe, advanced_rfe.estimator, x_data,
+                             y_data, train, test, scorer)
+    assert advanced_rfe.n_features_ == 1
+    np.testing.assert_array_equal(advanced_rfe.ranking_, [2, 3, 1])
+    np.testing.assert_array_equal(advanced_rfe.support_,
+                                  [False, False, True])
+    est = advanced_rfe.estimator_
+    assert isinstance(est, LinearRegression)
+    np.testing.assert_allclose(est.coef_, [1.0])
+    np.testing.assert_allclose(est.intercept_, 0.0, atol=1e-10)
+    np.testing.assert_allclose(scores, [0.0, 0.0, 0.0], atol=1e-10)
+
+    # With weights
+    scores = _rfe_single_fit(advanced_rfe, advanced_rfe.estimator, x_data,
+                             y_data, train, test, scorer,
+                             sample_weight=sample_weights)
+    assert advanced_rfe.n_features_ == 1
+    np.testing.assert_array_equal(advanced_rfe.ranking_, [1, 3, 2])
+    np.testing.assert_array_equal(advanced_rfe.support_,
+                                  [True, False, False])
+    est = advanced_rfe.estimator_
+    assert isinstance(est, LinearRegression)
+    np.testing.assert_allclose(est.coef_, [0.5])
+    np.testing.assert_allclose(est.intercept_, 0.0, atol=1e-10)
+    np.testing.assert_allclose(scores, [4.8, 4.8, 6.0])
+
+
+# _map_features
+
+
+TEST_MAP_FEATURES = [
+    ([True, True, True], [0, 1, 2]),
+    ([1, 1, 1], [0, 1, 2]),
+    ([True, True, False], [0, 1]),
+    ([1, 1, 0], [0, 1]),
+    ([True, False, True], [0, 1]),
+    ([1, 0, 1], [0, 1]),
+    ([False, True, True], [0, 1]),
+    ([0, 1, 1], [0, 1]),
+    ([True, False, False], [0]),
+    ([1, 0, 0], [0]),
+    ([False, True, False], [0]),
+    ([0, 1, 0], [0]),
+    ([False, False, True], [0]),
+    ([0, 0, 1], [0]),
+    ([False, False, False], []),
+    ([0, 0, 0], []),
+]
+
+FEATURES = [0, 1, 2]
+
+
+@pytest.mark.parametrize('support,output', TEST_MAP_FEATURES)
+def test_map_features(support, output):
+    """Test ``_map_features``."""
+    new_features = _map_features(FEATURES, support)
+    np.testing.assert_array_equal(new_features, output)
+
+
+# _update_transformers_param
+
+
+class NoPipeline(BaseEstimator):
+    """No pipeline."""
+
+    def __init__(self, test_transformers=1):
+        """Initialize instance."""
+        self.test_transformers = test_transformers
+
+    def fit(self, *_):
+        """Fit method."""
+        return self
+
+
+def test_update_transformers_fail_no_pipeline():
+    """Test ``_update_transformers_param`` expected fail."""
+    msg = 'estimator is not a Pipeline or AdvancedPipeline'
+    est = NoPipeline()
+    with pytest.raises(TypeError, match=msg):
+        _update_transformers_param(est, [])
+
+
+def test_update_transformers_fail_no_column_transformer():
+    """Test ``_update_transformers_param`` expected fail."""
+    msg = 'pipeline step is not a ColumnTransformer'
+    est = AdvancedPipeline([('no_pipeline', NoPipeline())])
+    with pytest.raises(TypeError, match=msg):
+        _update_transformers_param(est, [])
+
+
+def test_update_transformers_param_lin():
+    """Test ``_update_transformers_param``."""
+    est = LinearRegression()
+    params = deepcopy(est.get_params())
+    _update_transformers_param(est, [])
+    assert est.get_params() == params
+
+
+def test_update_transformers_column_transformer():
+    """Test ``_update_transformers_param``."""
+    trans1 = [('1', 'drop', [0, 1, 2])]
+    trans2 = [('2a', 'drop', [0]), ('2b', 'passthrough', [1, 2])]
+    est = AdvancedPipeline([
+        ('trans1', ColumnTransformer(trans1)),
+        ('trans2', ColumnTransformer(trans2)),
+        ('passthrough', 'passthrough'),
+    ])
+    params = deepcopy(est.get_params())
+    _update_transformers_param(est, np.array([True, False, True]))
+    new_params = est.get_params()
+    assert new_params != params
+    assert new_params['trans1__transformers'] == [('1', 'drop', [0, 1])]
+    assert new_params['trans2__transformers'] == [
+        ('2a', 'drop', [0]),
+        ('2b', 'passthrough', [1]),
+    ]
+
+
+# cross_val_score_weighted
+
+
+def test_cross_val_score_weighted():
+    """Test ``cross_val_score_weighted``."""
+    sample_weights = np.array([1.0, 1.0, 0.0, 1.0, 1.0, 0.0])
+    cv_score_kwargs = {
+        'estimator': LinearRegression(),
+        'x_data': np.arange(6).reshape(6, 1),
+        'y_data': np.array([0, 1, 1000, 0, -1, -1000]),
+        'groups': ['A', 'A', 'A', 'B', 'B', 'B'],
+        'scoring': 'neg_mean_absolute_error',
+        'cv': LeaveOneGroupOut(),
+        'fit_params': {'sample_weight': sample_weights},
+        'sample_weights': sample_weights,
+    }
+    scores = cross_val_score_weighted(**cv_score_kwargs)
+    np.testing.assert_allclose(scores, [-2.0, -4.0])
+
+
+# get_rfecv_transformer
+
+
+def test_get_rfecv_transformer_not_fitted():
+    """Test ``get_rfecv_transformer`` expected fail."""
+    rfecv = AdvancedRFECV(LinearRegression())
+    msg = ('RFECV instance used to initialize FeatureSelectionTransformer '
+           'must be fitted')
+    with pytest.raises(NotFittedError, match=msg):
+        get_rfecv_transformer(rfecv)
+
+
+def test_get_rfecv_transformer():
+    """Test ``get_rfecv_transformer``."""
+    rfecv = AdvancedRFECV(LinearRegression(), cv=2)
+    x_data = np.arange(30).reshape(10, 3)
+    y_data = np.arange(10)
+    rfecv.fit(x_data, y_data)
+    transformer = get_rfecv_transformer(rfecv)
+    assert isinstance(transformer, FeatureSelectionTransformer)
+    assert rfecv.n_features_ == transformer.n_features
+    np.testing.assert_allclose(rfecv.grid_scores_, transformer.grid_scores)
+    np.testing.assert_allclose(rfecv.ranking_, transformer.ranking)
+    np.testing.assert_allclose(rfecv.support_, transformer.support)
+    assert len(transformer.grid_scores) == 3
+    assert len(transformer.ranking) == 3
+    assert len(transformer.support) == 3
+
+
+# perform_efecv
+
+
+def test_perform_efecv():
+    """Test ``perform_efecv``."""
+    x_data = np.array([
+        [0, 0, 0],
+        [1, 1, 0],
+        [2, 0, 2],
+        [0, 3, 3],
+        [4, 4, 4],
+        [4, 4, 0],
+    ])
+    y_data = np.array([1, 0, 3, -5, -3, -3])
+
+    (best_est, transformer) = perform_efecv(LinearRegression(), x_data, y_data,
+                                            cv=2)
+
+    assert isinstance(best_est, LinearRegression)
+    np.testing.assert_allclose(best_est.coef_, [1, -2])
+    np.testing.assert_allclose(best_est.intercept_, 1.0)
+
+    assert isinstance(transformer, FeatureSelectionTransformer)
+    assert transformer.n_features == 2
+    assert len(transformer.grid_scores) == 7
+    np.testing.assert_array_equal(transformer.ranking, [1, 1, 2])
+    np.testing.assert_array_equal(transformer.support, [True, True, False])


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

This PR
- removes all previous dependencies on private `sklearn` functions and classes, so we do not get nasty surprises when `sklearn` is updated.
- increases the test coverage of `custom_sklearn.py` to 97% for the whole module and 100% for the customized `sklearn` functions in there. The missing 3% are lines in functions hat I copied (including the tests) from `sklearn` without modifying them.
- does **not** add new features or change existing features. The high number of added lines is simply due to the copying of the private functions from `sklearn`. I tested all affected recipes (the ones in `recipes/schlund20jgr/`) and found no differences to the current master.

<!--
    Please describe your changes here, especially focusing on why this PR makes
    ESMValTool better and what problem it solves.

    Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/en/latest/community/introduction.html).

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
Closes #1871.

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValTool/issues) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the PR is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

- [x] [🛠][1] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/en/latest/community/introduction.html#branches-pull-requests-and-code-review)
- [x] [🛠][1] Code follows the [style guide](https://docs.esmvaltool.org/en/latest/community/introduction.html#code-style)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/introduction.html#documentation) is available
- [x] [🛠][1] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/en/latest/community/introduction.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/en/latest/community/introduction.html#yaml) checks
- [x] [🛠][1] [Circle/CI tests pass](https://docs.esmvaltool.org/en/latest/community/introduction.html#branches-pull-requests-and-code-review)
- [x] [🛠][1] [Codacy code quality checks pass](https://docs.esmvaltool.org/en/latest/community/introduction.html#branches-pull-requests-and-code-review)
- [x] [🛠][1] [Documentation builds successfully](https://docs.esmvaltool.org/en/latest/community/introduction.html#branches-pull-requests-and-code-review) on readthedocs

***

To help with the number pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->

[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review