### PR TITLE
Update a diagnostic to new Iris version

### DIFF
--- a/esmvaltool/diag_scripts/ipcc_ar5/ch09_fig09_14.py
+++ b/esmvaltool/diag_scripts/ipcc_ar5/ch09_fig09_14.py
@@ -24,7 +24,7 @@ import logging
 import os
 
 import iris
-from iris.experimental.equalise_cubes import equalise_attributes
+from iris.util import equalise_attributes
 from iris.exceptions import CoordinateNotFoundError
 import iris.plot as iplt
 import matplotlib


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description
Recipe recipe_flato13ipcc.yml crashes due to a new IRIS version:
2021-10-28 11:31:58,651 [5412] INFO esmvaltool.diag_scripts.shared._base,550 Creating /work/bd1083/b380216/output/recipe_flato13ipcc_20211028_100738/plots/fig09-14/fig09-14
Traceback (most recent call last):
File "/mnt/lustre02/work/bd1083/b380216/CORE202102/ESMValTool/esmvaltool/diag_scripts/ipcc_ar5/ch09_fig09_14.py", line 407, in
main(cfg)
File "/mnt/lustre02/work/bd1083/b380216/CORE202102/ESMValTool/esmvaltool/diag_scripts/ipcc_ar5/ch09_fig09_14.py", line 396, in main
plot_path = produce_plots(config, data)
File "/mnt/lustre02/work/bd1083/b380216/CORE202102/ESMValTool/esmvaltool/diag_scripts/ipcc_ar5/ch09_fig09_14.py", line 351, in produce_plots
lines, labels = plot_zonal_mean_errors_ensemble(
File "/mnt/lustre02/work/bd1083/b380216/CORE202102/ESMValTool/esmvaltool/diag_scripts/ipcc_ar5/ch09_fig09_14.py", line 259, in plot_zonal_mean_errors_ensemble
cube_list = multi_model_merge(zonal_mean_errors)
File "/mnt/lustre02/work/bd1083/b380216/CORE202102/ESMValTool/esmvaltool/diag_scripts/ipcc_ar5/ch09_fig09_14.py", line 177, in multi_model_merge
equalise_attributes(cube_list)
File "/work/bd0854/b380216/anaconda3/envs/esmvaltool202106/lib/python3.9/site-packages/iris/experimental/equalise_cubes.py", line 30, in equalise_attributes
raise Exception(emsg)
Exception: The function "iris.experimental.equalise_cubes.equalise_attributes" has been moved.
Please replace "iris.experimental.equalise_cubes.equalise_attributes()" with "iris.util.equalise_attributes()".

It should be easy to fix with changing:
from iris.experimental.equalise_cubes import equalise_attributes
to
from iris.util import equalise_attributes
This new line is already used in ESMValCore/esmvalcore/preprocessor/_multimodel.py

I make this a draft first because I want to check if it runs (it did not the first time but that could have been caused by other issues.)
<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
- Closes #issue_number
- Link to documentation:

* * *

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [ ] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [x] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [x] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [x] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added

***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
