### PR TITLE
Fix MDER diagnostic regression_stepwise

### DIFF
--- a/esmvaltool/diag_scripts/mder/regression_stepwise.ncl
+++ b/esmvaltool/diag_scripts/mder/regression_stepwise.ncl
@@ -894,7 +894,7 @@ begin
       cfint2 = cdft_t(0.05 / 2.0, df) ^ 2 * ( \
         1.0 + hlp # inverse_matrix(transpose(D) # D) # transpose(hlp))
       cfint2 := cfint2(0, 0) * sigmae2
-      cfint2 := sqrt(cfint2 # xx(:, ppt))
+      cfint2 := sqrt(abs(cfint2 # xx(:, ppt)))
 
       yfit_std(ppt, 0, ti) = yfit_reg(ppt, ti) + cfint2
       yfit_std(ppt, 1, ti) = yfit_reg(ppt, ti) - cfint2


### PR DESCRIPTION
This PR fixes the diagnostic `regression_stepwise.ncl` used by `recipe_wenzel16jclim.yml`.
The problem is that calculation of the fitting errors fail in the original implementation, which then leads to the NCL drawing functions in `mder_scatter_plot` to "hang" indefinitely. In the original implementation
`cfint2 := sqrt(cfint2 # xx(:, ppt))`
produces nan as the argument of `sqrt` is negative. Changing this line to
`cfint2 := sqrt(abs(cfint2 # xx(:, ppt)))`
prevents this problem and the diagnostic runs fine. Output also looks fine to me but needs to be checked carefully by the author.