### PR TITLE
Fix diagnostic that uses `xarray`: `dtype` correctly set and harmonize `xarray` and `matplotlib`

### DIFF
--- a/esmvaltool/diag_scripts/kcs/local_resampling.py
+++ b/esmvaltool/diag_scripts/kcs/local_resampling.py
@@ -262,7 +262,7 @@ def _best_subset(combinations, n_sample=8):
     # Store the indices in a nice dataframe
     n_segments = combinations.shape[1]
     best_subset = pd.DataFrame(
-        data=None,
+        data=np.empty((n_sample, n_segments), dtype=int),
         columns=[f'Segment {x}' for x in range(n_segments)],
         index=[f'Combination {x}' for x in range(n_sample)])
 

--- a/esmvaltool/diag_scripts/kcs/local_resampling.py
+++ b/esmvaltool/diag_scripts/kcs/local_resampling.py
@@ -8,10 +8,13 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from esmvaltool.diag_scripts.shared import (ProvenanceLogger,
-                                            get_diagnostic_filename,
-                                            get_plot_filename, run_diagnostic,
-                                            select_metadata)
+from esmvaltool.diag_scripts.shared import (
+    ProvenanceLogger,
+    get_diagnostic_filename,
+    get_plot_filename,
+    run_diagnostic,
+    select_metadata,
+)
 
 LOGGER = logging.getLogger(Path(__file__).name)
 
@@ -199,8 +202,8 @@ def _within_bounds(values, bounds):
 def _get_subset(top1000, info, period):
     """Select samples based on the percentile bounds.
 
-    Select samples for which summer pr, and summer and winter tas
-    are within the percentile bounds specified in the recipe.
+    Select samples for which summer pr, and summer and winter tas are
+    within the percentile bounds specified in the recipe.
     """
     pr_summer = _within_bounds(top1000['pr_summer'],
                                info[f'pr_summer_{period}'])
@@ -215,11 +218,11 @@ def _get_subset(top1000, info, period):
 def get_percentile_subsets(cfg, segment_season_means, top1000s):
     """Get subsets based on percentile ranges.
 
-    For each set of 1000 samples, compute summer precipitation,
-    and summer and winter temperature.
-    Then, for each scenario, select samples for which
-    summer precipitation, and summer and winter temperature are
-    within the percentile bounds specified in the recipe.
+    For each set of 1000 samples, compute summer precipitation, and
+    summer and winter temperature. Then, for each scenario, select
+    samples for which summer precipitation, and summer and winter
+    temperature are within the percentile bounds specified in the
+    recipe.
     """
     # Overwrite top1000s with seasonal mean characteristics
     for name, dataframe in top1000s.items():
@@ -286,11 +289,10 @@ def _best_subset(combinations, n_sample=8):
 def select_final_subset(cfg, subsets, prov=None):
     """Select sample with minimal reuse of ensemble segments.
 
-    Final set of eight samples should have with minimal reuse
-    of the same ensemble member for the same period.
-    From 10.000 randomly selected sets of 8 samples, count
-    and penalize re-used segments (1 for 3*reuse, 5 for 4*reuse).
-    Choose the set with the lowest penalty.
+    Final set of eight samples should have with minimal reuse of the
+    same ensemble member for the same period. From 10.000 randomly
+    selected sets of 8 samples, count and penalize re-used segments (1
+    for 3*reuse, 5 for 4*reuse). Choose the set with the lowest penalty.
     """
     n_samples = cfg['n_samples']
     all_scenarios = {}

--- a/esmvaltool/diag_scripts/weighting/weighted_temperature_graph.py
+++ b/esmvaltool/diag_scripts/weighting/weighted_temperature_graph.py
@@ -37,9 +37,9 @@ def visualize_and_save_temperatures(temperature: 'xr.DataArray',
 
     def plot_shaded(xrange, upper, lower, color, **kwargs):
         axes.fill_between(
-            xrange,
-            upper,
-            lower,
+            xrange.data,
+            upper.data,
+            lower.data,
             facecolor=color,
             edgecolor='none',
             alpha=0.3,
@@ -69,8 +69,8 @@ def visualize_and_save_temperatures(temperature: 'xr.DataArray',
               color=color_non_weighted,
               label='Non-weighted {}'.format(central_string))
     plot_shaded(uncertainty_range.time,
-                uncertainty_range.data[:, 0],
-                uncertainty_range.data[:, 1],
+                uncertainty_range[:, 0],
+                uncertainty_range[:, 1],
                 color=color_non_weighted,
                 label=f'Non-weighted {range_string} range')
 
@@ -80,8 +80,8 @@ def visualize_and_save_temperatures(temperature: 'xr.DataArray',
               label='Weighted {}'.format(central_string))
     plot_shaded(
         uncertainty_range_weighted.time,
-        uncertainty_range_weighted.data[:, 0],
-        uncertainty_range_weighted.data[:, 1],
+        uncertainty_range_weighted[:, 0],
+        uncertainty_range_weighted[:, 1],
         color=color_weighted,
         label='Weighted {} range'.format(range_string),
     )


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

Ensure `dtype`'s are correct and make latest `xarray` work well with `matplotlib`

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->


## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

