### PR TITLE
Reduced time range in `recipe_globwat.yml`

### DIFF
--- a/esmvaltool/recipes/hydrology/recipe_globwat.yml
+++ b/esmvaltool/recipes/hydrology/recipe_globwat.yml
@@ -56,8 +56,9 @@ diagnostics:
     variables:
       pr: &daily_var
         mip: day
-        start_year: 1986
-        end_year: 2016
+        # for 30 years, this calculation takes a very long time
+        # timerange: 1986/2016  # uncomment this line for the original settings
+        timerange: 19860101/19860110  # comment this line for the original settings
         # comment preprocessor to process data on the global scale
         preprocessor: area_selection
       tas: *daily_var
@@ -75,25 +76,26 @@ diagnostics:
         regrid_scheme: area_weighted
 
   diagnostic_monthly_GlobWat:
-      description: monthly precipitation and potential evaporation of ERA5 & ERA-Interim
-      additional_datasets:
-        - {dataset: ERA-Interim, project: OBS6, tier: 3, type: reanaly, version: 1}
-        - {dataset: ERA5, project: native6, type: reanaly, version: '1', tier: 3}
-      variables:
-        pr: &var_monthly
-          mip: Amon
-          start_year: 1986
-          end_year: 2016
-          # comment preprocessor to process data on the global scale
-          preprocessor: area_selection
-        tas: *var_monthly
-        # comment psl, rsds and rsdt if langbein_pet is True
-        psl: *var_monthly
-        rsds: *var_monthly
-        rsdt: *var_monthly
-      scripts:
-        script:
-          script: hydrology/globwat.py
-          target_grid_file: 'globwat/globwat_target_grid.nc'
-          evaporation_method: debruin # options: debruin or langbein
-          regrid_scheme: area_weighted
+    description: monthly precipitation and potential evaporation of ERA5 & ERA-Interim
+    additional_datasets:
+      - {dataset: ERA-Interim, project: OBS6, tier: 3, type: reanaly, version: 1}
+      - {dataset: ERA5, project: native6, type: reanaly, version: '1', tier: 3}
+    variables:
+      pr: &var_monthly
+        mip: Amon
+        # for 30 years, this calculation takes a very long time
+        # timerange: 1986/2016  # uncomment this line for the original settings
+        timerange: 198601/198612  # comment this line for the original settings
+        # comment preprocessor to process data on the global scale
+        preprocessor: area_selection
+      tas: *var_monthly
+      # comment psl, rsds and rsdt if langbein_pet is True
+      psl: *var_monthly
+      rsds: *var_monthly
+      rsdt: *var_monthly
+    scripts:
+      script:
+        script: hydrology/globwat.py
+        target_grid_file: 'globwat/globwat_target_grid.nc'
+        evaporation_method: debruin # options: debruin or langbein
+        regrid_scheme: area_weighted


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

This PR greatly reduces the time range in `recipe_globwat.yml`. Now the recipe rans in about 15 min. The original time range is still available in a comment.

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
- Closes #2543

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [x] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [x] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [x] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [x] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added
***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
