### PR TITLE
CMORizer for CLARA-AVHRR cloud data

### DIFF
--- a/doc/sphinx/source/input.rst
+++ b/doc/sphinx/source/input.rst
@@ -182,6 +182,8 @@ A list of the datasets for which a cmorizers is available is provided in the fol
 | CERES-SYN1deg                | rlds, rldscs, rlus, rluscs, rlut, rlutcs, rsds, rsdscs, rsus, rsuscs, rsut, rsutcs (3hr)             |   3  | NCL             |
 |                              | rlds, rldscs, rlus, rlut, rlutcs, rsds, rsdt, rsus, rsut, rsutcs (Amon)                              |      |                 |
 +------------------------------+------------------------------------------------------------------------------------------------------+------+-----------------+
+| CLARA-AVHRR                  | clt, clivi, clwvi (Amon)                                                                             |   3  | NCL             |
++------------------------------+------------------------------------------------------------------------------------------------------+------+-----------------+
 | CowtanWay                    | tasa (Amon)                                                                                          |   2  | Python          |
 +------------------------------+------------------------------------------------------------------------------------------------------+------+-----------------+
 | CRU                          | tas, pr (Amon)                                                                                       |   2  | Python          |

--- a/doc/sphinx/source/input.rst
+++ b/doc/sphinx/source/input.rst
@@ -182,7 +182,7 @@ A list of the datasets for which a cmorizers is available is provided in the fol
 | CERES-SYN1deg                | rlds, rldscs, rlus, rluscs, rlut, rlutcs, rsds, rsdscs, rsus, rsuscs, rsut, rsutcs (3hr)             |   3  | NCL             |
 |                              | rlds, rldscs, rlus, rlut, rlutcs, rsds, rsdt, rsus, rsut, rsutcs (Amon)                              |      |                 |
 +------------------------------+------------------------------------------------------------------------------------------------------+------+-----------------+
-| CLARA-AVHRR                  | clt, clivi, clwvi (Amon)                                                                             |   3  | NCL             |
+| CLARA-AVHRR                  | clt, clivi, lwp (Amon)                                                                               |   3  | NCL             |
 +------------------------------+------------------------------------------------------------------------------------------------------+------+-----------------+
 | CowtanWay                    | tasa (Amon)                                                                                          |   2  | Python          |
 +------------------------------+------------------------------------------------------------------------------------------------------+------+-----------------+

--- a/esmvaltool/cmorizers/obs/cmorize_obs_clara_avhrr.ncl
+++ b/esmvaltool/cmorizers/obs/cmorize_obs_clara_avhrr.ncl
@@ -1,0 +1,235 @@
+; #############################################################################
+; ESMValTool CMORizer for CM SAF CLARA-AHRR v2 data
+; #############################################################################
+;
+; Tier
+;    Tier 3: restricted dataset.
+;
+; Source
+;    https://wui.cmsaf.eu/
+;
+; Last access
+;    2021-03-22
+;
+; Download and processing instructions
+;    1) Create ("register") an user account at
+;       https://wui.cmsaf.eu/safira/action/viewLogin?menuName=NUTZER_HOME
+;    2) login (same URL as above)
+;    3) Search data using search form at
+;       https://wui.cmsaf.eu/safira/action/viewProduktHome?menuName=PRODUKT_HOME
+;
+;      - Product group: Climate Data Records
+;      - Product family: CLARA-A ed. 2.1
+;      - Product name: CFC - Factional cloud cover
+;                      IWP - Ice water path
+;                      LWP - Liquid water path
+;      - Area: Global
+;      - Temporal resolution: Monthly
+;
+;    4) Select "CLARA-A ed. 2.1 AVHRR on polar orbiting satellites" from
+;       list of results.
+;    5) Click on "Add to order cart"
+;    6) Follow download instructions in automatic email received when data
+;       are ready for download.
+;    7) Untar all .tar files into a single directory.
+;
+; Modification history
+;    20210323-laue_axel: written.
+;
+; #############################################################################
+loadscript(getenv("esmvaltool_root") + \
+           "/esmvaltool/cmorizers/obs/interface.ncl")
+
+begin
+
+  ; Script name (for logger)
+  DIAG_SCRIPT = "cmorize_obs_clara_avhrr.ncl"
+
+  ; Source name
+  OBSNAME = "CLARA-AVHRR"
+
+  ; Tier
+  TIER = 3
+
+  ; Period
+  YEAR1 = 1982
+  YEAR2 = 2018
+
+  ; Selected variable (standard name)
+  VAR = (/"clt", "clivi", "clwvi"/)
+
+  ; Name in the raw data
+  NAME = (/"cfc", "iwp_allsky", "lwp_allsky"/)
+
+  ; Filename base
+  FNBASE = (/"CFCmm", "IWPmm", "LWPmm"/)
+
+  ; Conversion factor
+  ; Remark: total cloud cover (CFC) is reported as "1" but is actually "%"
+  ; IWP and LWP use scale_factor to convert to kg/m2
+  ;CONV = (/1., 1., 1./)
+
+  ; MIP
+  MIP = (/"Amon", "Amon", "Amon"/)
+
+  ; Frequency
+  FREQ = (/"mon", "mon", "mon"/)
+
+  ; CMOR table
+  CMOR_TABLE = getenv("cmor_tables") + \
+    (/"/cmip5/Tables/CMIP5_Amon", \
+      "/cmip5/Tables/CMIP5_Amon", \
+      "/cmip5/Tables/CMIP5_Amon"/)
+
+  ; Type
+  TYPE = "sat"
+
+  ; Version
+  VERSION = "V002_01"
+
+  ; Global attributes
+  SOURCE = "https://wui.cmsaf.eu/"
+  REF = "https://doi.org/10.5676/EUM_SAF_CM/CLARA_AVHRR/V002_01"
+  COMMENT = "The CM SAF data are owned by EUMETSAT and are available to " \
+    + "all users free of charge and with no conditions to use. If you wish " \
+    + "to use these products, EUMETSAT's copyright credit must be shown by " \
+    + "displaying the words 'Copyright (c) (2020) EUMETSAT' under/in each " \
+    + "of these SAF Products used in a project or shown in a publication " \
+    + "or website. Please follow the citation guidelines given at " \
+    + "https://doi.org/10.5676/EUM_SAF_CM/CLARA_AVHRR/V002_01 and also " \
+    + "register as a user at http://cm-saf.eumetsat.int/ to receive latest " \
+    + "information on CM SAF services and to get access to the CM SAF User " \
+    + "Help Desk."
+
+end
+
+begin
+
+  do vv = 0, dimsizes(VAR) - 1
+
+    log_info("Processing " + VAR(vv) + " (" + MIP(vv) + ")")
+
+    time = create_timec(YEAR1, YEAR2)
+    date = cd_calendar(time, 1)
+
+    ; Create timeseries
+    do yy = YEAR1, YEAR2
+
+      syear = sprinti("%i", yy)
+      do mm = 1, 12
+
+        smonth = sprinti("%0.2i", mm)
+
+        ; Read file
+        fname = systemfunc("ls " + input_dir_path + FNBASE(vv) + \
+                           syear + smonth + "01*.nc")
+
+        ; No files found
+        if (ismissing(fname)) then
+          continue
+        end if
+
+        ; Extract data
+        f = addfile(fname, "r")
+        val = f->$NAME(vv)$
+        if (isatt(val, "scale_factor")) then
+          scalefac = tofloat(val@scale_factor)
+        else
+          scalefac = 1.0
+        end if
+        if (isatt(val, "add_offset")) then
+          offset = tofloat(val@add_offset)
+        else
+          offset = 0.0
+        end if
+        xx = tofloat(val) * scalefac + offset
+        delete(val)
+
+        ; lwp is not a CMOR variable, derive as clwvi = lwp + iwp
+        if (VAR(vv).eq."clwvi") then
+          ; Read 2nd variable containing iwp (variable "iwp_allsky")
+          ii = ind(NAME .eq. "iwp_allsky")
+          fname2 = systemfunc("ls " + input_dir_path + FNBASE(ii) + \
+                              syear + smonth + "01*.nc")
+          ; No files found
+          if (ismissing(fname)) then
+            continue
+          end if
+          ; Extract data
+          f2 = addfile(fname2, "r")
+          iwpname = NAME(ii)
+          xx2 = f2->$iwpname$
+          if (isatt(xx2, "scale_factor")) then
+            scalefac = tofloat(xx2@scale_factor)
+          else
+            scalefac = 1.0
+          end if
+          if (isatt(xx2, "add_offset")) then
+            offset = tofloat(xx2@add_offset)
+          else
+            offset = 0.0
+          end if
+          iwp = tofloat(xx2) * scalefac + offset
+          delete(xx2)
+          ; add iwp to lwp to calculate cmor variable "clwvi"
+          xx = xx + iwp
+          delete(iwp)
+          delete(fname2)
+        end if
+
+        ; Assign to global array
+        if (.not.isdefined("output")) then
+          dims = dimsizes(xx)
+          dims(0) = dimsizes(time)
+          output = new(dims, float)
+          output!0 = "time"
+          output&time = time
+          output!1 = "lat"
+          output&lat = f->lat
+          output!2 = "lon"
+          output&lon = f->lon
+        end if
+        output(ind(toint(yy * 100 + mm).eq.date), :, :) = (/xx/)
+
+        delete(fname)
+        delete(f)
+
+      end do
+    end do
+
+    ; Set fill value
+    output = where(output.eq.xx@_FillValue, output@_FillValue, output)
+
+    ; Format coordinates
+    output!0 = "time"
+    output!1 = "lat"
+    output!2 = "lon"
+    format_coords(output, YEAR1 + "0101", YEAR2 + "1231", FREQ(vv))
+
+    ; Set variable attributes
+    tmp = format_variable(output, VAR(vv), CMOR_TABLE(vv))
+    delete(output)
+    output = tmp
+    delete(tmp)
+
+    ; Calculate coordinate bounds
+    bounds = guess_coord_bounds(output, FREQ(vv))
+
+    ; Set global attributes
+    gAtt = set_global_atts(OBSNAME, TIER, SOURCE, REF, COMMENT)
+
+    ; Output file
+    DATESTR = YEAR1 + "01-" + YEAR2 + "12"
+    fout = output_dir_path + \
+      str_join((/"OBS", OBSNAME, TYPE, VERSION, \
+                 MIP(vv), VAR(vv), DATESTR/), "_") + ".nc"
+
+    ; Write variable
+    write_nc(fout, VAR(vv), output, bounds, gAtt)
+    delete(gAtt)
+    delete(output)
+    delete(bounds)
+
+  end do
+
+end

--- a/esmvaltool/cmorizers/obs/cmorize_obs_clara_avhrr.ncl
+++ b/esmvaltool/cmorizers/obs/cmorize_obs_clara_avhrr.ncl
@@ -34,7 +34,8 @@
 ;    7) Untar all .tar files into a single directory.
 ;
 ; Modification history
-;    20210323-laue_axel: written.
+;    20210506-lauer_axel: output of lwp instead of clwvi
+;    20210323-lauer_axel: written.
 ;
 ; #############################################################################
 loadscript(getenv("esmvaltool_root") + \
@@ -56,7 +57,7 @@ begin
   YEAR2 = 2018
 
   ; Selected variable (standard name)
-  VAR = (/"clt", "clivi", "clwvi"/)
+  VAR = (/"clt", "clivi", "lwp"/)
 
   ; Name in the raw data
   NAME = (/"cfc", "iwp_allsky", "lwp_allsky"/)
@@ -79,7 +80,7 @@ begin
   CMOR_TABLE = getenv("cmor_tables") + \
     (/"/cmip5/Tables/CMIP5_Amon", \
       "/cmip5/Tables/CMIP5_Amon", \
-      "/cmip5/Tables/CMIP5_Amon"/)
+      "/custom/CMOR_lwp.dat"/)
 
   ; Type
   TYPE = "sat"
@@ -126,6 +127,8 @@ begin
 
         ; No files found
         if (ismissing(fname)) then
+          log_info("Warning: no input data found for variable " + VAR(vv) + \
+                   " (" + syear + smonth + ")")
           continue
         end if
 
@@ -144,38 +147,6 @@ begin
         end if
         xx = tofloat(val) * scalefac + offset
         delete(val)
-
-        ; lwp is not a CMOR variable, derive as clwvi = lwp + iwp
-        if (VAR(vv).eq."clwvi") then
-          ; Read 2nd variable containing iwp (variable "iwp_allsky")
-          ii = ind(NAME .eq. "iwp_allsky")
-          fname2 = systemfunc("ls " + input_dir_path + FNBASE(ii) + \
-                              syear + smonth + "01*.nc")
-          ; No files found
-          if (ismissing(fname)) then
-            continue
-          end if
-          ; Extract data
-          f2 = addfile(fname2, "r")
-          iwpname = NAME(ii)
-          xx2 = f2->$iwpname$
-          if (isatt(xx2, "scale_factor")) then
-            scalefac = tofloat(xx2@scale_factor)
-          else
-            scalefac = 1.0
-          end if
-          if (isatt(xx2, "add_offset")) then
-            offset = tofloat(xx2@add_offset)
-          else
-            offset = 0.0
-          end if
-          iwp = tofloat(xx2) * scalefac + offset
-          delete(xx2)
-          ; add iwp to lwp to calculate cmor variable "clwvi"
-          xx = xx + iwp
-          delete(iwp)
-          delete(fname2)
-        end if
 
         ; Assign to global array
         if (.not.isdefined("output")) then

--- a/esmvaltool/cmorizers/obs/cmorize_obs_clara_avhrr.ncl
+++ b/esmvaltool/cmorizers/obs/cmorize_obs_clara_avhrr.ncl
@@ -16,7 +16,7 @@
 ;       https://wui.cmsaf.eu/safira/action/viewLogin?menuName=NUTZER_HOME
 ;    2) login (same URL as above)
 ;    3) Search data using search form at
-;       https://wui.cmsaf.eu/safira/action/viewProduktHome?menuName=PRODUKT_HOME
+;    https://wui.cmsaf.eu/safira/action/viewProduktHome?menuName=PRODUKT_HOME
 ;
 ;      - Product group: Climate Data Records
 ;      - Product family: CLARA-A ed. 2.1
@@ -67,7 +67,7 @@ begin
   ; Conversion factor
   ; Remark: total cloud cover (CFC) is reported as "1" but is actually "%"
   ; IWP and LWP use scale_factor to convert to kg/m2
-  ;CONV = (/1., 1., 1./)
+  ; CONV = (/1., 1., 1./)
 
   ; MIP
   MIP = (/"Amon", "Amon", "Amon"/)

--- a/esmvaltool/recipes/examples/recipe_check_obs.yml
+++ b/esmvaltool/recipes/examples/recipe_check_obs.yml
@@ -760,7 +760,7 @@ diagnostics:
         mip: Amon
       clivi:
         mip: Amon
-      clwvi:
+      lwp:
         mip: Amon
     additional_datasets:
       - {dataset: CLARA-AVHRR, project: OBS, tier: 3,

--- a/esmvaltool/recipes/examples/recipe_check_obs.yml
+++ b/esmvaltool/recipes/examples/recipe_check_obs.yml
@@ -753,6 +753,21 @@ diagnostics:
     scripts: null
 
 
+  CLARA-AVHRR:
+    description: CLARA-AVHRR check
+    variables:
+      clt:
+        mip: Amon
+      clivi:
+        mip: Amon
+      clwvi:
+        mip: Amon
+    additional_datasets:
+      - {dataset: CLARA-AVHRR, project: OBS, tier: 3,
+         type: sat, version: V002_01, start_year: 1982, end_year: 2018}
+    scripts: null
+
+
   ERA-Interim:
     description: ERA-Interim check
     variables:

--- a/esmvaltool/references/clara-avhrr.bibtex
+++ b/esmvaltool/references/clara-avhrr.bibtex
@@ -1,0 +1,9 @@
+@article{clara-avhrr,
+	doi = {10.5676/EUM_SAF_CM/CLARA_AVHRR/V002_01},
+	url = {https://doi.org/10.5676/EUM_SAF_CM/CLARA_AVHRR/V002_01},
+	year = 2020,
+	publisher = {Satellite Application Facility on Climate Monitoring (CM SAF)},
+	author = {Karlsson, Karl-Göran and Anttila, Kati and Trentmann, Jörg and Stengel, Martin and Solodovnik, Irina and Meirink, Jan Fokke and Devasthale, Abhay and Kothe, Steffen and Jääskeläinen, Emmihenna and Sedlar, Joseph and Benas, Nikos and van Zadelhoff, Gerd-Jan and Stein, Diana and Finkensieper, Stephan and Håkansson, Nina and Hollmann, Rainer and Kaiser, Johannes and Werscheck, Martin},
+	title = {CLARA-A2.1: CM SAF cLoud, Albedo and surface RAdiation dataset from AVHRR data - Edition 2.1},
+	journal = {Satellite Application Facility on Climate Monitoring}
+}


### PR DESCRIPTION
This PR add a CMORizer script for the CLARA-AVHRR cloud dataset (variables clt, clivi, clwvi) from the Satellite Application Facility on Climate Monitoring (CM SAF).

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

### [New or updated data reformatting script](https://docs.esmvaltool.org/en/latest/develop/dataset.html)

- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/dataset.html#dataset-documentation) is available
- [x] [🛠][1] The dataset has been [added to the CMOR check recipe](https://docs.esmvaltool.org/en/latest/community/dataset.html#testing)
- [x] [🧪][2] Numbers and units of the data look [physically meaningful](https://docs.esmvaltool.org/en/latest/community/dataset.html#scientific-sanity-check)