### PR TITLE
Move private _(global)_stock_cube from esmvacore.preprocessor._regrid to cmorizer

### DIFF
--- a/esmvaltool/cmorizers/obs/cmorize_obs_cds_uerra.py
+++ b/esmvaltool/cmorizers/obs/cmorize_obs_cds_uerra.py
@@ -35,16 +35,124 @@ Modification history
 import glob
 import logging
 import os
+import re
 from copy import deepcopy
 
 import cf_units
 import iris
+import numpy as np
 import xarray as xr
 import xesmf as xe
 
 from esmvaltool.cmorizers.obs import utilities as utils
 
 logger = logging.getLogger(__name__)
+
+
+# Regular expression to parse a "MxN" cell-specification.
+_CELL_SPEC = re.compile(
+    r'''\A
+        \s*(?P<dlon>\d+(\.\d+)?)\s*
+        x
+        \s*(?P<dlat>\d+(\.\d+)?)\s*
+        \Z
+     ''', re.IGNORECASE | re.VERBOSE)
+
+# Default fill-value.
+_MDI = 1e+20
+
+# Stock cube - global grid extents (degrees).
+_LAT_MIN = -90.0
+_LAT_MAX = 90.0
+_LAT_RANGE = _LAT_MAX - _LAT_MIN
+_LON_MIN = 0.0
+_LON_MAX = 360.0
+_LON_RANGE = _LON_MAX - _LON_MIN
+
+
+def _generate_cube_from_dimcoords(latdata, londata, circular: bool = False):
+    """Generate cube from lat/lon points.
+
+    Parameters
+    ----------
+    latdata : np.ndarray
+        List of latitudes.
+    londata : np.ndarray
+        List of longitudes.
+    circular : bool
+        Wrap longitudes around the full great circle. Bounds will not be
+        generated for circular coordinates.
+
+    Returns
+    -------
+    :class:`~iris.cube.Cube`
+    """
+    lats = iris.coords.DimCoord(latdata,
+                                standard_name='latitude',
+                                units='degrees_north',
+                                var_name='lat',
+                                circular=circular)
+
+    lons = iris.coords.DimCoord(londata,
+                                standard_name='longitude',
+                                units='degrees_east',
+                                var_name='lon',
+                                circular=circular)
+
+    if not circular:
+        # cannot guess bounds for wrapped coordinates
+        lats.guess_bounds()
+        lons.guess_bounds()
+
+    # Construct the resultant stock cube, with dummy data.
+    shape = (latdata.size, londata.size)
+    dummy = np.empty(shape, dtype=np.dtype('int8'))
+    coords_spec = [(lats, 0), (lons, 1)]
+    cube = iris.cube.Cube(dummy, dim_coords_and_dims=coords_spec)
+
+    return cube
+
+
+def parse_cell_spec(spec):
+    """Parse an MxN cell specification string.
+
+    Parameters
+    ----------
+    spec: str
+        ``MxN`` degree cell-specification for the global grid.
+
+    Returns
+    -------
+    tuple
+        tuple of (float, float) of parsed (lon, lat)
+
+    Raises
+    ------
+    ValueError
+        if the MxN cell specification is malformed.
+    ValueError
+        invalid longitude and latitude delta in cell specification.
+    """
+    cell_match = _CELL_SPEC.match(spec)
+    if cell_match is None:
+        emsg = 'Invalid MxN cell specification for grid, got {!r}.'
+        raise ValueError(emsg.format(spec))
+
+    cell_group = cell_match.groupdict()
+    dlon = float(cell_group['dlon'])
+    dlat = float(cell_group['dlat'])
+
+    if (np.trunc(_LON_RANGE / dlon) * dlon) != _LON_RANGE:
+        emsg = ('Invalid longitude delta in MxN cell specification '
+                'for grid, got {!r}.')
+        raise ValueError(emsg.format(dlon))
+
+    if (np.trunc(_LAT_RANGE / dlat) * dlat) != _LAT_RANGE:
+        emsg = ('Invalid latitude delta in MxN cell specification '
+                'for grid, got {!r}.')
+        raise ValueError(emsg.format(dlat))
+
+    return dlon, dlat
 
 
 def _stock_cube(spec, lat_offset=True, lon_offset=True):

--- a/esmvaltool/cmorizers/obs/cmorize_obs_cds_uerra.py
+++ b/esmvaltool/cmorizers/obs/cmorize_obs_cds_uerra.py
@@ -245,6 +245,7 @@ def _cmorize_dataset(in_file, var, cfg, out_dir):
     cube.long_name = definition.long_name
 
     # Convert units if required
+    cube.units = '1'
     cube.convert_units(definition.units)
 
     # Set global attributes


### PR DESCRIPTION
Private import and on top of it all, func changed name from `_stock_cube` to `_global_stock_cube`. A bit clunky since I had to move a host of global variables but heyho, more secure now.