### PR TITLE
remove use of OBS and use CMIP instead in `examples/recipe_ncl.yml`

### DIFF
--- a/esmvaltool/recipes/examples/recipe_ncl.yml
+++ b/esmvaltool/recipes/examples/recipe_ncl.yml
@@ -26,8 +26,6 @@ datasets:
      start_year: 2000, end_year: 2002}
   - {dataset: MPI-ESM-LR, project: CMIP5, exp: historical, ensemble: r1i1p1,
      start_year: 2000, end_year: 2002}
-  - {dataset: ERA-Interim, project: OBS6, tier: 3, type: reanaly, version: 1,
-     start_year: 2000, end_year: 2002}
 
 preprocessors:
   preprocessor_1:
@@ -45,10 +43,10 @@ diagnostics:
     variables:
       ta:
         preprocessor: preprocessor_1
-        reference_dataset: ERA-Interim
+        reference_dataset: MPI-ESM-LR
         mip: Amon
         additional_datasets:
-          - {dataset: NCEP, project: OBS, tier: 2, type: reanaly, version: 1,
+          - {dataset: CanESM2, project: CMIP5, exp: historical, ensemble: r1i1p1,
              start_year: 2000, end_year: 2002}
     scripts:
       test_ta: &settings


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

As mentioned in https://github.com/ESMValGroup/ESMValTool/issues/2301 it's good to have the basic examples recipes (Python, NCL, Julia, R) not use any OBS data since it can't be automatically downloaded (yes, it can be downloaded and cmorized by the user but we shouldn't expect brand new users who we target those recipes to to do it just yet). I checked the other examples and only the NCL one needed OBS data.

I am asking two NCL-ers to review this (even though I've not changed any NCL code) and Sarah since she may want to comment from the what's best for users type of perspective :beer: 

- Closes #2301 
- Link to documentation:

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [ ] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [ ] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [ ] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [ ] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [ ] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [ ] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added

