### PR TITLE
Generalize `recipe_validation*` diagnostic to work with identical control and experiment dataset names

### DIFF
--- a/doc/sphinx/source/recipes/recipe_validation.rst
+++ b/doc/sphinx/source/recipes/recipe_validation.rst
@@ -15,9 +15,8 @@ The meridional_mean and zonal_mean produce variable vs coordinate (``latitude`` 
 in each plot, for the entire duration of time specified and also, if the user wishes, for each season (seasonal means): winter DJF, spring MAM, summer JJA, autumn SON (by setting ``seasonal_analysis: true`` in the recipe).
 
 At least regridding on a common grid for all model and observational datasets should be performed in preprocessing (if datasets
-are on different grids). Also note that currently it is not allowed to use the same dataset (with varying parameters like experiment
-or ensemble) for both CONTROL and EXPERIMENT (the use case for comparison between different experiments or ensembles for the same model
-will be implemented in a future release).
+are on different grids). Also note that it is allowed to use the same dataset (with varying parameters like experiment
+or ensemble or mip) for both CONTROL and EXPERIMENT (as long as at least one data parameter is different).
 
 Available recipes and diagnostics
 -----------------------------------

--- a/esmvaltool/diag_scripts/shared/_validation.py
+++ b/esmvaltool/diag_scripts/shared/_validation.py
@@ -36,7 +36,21 @@ def get_control_exper_obs(short_name, input_data, cfg, cmip_type):
     else:
         obs_selection = []
 
+    # print out OBS's
+    if obs_selection:
+        logger.info("Observations dataset(s) %s",
+                    [obs['dataset'] for obs in obs_selection])
+
     # determine CONTROL and EXPERIMENT datasets
+
+    # corner case: they could be the same dataset name
+    if cfg['control_model'] == cfg['exper_model']:
+        logger.info("Identical Control/Experiment dataset names: %s",
+                    dataset_selection[0]['dataset'])
+        control, experiment = dataset_selection
+        return control, experiment, obs_selection
+
+    # if they're not the same dataset, fire away
     for model in dataset_selection:
         if model['dataset'] == cfg['control_model']:
             logger.info("Control dataset %s", model['dataset'])
@@ -44,10 +58,6 @@ def get_control_exper_obs(short_name, input_data, cfg, cmip_type):
         elif model['dataset'] == cfg['exper_model']:
             logger.info("Experiment dataset %s", model['dataset'])
             experiment = model
-
-    if obs_selection:
-        logger.info("Observations dataset(s) %s",
-                    [obs['dataset'] for obs in obs_selection])
 
     return control, experiment, obs_selection
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

This is a natural evolution of the `validation.py` diagnostic making it work when one supplies the same datasets for both CONTROL and EXPERIMENT ie the same dataset name, but with differing parameters (like `mip` or `exp` or `grid` etc - at least one of these parameters needs to differ); this is useful when comparing the same instance of a model but for different runs.

- Closes #2281 
- Link to documentation:

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [ ] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [x] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [x] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)

### [New or updated data reformatting script](https://docs.esmvaltool.org/en/latest/develop/dataset.html)

***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
