### PR TITLE
Remove missing CMIP5 data from 2 recipes

### DIFF
--- a/esmvaltool/recipes/recipe_collins13ipcc.yml
+++ b/esmvaltool/recipes/recipe_collins13ipcc.yml
@@ -166,7 +166,7 @@ diagnostics:
       - {dataset: BNU-ESM,          start_year: 1850, end_year: 2005}
       - {dataset: CESM1-BGC,        start_year: 1850, end_year: 2005}
       - {dataset: CESM1-CAM5,       start_year: 1850, end_year: 2005}
-      - {dataset: CESM1-CAM5-1-FV2, start_year: 1850, end_year: 2005}
+      #- {dataset: CESM1-CAM5-1-FV2, start_year: 1850, end_year: 2005}
       - {dataset: CESM1-FASTCHEM,   start_year: 1850, end_year: 2005}
       - {dataset: CESM1-WACCM,      start_year: 1955, end_year: 2005,
          ensemble: r2i1p1}
@@ -627,7 +627,7 @@ diagnostics:
       - {dataset: CESM1-CAM5,    exp: rcp60, start_year: 2006, end_year: 2100}
       - {dataset: CSIRO-Mk3-6-0, exp: rcp60, start_year: 2006, end_year: 2100}
       - {dataset: IPSL-CM5A-LR,  exp: rcp60, start_year: 2006, end_year: 2100}
-      - {dataset: GFDL-CM3,      exp: rcp60, start_year: 2006, end_year: 2100}
+      #- {dataset: GFDL-CM3,      exp: rcp60, start_year: 2006, end_year: 2100}
 
       - {dataset: CanESM2,       exp: rcp85, start_year: 2006, end_year: 2100}
       - {dataset: CCSM4,         exp: rcp85, start_year: 2006, end_year: 2100}
@@ -3070,8 +3070,8 @@ diagnostics:
       - {dataset: ACCESS1-3, exp: rcp85, start_year: 2006, end_year: 2100}
       - {dataset: bcc-csm1-1, exp: historical, start_year: 1960, end_year: 2005}
       - {dataset: bcc-csm1-1, exp: rcp85, start_year: 2006, end_year: 2100}
-      - {dataset: bcc-csm1-1-m, exp: historical, start_year: 1960, end_year: 2005}
-      - {dataset: bcc-csm1-1-m, exp: rcp85, start_year: 2006, end_year: 2100}
+      #- {dataset: bcc-csm1-1-m, exp: historical, start_year: 1960, end_year: 2005}
+      #- {dataset: bcc-csm1-1-m, exp: rcp85, start_year: 2006, end_year: 2100}
       - {dataset: CanESM2, exp: historical, start_year: 1960, end_year: 2005}
       - {dataset: CanESM2, exp: rcp85, start_year: 2006, end_year: 2100}
       - {dataset: CCSM4, exp: historical, start_year: 1960, end_year: 2005}
@@ -3090,8 +3090,8 @@ diagnostics:
       - {dataset: GFDL-ESM2G, exp: rcp85, start_year: 2006, end_year: 2100}
       - {dataset: GFDL-ESM2M, exp: historical, start_year: 1960, end_year: 2005}
       - {dataset: GFDL-ESM2M, exp: rcp85, start_year: 2006, end_year: 2100}
-      - {dataset: inmcm4, exp: historical, start_year: 1960, end_year: 2005}
-      - {dataset: inmcm4, exp: rcp85, start_year: 2006, end_year: 2100}
+      #- {dataset: inmcm4, exp: historical, start_year: 1960, end_year: 2005}
+      #- {dataset: inmcm4, exp: rcp85, start_year: 2006, end_year: 2100}
       - {dataset: IPSL-CM5A-LR, exp: historical, start_year: 1960, end_year: 2005}
       - {dataset: IPSL-CM5A-LR, exp: rcp85, start_year: 2006, end_year: 2100}
       - {dataset: IPSL-CM5A-MR, exp: historical, start_year: 1960, end_year: 2005}
@@ -3161,7 +3161,7 @@ diagnostics:
       - {dataset: ACCESS1-0}
       - {dataset: ACCESS1-3}
       - {dataset: bcc-csm1-1}
-      - {dataset: bcc-csm1-1-m}
+      #- {dataset: bcc-csm1-1-m}
       - {dataset: CanESM2}
       - {dataset: CCSM4}
       - {dataset: CESM1-CAM5}
@@ -3171,7 +3171,7 @@ diagnostics:
       - {dataset: GFDL-CM3}
       - {dataset: GFDL-ESM2G}
       - {dataset: GFDL-ESM2M}
-      - {dataset: inmcm4}
+      #- {dataset: inmcm4}
       - {dataset: IPSL-CM5A-LR}
       - {dataset: IPSL-CM5A-MR}
       - {dataset: IPSL-CM5B-LR}

--- a/esmvaltool/recipes/recipe_collins13ipcc.yml
+++ b/esmvaltool/recipes/recipe_collins13ipcc.yml
@@ -166,7 +166,7 @@ diagnostics:
       - {dataset: BNU-ESM,          start_year: 1850, end_year: 2005}
       - {dataset: CESM1-BGC,        start_year: 1850, end_year: 2005}
       - {dataset: CESM1-CAM5,       start_year: 1850, end_year: 2005}
-      #- {dataset: CESM1-CAM5-1-FV2, start_year: 1850, end_year: 2005}
+      #- {dataset: CESM1-CAM5-1-FV2, start_year: 1850, end_year: 2005} # data is missing on ESGF
       - {dataset: CESM1-FASTCHEM,   start_year: 1850, end_year: 2005}
       - {dataset: CESM1-WACCM,      start_year: 1955, end_year: 2005,
          ensemble: r2i1p1}
@@ -627,7 +627,7 @@ diagnostics:
       - {dataset: CESM1-CAM5,    exp: rcp60, start_year: 2006, end_year: 2100}
       - {dataset: CSIRO-Mk3-6-0, exp: rcp60, start_year: 2006, end_year: 2100}
       - {dataset: IPSL-CM5A-LR,  exp: rcp60, start_year: 2006, end_year: 2100}
-      #- {dataset: GFDL-CM3,      exp: rcp60, start_year: 2006, end_year: 2100}
+      #- {dataset: GFDL-CM3,      exp: rcp60, start_year: 2006, end_year: 2100} # data is missing on ESGF
 
       - {dataset: CanESM2,       exp: rcp85, start_year: 2006, end_year: 2100}
       - {dataset: CCSM4,         exp: rcp85, start_year: 2006, end_year: 2100}
@@ -3070,8 +3070,8 @@ diagnostics:
       - {dataset: ACCESS1-3, exp: rcp85, start_year: 2006, end_year: 2100}
       - {dataset: bcc-csm1-1, exp: historical, start_year: 1960, end_year: 2005}
       - {dataset: bcc-csm1-1, exp: rcp85, start_year: 2006, end_year: 2100}
-      #- {dataset: bcc-csm1-1-m, exp: historical, start_year: 1960, end_year: 2005}
-      #- {dataset: bcc-csm1-1-m, exp: rcp85, start_year: 2006, end_year: 2100}
+      #- {dataset: bcc-csm1-1-m, exp: historical, start_year: 1960, end_year: 2005} # areacello data missing on ESGF
+      #- {dataset: bcc-csm1-1-m, exp: rcp85, start_year: 2006, end_year: 2100} # areacello data missing on ESGF
       - {dataset: CanESM2, exp: historical, start_year: 1960, end_year: 2005}
       - {dataset: CanESM2, exp: rcp85, start_year: 2006, end_year: 2100}
       - {dataset: CCSM4, exp: historical, start_year: 1960, end_year: 2005}
@@ -3090,8 +3090,8 @@ diagnostics:
       - {dataset: GFDL-ESM2G, exp: rcp85, start_year: 2006, end_year: 2100}
       - {dataset: GFDL-ESM2M, exp: historical, start_year: 1960, end_year: 2005}
       - {dataset: GFDL-ESM2M, exp: rcp85, start_year: 2006, end_year: 2100}
-      #- {dataset: inmcm4, exp: historical, start_year: 1960, end_year: 2005}
-      #- {dataset: inmcm4, exp: rcp85, start_year: 2006, end_year: 2100}
+      #- {dataset: inmcm4, exp: historical, start_year: 1960, end_year: 2005} # areacello data missing on ESGF
+      #- {dataset: inmcm4, exp: rcp85, start_year: 2006, end_year: 2100} # areacello data missing on ESGF
       - {dataset: IPSL-CM5A-LR, exp: historical, start_year: 1960, end_year: 2005}
       - {dataset: IPSL-CM5A-LR, exp: rcp85, start_year: 2006, end_year: 2100}
       - {dataset: IPSL-CM5A-MR, exp: historical, start_year: 1960, end_year: 2005}
@@ -3161,7 +3161,7 @@ diagnostics:
       - {dataset: ACCESS1-0}
       - {dataset: ACCESS1-3}
       - {dataset: bcc-csm1-1}
-      #- {dataset: bcc-csm1-1-m}
+      #- {dataset: bcc-csm1-1-m} # areacello data missing on ESGF
       - {dataset: CanESM2}
       - {dataset: CCSM4}
       - {dataset: CESM1-CAM5}
@@ -3171,7 +3171,7 @@ diagnostics:
       - {dataset: GFDL-CM3}
       - {dataset: GFDL-ESM2G}
       - {dataset: GFDL-ESM2M}
-      #- {dataset: inmcm4}
+      #- {dataset: inmcm4} # areacello data missing on ESGF
       - {dataset: IPSL-CM5A-LR}
       - {dataset: IPSL-CM5A-MR}
       - {dataset: IPSL-CM5B-LR}

--- a/esmvaltool/recipes/recipe_perfmetrics_land_CMIP5.yml
+++ b/esmvaltool/recipes/recipe_perfmetrics_land_CMIP5.yml
@@ -308,7 +308,7 @@ diagnostics:
         start_year: 1980
         end_year: 1999
     additional_datasets:
-      - {dataset: BNU-ESM}
+      #- {dataset: BNU-ESM}
       - {dataset: CanESM2}
       - {dataset: CESM1-BGC}
       - {dataset: CMCC-CESM}

--- a/esmvaltool/recipes/recipe_perfmetrics_land_CMIP5.yml
+++ b/esmvaltool/recipes/recipe_perfmetrics_land_CMIP5.yml
@@ -308,7 +308,7 @@ diagnostics:
         start_year: 1980
         end_year: 1999
     additional_datasets:
-      #- {dataset: BNU-ESM}
+      #- {dataset: BNU-ESM} # data is missing on ESGF
       - {dataset: CanESM2}
       - {dataset: CESM1-BGC}
       - {dataset: CMCC-CESM}


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
This is the last PR to remove missing CMIP5 data from recipes. Data removed:

1. `recipe_collins13ipcc`:
  - tas_Amon_CESM1-CAM5-1-FV2_historical_r1i1p1*.nc
  - areacello_fx_bcc-csm1-1-m_historical_r0i0p0*.nc
  - areacello_fx_bcc-csm1-1-m_rcp85_r0i0p0*.nc
  - areacello_fx_inmcm4_historical_r0i0p0*.nc
  - areacello_fx_inmcm4_historical_r0i0p0*.nc
  - NOAA-GFDL/GFDL-CM3/rcp60/mon/atmos/Amon/r1i1p1/v20110601/rtmt_Amon_GFDL-CM3_rcp60_r1i1p1_*nc

2. `recipe_perfmetrics_land_CMIP5.yml`:
  - fgco2_Omon_BNU-ESM_historical_r1i1p1*.nc
  
None of the data above can be found on ESGF nodes and CMIP5 data archive.

In both cases, removing missing data is not enough to run the recipes successfully but the data retrieval step is now completed find.

[Run for recipe_perfmetrics_land_CMIP5.yml](https://esmvaltool.dkrz.de/shared/esmvaltool/v2.5.0-test-rc4/recipe_perfmetrics_land_CMIP5_20220303_185908/run/main_log_debug.txt) with missing data removed using v2.5.0rc4. Recipe crashes for data issue (model fix likely needed).

[Run for recipe_collins13ipcc](https://esmvaltool.dkrz.de/shared/esmvaltool/v2.5.0-test-rc4/recipe_collins13ipcc_20220307_130032/run/main_log_debug.txt) with missing data removed using v2.5.0rc4. Recipe crashes due to lack of memory on Mistral. The recipe is probably not runnable on Mistral but at least half of the diagnostics completed before the memory failure.

This PR aims at easing the future maintenance of these 2 recipes.

- Related to #2408 and #2535
- Link to documentation:

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
~~- [ ] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)~~
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- ~~[ ] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)~~
- [x] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- ~~[ ] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature~~
- [x] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added

### [New or updated data reformatting script](https://docs.esmvaltool.org/en/latest/develop/dataset.html)

~~- [ ] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/dataset.html#dataset-documentation) is available~~
~~- [ ] [🛠][1] The dataset has been [added to the CMOR check recipe](https://docs.esmvaltool.org/en/latest/community/dataset.html#testing)~~
~~- [ ] [🧪][2] Numbers and units of the data look [physically meaningful](https://docs.esmvaltool.org/en/latest/community/dataset.html#scientific-sanity-check)~~

***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
