### PR TITLE
Add `python-cdo` as conda-forge dependency in environment files to ensure `cdo` gets used from conda-forge and not pip

### DIFF
--- a/.github/workflows/test-development.yml
+++ b/.github/workflows/test-development.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
     - main
-    - add_python-cdo_conda_dependency
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/test-development.yml
+++ b/.github/workflows/test-development.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
     - main
+    - add_python-cdo_conda_dependency
   schedule:
     - cron: '0 0 * * *'
 

--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,7 @@ dependencies:
   - imagemagick
   - julia
   - nco
+  - python-cdo
   - ruamel.yaml
   - scikit-learn  # may hit hw-specific issue if from pypi https://github.com/scikit-learn/scikit-learn/issues/14485
   - xgboost

--- a/environment_osx.yml
+++ b/environment_osx.yml
@@ -21,6 +21,7 @@ dependencies:
   - cdo
   - imagemagick
   - nco
+  - python-cdo
   - ruamel.yaml
   # may hit hw-specific issue if from pypi
   # https://github.com/scikit-learn/scikit-learn/issues/14485


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

This is an idea stemmed from @zklaus 's https://github.com/ESMValGroup/ESMValTool/issues/2457#issuecomment-1010093402 and responded through this chain of install events:

@zklaus good point about conda-forge! So as it stands now, the chain of events is as follows:

- when creating the conda env, with `mamba env create -n esmvalttool -f environment.yml`, mamba installs `cdo` from conda-forge, but tis not Python-functional since it doesn't have `python-cdo`:
```
(base) valeriu@valeriu-PORTEGE-Z30-C:~/ESMValTool$ conda activate esmvaltool2
(esmvaltool2) valeriu@valeriu-PORTEGE-Z30-C:~/ESMValTool$ conda list cdo
# packages in environment at /home/valeriu/miniconda3/envs/esmvaltool2:
#
# Name                    Version                   Build  Channel
cdo                       2.0.2                h34154eb_0    conda-forge
(esmvaltool2) valeriu@valeriu-PORTEGE-Z30-C:~/ESMValTool$ vim testcdo.py
(esmvaltool2) valeriu@valeriu-PORTEGE-Z30-C:~/ESMValTool$ python testcdo.py
Traceback (most recent call last):
  File "/home/valeriu/ESMValTool/testcdo.py", line 1, in <module>
    from cdo import Cdo
ModuleNotFoundError: No module named 'cdo'
```
- then, after installing ESMValTool with `pip install -e .[develop]`, `pip` installs the Python cdo wheel:
```
Collecting cdo
  Using cached cdo-1.5.6-py3-none-any.whl
```
and this one replaces the conda-forge installed package.

As I see it, we can add `python-cdo` as conda dependency and remove `cdo` from `setup.py` and that'll insure `cdo` is straight off and only from conda-forge. Well, not remove it, but it will not be used for the install env. What do you think?

in fact I've just tested that, and adding `python-cdo` as dependency in our environment file ensures conda-forge cdo, and functional too:
```
(esmvaltool3) valeriu@valeriu-PORTEGE-Z30-C:~/ESMValTool$ conda list cdo
# packages in environment at /home/valeriu/miniconda3/envs/esmvaltool3:
#
# Name                    Version                   Build  Channel
cdo                       2.0.2                h34154eb_0    conda-forge
python-cdo                1.5.6              pyhd8ed1ab_0    conda-forge
```
Gonna open a PR now :+1: 

See https://github.com/ESMValGroup/ESMValTool/issues/2457 for full flow.

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully - yess, also [Github Actions](https://github.com/ESMValGroup/ESMValTool/actions/runs/1683533829)
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

