### PR TITLE
Temporary pin esmpy to `esmpy!=8.1.0` to bring environment in harmony with ESMValCore

### DIFF
--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
     - main
-    - pin_esmpy
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/action-test-development.yml
+++ b/.github/workflows/action-test-development.yml
@@ -12,7 +12,7 @@ on:
   push:
     branches:
     - main
-    - unpin_iris
+    - pin_esmpy
   schedule:
     - cron: '0 0 * * *'
 

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - cartopy>=0.18
   - compilers
   - gdal
-  - esmpy
+  - esmpy!=8.1.0  # see github.com/ESMValGroup/ESMValCore/issues/1208
   - esmvalcore>=2.3.1,<2.4
   - iris>=3.0.2
   - matplotlib>3.3.1,<3.4  # bug in 3.3.1, issue with nc-time-axis for >=3.4

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -78,7 +78,7 @@ outputs:
         - dask>=2.12
         - ecmwf-api-client  # in esmvalgroup channel
         - eofs
-        - esmpy
+        - esmpy!=8.1.0,  # see github.com/ESMValGroup/ESMValCore/issues/1208
         - esmvalcore>=2.3.1,<2.4  # in esmvalgroup channel
         - fiona
         - gdal

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ REQUIREMENTS = {
         'dask>=2.12',
         'ecmwf-api-client',
         'eofs',
-        'esmpy!=8.1.0',  # see github.com/ESMValGroup/ESMValCore/issues/1208
         'esmvalcore>=2.3.1,<2.4',
         'fiona',
         'GDAL',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ REQUIREMENTS = {
         'dask>=2.12',
         'ecmwf-api-client',
         'eofs',
-        'ESMPy',
+        'esmpy!=8.1.0',  # see github.com/ESMValGroup/ESMValCore/issues/1208
         'esmvalcore>=2.3.1,<2.4',
         'fiona',
         'GDAL',

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ REQUIREMENTS = {
         'ecmwf-api-client',
         'eofs',
         'esmvalcore>=2.3.1,<2.4',
+        'esmpy',
         'fiona',
         'GDAL',
         'jinja2',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ REQUIREMENTS = {
         'ecmwf-api-client',
         'eofs',
         'esmvalcore>=2.3.1,<2.4',
-        'esmpy',
+        'ESMPy',
         'fiona',
         'GDAL',
         'jinja2',


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

`esmpy` is at odds in Tool vs Core: free env creation grabs 8.1.1 for Core and 8.1.0 for Tool (8.1.1 can not currently be installed in the Tool environment, due to some deps conflict). So when it comes to first installing Tool, then going to install Core in development mode (overriding the conda-forge installed Core while creating the environment), one gets to a deadlock seen in the latest [Github Actions test](https://github.com/ESMValGroup/ESMValTool/runs/3710532309?check_suite_focus=true) runs. Pinning it this way ensures harmony between Core and Tool via the installation of 8.0.1.

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
- Closes - no issue created

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->


## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [ ] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful


