### PR TITLE
comment out rc channel in osx environment file

### DIFF
--- a/environment_osx.yml
+++ b/environment_osx.yml
@@ -1,7 +1,10 @@
 ---
 name: esmvaltool
 channels:
-  - conda-forge/label/esmvalcore_rc
+  # The release candidate channel should only be activated
+  # during the rc phase right before the next release of the
+  # ESMValCore.
+  # - conda-forge/label/esmvalcore_rc
   - conda-forge
   - nodefaults
 


### PR DESCRIPTION
Discovered by looking at the [GA test](https://github.com/ESMValGroup/ESMValTool/runs/4172628348?check_suite_focus=true) that the rc channel should be commented out in the `environment_osx.yml` file too :beer: 