### PR TITLE
Expanded recipe output comparison tool to better handle absolute paths in output

### DIFF
--- a/esmvaltool/utils/testing/regression/compare.py
+++ b/esmvaltool/utils/testing/regression/compare.py
@@ -162,7 +162,7 @@ def adapt_attributes(attributes: dict, ignore_attributes: tuple[str, ...],
             recipe_dir = get_recipe_dir_from_str(attr_val, recipe_name)
 
             # If recipe_dir is present in attribute value, assume this
-            # attribute values is a path and convert it to a relative path
+            # attribute value is a path and convert it to a relative path
             if recipe_dir is not None:
                 attr_val = Path(attr_val).relative_to(recipe_dir)
 
@@ -372,7 +372,7 @@ def get_recipe_dir_from_str(str_in: str, recipe_name: str) -> Optional[Path]:
         if recipe_dir_match[0] in str(parent):
             return parent
 
-    # If not valid parent is found, return str_in
+    # If no valid parent is found, return str_in
     # E.g., for str_in = /root/path/recipe_test_20220202_222222 no valid
     # parents are found; thus, return str_in itself
     return Path(str_in)

--- a/esmvaltool/utils/testing/regression/compare.py
+++ b/esmvaltool/utils/testing/regression/compare.py
@@ -31,7 +31,7 @@ IGNORE_FILES: tuple[str, ...] = (
 """Files to ignore when comparing results."""
 
 IGNORE_GLOBAL_ATTRIBUTES: tuple[str, ...] = (
-    'auxiliary_data_dir',
+    'auxiliary_data_dir',  # see https://github.com/ESMValGroup/ESMValCore/issues/1657
     'creation_date',
     'history',
     'provenance',

--- a/esmvaltool/utils/testing/regression/compare.py
+++ b/esmvaltool/utils/testing/regression/compare.py
@@ -31,12 +31,14 @@ IGNORE_FILES: tuple[str, ...] = (
 """Files to ignore when comparing results."""
 
 IGNORE_GLOBAL_ATTRIBUTES: tuple[str, ...] = (
-    'auxiliary_data_dir',  # see https://github.com/ESMValGroup/ESMValCore/issues/1657
+    # see https://github.com/ESMValGroup/ESMValCore/issues/1657
+    'auxiliary_data_dir',
     'creation_date',
     'history',
     'provenance',
     'software',
-    'version',  # see https://github.com/ESMValGroup/ESMValCore/issues/1657
+    # see https://github.com/ESMValGroup/ESMValCore/issues/1657
+    'version',
 )
 """Global NetCDF attributes to ignore when comparing."""
 
@@ -44,8 +46,8 @@ IGNORE_VARIABLE_ATTRIBUTES: tuple[str, ...] = IGNORE_GLOBAL_ATTRIBUTES
 """Variable NetCDF attributes to ignore when comparing."""
 
 IGNORE_VARIABLES: tuple[str, ...] = (
-    'temp_list',  # used by perfmetrics diagnostics to save absolute paths
     # see https://github.com/ESMValGroup/ESMValTool/issues/2714
+    'temp_list',  # used by perfmetrics diagnostics to save absolute paths
 )
 """Variables in NetCDF files to ignore when comparing."""
 

--- a/esmvaltool/utils/testing/regression/compare.py
+++ b/esmvaltool/utils/testing/regression/compare.py
@@ -148,7 +148,7 @@ def diff_dataset(ref: xr.Dataset, cur: xr.Dataset) -> str:
 
 def adapt_attributes(attributes: dict, ignore_attributes: tuple[str, ...],
                      recipe_name: str) -> dict:
-    """Remove ignored attributes and references to absolute paths."""
+    """Remove ignored attributes and make absolute paths relative."""
     new_attrs = {}
 
     for (attr, attr_val) in attributes.items():

--- a/esmvaltool/utils/testing/regression/compare.py
+++ b/esmvaltool/utils/testing/regression/compare.py
@@ -45,6 +45,7 @@ IGNORE_VARIABLE_ATTRIBUTES: tuple[str, ...] = IGNORE_GLOBAL_ATTRIBUTES
 
 IGNORE_VARIABLES: tuple[str, ...] = (
     'temp_list',  # used by perfmetrics diagnostics to save absolute paths
+    # see https://github.com/ESMValGroup/ESMValTool/issues/2714
 )
 """Variables in NetCDF files to ignore when comparing."""
 

--- a/esmvaltool/utils/testing/regression/compare.py
+++ b/esmvaltool/utils/testing/regression/compare.py
@@ -36,7 +36,7 @@ IGNORE_GLOBAL_ATTRIBUTES: tuple[str, ...] = (
     'history',
     'provenance',
     'software',
-    'version',
+    'version',  # see https://github.com/ESMValGroup/ESMValCore/issues/1657
 )
 """Global NetCDF attributes to ignore when comparing."""
 

--- a/esmvaltool/utils/testing/regression/compare.py
+++ b/esmvaltool/utils/testing/regression/compare.py
@@ -31,7 +31,6 @@ IGNORE_FILES: tuple[str, ...] = (
 """Files to ignore when comparing results."""
 
 IGNORE_GLOBAL_ATTRIBUTES: tuple[str, ...] = (
-    'ancestors',
     'auxiliary_data_dir',
     'creation_date',
     'history',


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

Many diagnostics set netcdf attributes that include absolute paths. Since these are expected to differ between two recipe runs, this PR expands the recipe output comparison tool to only compare relative paths.

~~Note that this only works if the recipe output has not been copied to another location, since the current root path is used as a reference to determine relative paths.~~
EDIT: this now also works if the output has been copied. The only prerequisite is that the output dir follows the pattern `recipe_{recipe_name}_YYYYMMDD_HHMMSS` (which has already been the case before this change).

In addition, it allows ignoring variable netcdf attributes and entire netcdf variables (e.g., those that are intended to store paths).

Additionally ignored attributes:
- ~~`'ancestors'` (is a list of str; to handle this case the code would need to be overly complicated)~~ EDIT: Handled by https://github.com/ESMValGroup/ESMValTool/pull/2713
- `'auxiliary_data_dir'` (used by perfmetrics diagnostics)
- `'version'` (used by perfmetrics diagnostics)

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
- Addresses part of #2708

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful


***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
