### PR TITLE
Remove the use of `esmvalgroup` channel from the conda install Github Action workflow

### DIFF
--- a/.github/workflows/install-from-conda.yml
+++ b/.github/workflows/install-from-conda.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
     - main
+    - remove_esmvalgroup_GA
   schedule:
     - cron: '0 4 * * *'
 
@@ -24,7 +25,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           miniconda-version: "latest"
-          channels: esmvalgroup,conda-forge
+          channels: conda-forge
       - shell: bash -l {0}
         run: mkdir -p conda_install_linux_artifacts_python_${{ matrix.python-version }}
       - shell: bash -l {0}
@@ -64,7 +65,7 @@ jobs:
 #        with:
 #          python-version: ${{ matrix.python-version }}
 #          miniconda-version: "latest"
-#          channels: esmvalgroup,conda-forge
+#          channels: conda-forge
 #      - shell: bash -l {0}
 #        run: mkdir -p conda_install_osx_artifacts_python_${{ matrix.python-version }}
 #      - shell: bash -l {0}

--- a/.github/workflows/install-from-conda.yml
+++ b/.github/workflows/install-from-conda.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
     - main
-    - remove_esmvalgroup_GA
   schedule:
     - cron: '0 4 * * *'
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

This is legacy code and due to the presence of `esmvalgroup` in the conda install GA workflow we are installing a very old esmvalcore (2.2.0), as seen [here](https://github.com/ESMValGroup/ESMValTool/runs/4178107701?check_suite_focus=true)

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

