### PR TITLE
Add backwards incompatible changes at the top of the release notes draft

### DIFF
--- a/esmvaltool/utils/draft_release_notes.py
+++ b/esmvaltool/utils/draft_release_notes.py
@@ -10,7 +10,6 @@ or esmvaltool
 """
 import datetime
 from pathlib import Path
-from typing import DefaultDict
 
 import dateutil
 import esmvalcore
@@ -24,7 +23,8 @@ except ImportError:
     print("Please `pip install pygithub`")
 
 try:
-    GITHUB_API_KEY = Path("~/.github_api_key").expanduser().read_text().strip()
+    GITHUB_API_KEY = Path("~/.github_api_key").expanduser().read_text(
+        encoding='utf-8').strip()
 except FileNotFoundError:
     print("Please create an access token and store it in the file "
           "~/.github_api_key, see:\nhttps://help.github.com/en/github/"
@@ -46,6 +46,7 @@ PREVIOUS_RELEASE = {
 }
 LABELS = {
     'esmvalcore': (
+        'backwards incompatible change',
         'bug',
         'deprecated feature',
         'documentation',
@@ -58,6 +59,7 @@ LABELS = {
         'enhancement',
     ),
     'esmvaltool': (
+        'backwards incompatible change',
         'bug',
         'deprecated feature',
         'documentation',
@@ -71,8 +73,9 @@ LABELS = {
 }
 
 TITLES = {
-    'bug': 'Bug fixes',
+    'backwards incompatible change': 'Backwards incompatible changes',
     'deprecated feature': 'Deprecations',
+    'bug': 'Bug fixes',
     'cmor': 'CMOR standard',
     'diagnostic': 'Diagnostics',
     'fix for dataset': 'Fixes for datasets',
@@ -106,7 +109,7 @@ def draft_notes_since(project, previous_release_date=None, labels=None):
 
     pulls = _get_pull_requests(project)
 
-    lines = DefaultDict(list)
+    lines = {label: [] for label in labels}
     labelless_pulls = []
     for pull in pulls:
         print(pull.updated_at, pull.merged_at, pull.number, pull.title)
@@ -126,21 +129,33 @@ def draft_notes_since(project, previous_release_date=None, labels=None):
     # Warn about label-less PR:
     _list_labelless_pulls(labelless_pulls)
 
-    # Create sections
+    # Format lines to a human readable changelog
+    format_notes(lines, VERSION[project])
+
+
+def format_notes(lines, version):
+    """Format release notes."""
     sections = [
-        VERSION[project],
-        '-' * len(VERSION[project]),
+        version,
+        '-' * len(version),
+        'Highlights',
+        '',
+        'TODO: add highlights',
         '',
         "This release includes",
     ]
-    for label in labels:
+    for label in lines:
         try:
             entries = sorted(lines[label])  # sort by merge time
         except KeyError:
             continue
         title = TITLES.get(label, label.title())
-        sections.append('\n'.join(['', title, '~' * len(title), '']))
-        sections.append('\n'.join(entry for _, entry in entries))
+        if entries:
+            sections.append('\n'.join(['', title, '~' * len(title), '']))
+            if label == 'backwards incompatible change':
+                sections.append(
+                    'TODO: add examples of how to deal with these changes\n')
+            sections.append('\n'.join(entry for _, entry in entries))
     notes = '\n'.join(sections)
     print(notes)
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
This adds any backwards-incompatible changes at the top of the draft release notes that can be generated with the draft_release_notes.py tool.

@zklaus Would it be possible to re-generate the release notes for ESMValCore v2.4 with this version of the script? I realized that backwards-incompatible changes are currently hard to find in the changelog.

- Link to documentation: https://esmvaltool--2431.org.readthedocs.build/en/2431/utils.html#draft-release-notes-py

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [ ] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful


***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
