### PR TITLE
Fixed `recipe_kcs.yml`

### DIFF
--- a/esmvaltool/diag_scripts/kcs/global_matching.py
+++ b/esmvaltool/diag_scripts/kcs/global_matching.py
@@ -106,7 +106,7 @@ def make_plot(metadata, scenarios, cfg, provenance):
                       dataset.tas.values,
                       color='k',
                       linewidth=2,
-                      label='CMIP ' + Path(filename).stem.split('_')[0][10:])
+                      label='CMIP ' + member['alias'][10:])
 
     for member in select_metadata(metadata, variable_group='tas_target'):
         filename = member['filename']

--- a/esmvaltool/diag_scripts/kcs/global_matching.py
+++ b/esmvaltool/diag_scripts/kcs/global_matching.py
@@ -35,7 +35,7 @@ def mean_of_target_models(metadata):
     target_model_data = select_metadata(metadata, variable_group='tas_target')
     files = [
         tmd['filename'] for tmd in target_model_data
-        if 'MultiModel' not in tmd['dataset']
+        if 'MultiModel' not in tmd['filename']
     ]
     datasets = xr.open_mfdataset(files, combine='nested', concat_dim='ens')
     provenance = create_provenance_record(files)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

After some changes in the multi-model preprocessors, the output attributes of the output files changed (e.g., the `dataset` attribute is set to the name of the original datasets if these are equal, not to `MultiModelXXX` anymore. This causes `recipe_kcs-yml` to fail (see e.g. #2223 and [this log](https://esmvaltool.dkrz.de/shared/esmvaltool/v2.5.0-test-rc2/recipe_kcs_20220213_153930/run/main_log_debug.txt)). This PR fixes this.

The resulting plots look very similar to those in the doc (https://docs.esmvaltool.org/en/latest/recipes/recipe_kcs.html), but it might be good if someone else could double-check this. Thanks!!

After that I will have a look at #2221 and #2223

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [x] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [x] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [x] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [x] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added

***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
