### PR TITLE
Removed custom version of `AtmosphereSigmaFactory` in diagnostics

### DIFF
--- a/esmvaltool/diag_scripts/emergent_constraints/ecs_scatter.py
+++ b/esmvaltool/diag_scripts/emergent_constraints/ecs_scatter.py
@@ -49,7 +49,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
-from esmvalcore.cmor.fixes import add_plev_from_altitude, add_sigma_factory
+from esmvalcore.cmor.fixes import add_plev_from_altitude
 from joblib import Parallel, delayed
 from scipy.interpolate import interp1d
 from scipy.stats import linregress
@@ -384,8 +384,6 @@ def _get_zhai_data_frame(datasets, lat_constraint):
     if not cl_cube.coords('air_pressure'):
         if cl_cube.coords('altitude'):
             add_plev_from_altitude(cl_cube)
-        elif cl_cube.coords('atmosphere_sigma_coordinate'):
-            add_sigma_factory(cl_cube)
         else:
             raise ValueError(
                 f"No 'air_pressure' coord available in cube "
@@ -474,8 +472,6 @@ def brient_shal(grouped_data, cfg):
         if not cl_cube.coords('air_pressure'):
             if cl_cube.coords('altitude'):
                 add_plev_from_altitude(cl_cube)
-            elif cl_cube.coords('atmosphere_sigma_coordinate'):
-                add_sigma_factory(cl_cube)
             else:
                 raise ValueError(
                     f"No 'air_pressure' coord available in cube "


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

This PR removes the custom version of `AtmosphereSigmaFactory` in all affected diagnostics.

Corresponding PR in the core: ESMValGroup/ESMValCore#1382

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
- Related to ESMValGroup/ESMValCore#1380 and #2354 

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [x] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [x] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [x] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [x] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added


***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
