### PR TITLE
skip recipe filler tests until we have a new release since GA tests are failing

### DIFF
--- a/tests/integration/test_recipe_filler.py
+++ b/tests/integration/test_recipe_filler.py
@@ -1,13 +1,15 @@
 """Tests for _data_finder.py."""
 import contextlib
 import os
-import sys
 import shutil
+import sys
 import tempfile
 
 import pytest
 import yaml
+from packaging import version
 
+import esmvalcore
 import esmvaltool.utils.recipe_filler as recipe_filler
 from esmvalcore.cmor.table import read_cmor_tables
 from esmvaltool.utils.recipe_filler import run
@@ -119,7 +121,10 @@ def setup_files(tmp_path, root, cfg):
     return user_config_file, recipe, output_recipe
 
 
-@pytest.mark.skip(reason="reactivate for esmvalcore=2.3.0")
+@pytest.mark.skipif(
+    version.parse(esmvalcore.__version__) < version.parse("2.3.0"),
+    reason="reactivate for esmvalcore=2.3.0"
+)
 @pytest.mark.parametrize('cfg', CONFIG['has_additional_datasets'])
 def test_adding_datasets(tmp_path, root, cfg):
     """Test retrieving additional datasets."""
@@ -145,7 +150,10 @@ def test_adding_datasets(tmp_path, root, cfg):
         assert "additional_datasets" in var
 
 
-@pytest.mark.skip(reason="reactivate for esmvalcore=2.3.0")
+@pytest.mark.skipif(
+    version.parse(esmvalcore.__version__) < version.parse("2.3.0"),
+    reason="reactivate for esmvalcore=2.3.0"
+)
 @pytest.mark.parametrize('cfg', CONFIG['no_additional_datasets'])
 def test_not_adding_datasets(tmp_path, root, cfg):
     """Test retrieving no additional datasets."""
@@ -171,7 +179,10 @@ def test_not_adding_datasets(tmp_path, root, cfg):
         assert "additional_datasets" not in var
 
 
-@pytest.mark.skip(reason="reactivate for esmvalcore=2.3.0")
+@pytest.mark.skipif(
+    version.parse(esmvalcore.__version__) < version.parse("2.3.0"),
+    reason="reactivate for esmvalcore=2.3.0"
+)
 def test_bad_var(tmp_path, root):
     """Test a bad variable in the works."""
     cfg = CONFIG['bad_variable'][0]

--- a/tests/integration/test_recipe_filler.py
+++ b/tests/integration/test_recipe_filler.py
@@ -119,6 +119,7 @@ def setup_files(tmp_path, root, cfg):
     return user_config_file, recipe, output_recipe
 
 
+@pytest.mark.skip(reason="reactivate for esmvalcore=2.3.0")
 @pytest.mark.parametrize('cfg', CONFIG['has_additional_datasets'])
 def test_adding_datasets(tmp_path, root, cfg):
     """Test retrieving additional datasets."""
@@ -144,6 +145,7 @@ def test_adding_datasets(tmp_path, root, cfg):
         assert "additional_datasets" in var
 
 
+@pytest.mark.skip(reason="reactivate for esmvalcore=2.3.0")
 @pytest.mark.parametrize('cfg', CONFIG['no_additional_datasets'])
 def test_not_adding_datasets(tmp_path, root, cfg):
     """Test retrieving no additional datasets."""
@@ -169,6 +171,7 @@ def test_not_adding_datasets(tmp_path, root, cfg):
         assert "additional_datasets" not in var
 
 
+@pytest.mark.skip(reason="reactivate for esmvalcore=2.3.0")
 def test_bad_var(tmp_path, root):
     """Test a bad variable in the works."""
     cfg = CONFIG['bad_variable'][0]


### PR DESCRIPTION
Since the GA development tests are using the latest esmvalcore development branch, and the recipe filler is configured for the (lagging behind) release, GA full development tests are failing, that, in turn, may mask an issue with the latest esmvalcore development branch + esmvaltool. Discussed with @schlunma in #2088 :+1: We'll have to reactivate them when we release esmvalcore 2.3.0 and change the setup in the recipe filler to use the new config module

Closes #2088 