### PR TITLE
Extending documenation: broken recipe policy

### DIFF
--- a/doc/sphinx/source/community/broken_recipe_policy.rst
+++ b/doc/sphinx/source/community/broken_recipe_policy.rst
@@ -1,0 +1,2 @@
+Broken recipe policy
+====================

--- a/doc/sphinx/source/community/broken_recipe_policy.rst
+++ b/doc/sphinx/source/community/broken_recipe_policy.rst
@@ -1,2 +1,14 @@
 Broken recipe policy
 ====================
+
+Recipes might stop to work properly because of different reasons. Among those is the continued development of the ESMValTool
+introducing new features or retiring old ones as well as e.g. changes of Python or used dependencies such as library functions.
+In such cases, the :ref:`recipe maintainer<Maintaining a recipe>` is contacted by the technical core development team to find
+a solution for fixing the affected recipe and checking the scientific validity of the fix. If no recipe maintainer is available,
+such recipes will be flagged by the release manager during the
+:ref:`Release schedule and procedure for ESMValCore and ESMValTool release procedure` as "broken".
+If a recipe continues to be broken for three releases of the ESMValTool (about one year) and no recipe maintainer could be found
+during this time, the affected recipe and diagnostics will be retired. This means the recipe and diagnostic code are
+removed from the ESMValTool main branch by the release manager and thus will not be included in future releases.
+Only the scientific documentation of the recipe (and diagnostics) will be kept in the user and developer guide with an
+additional note and link to the last release in which the recipe was still fully functional.

--- a/doc/sphinx/source/community/broken_recipe_policy.rst
+++ b/doc/sphinx/source/community/broken_recipe_policy.rst
@@ -1,10 +1,11 @@
 Broken recipe policy
 ====================
 
-Recipes might stop to work properly because of different reasons. Among those is the continued development of the ESMValTool
-introducing new features or retiring old ones as well as e.g. changes of Python or used dependencies such as library functions.
+Recipes might stop to work properly because of different reasons. Among those is, for instance, the withdrawal of datasets
+used by the recipe, continued development of the ESMValTool introducing new features or retiring old ones as well as
+changes to Python or used dependencies such as library functions.
 In such cases, the :ref:`recipe maintainer<Maintaining a recipe>` is contacted by the technical core development team to find
-a solution for fixing the affected recipe and checking the scientific validity of the fix. If no recipe maintainer is available,
+a solution, fixing the affected recipe and checking the scientific validity of the fix. If no recipe maintainer is available,
 such recipes will be flagged by the release manager during the
 :ref:`Release schedule and procedure for ESMValCore and ESMValTool release procedure` as "broken".
 If a recipe continues to be broken for three releases of the ESMValTool (about one year) and no recipe maintainer could be found

--- a/doc/sphinx/source/community/broken_recipe_policy.rst
+++ b/doc/sphinx/source/community/broken_recipe_policy.rst
@@ -8,6 +8,8 @@ In such cases, the :ref:`recipe maintainer<Maintaining a recipe>` is contacted b
 a solution, fixing the affected recipe and checking the scientific validity of the fix. If no recipe maintainer is available,
 such recipes will be flagged by the release manager during the
 :ref:`Release schedule and procedure for ESMValCore and ESMValTool release procedure` as "broken".
+For this, the affected recipe is listed under "broken recipes" in the :ref:`Changelog`, together with the version number of the
+last release in which the recipe was still working.
 If a recipe continues to be broken for three releases of the ESMValTool (about one year) and no recipe maintainer could be found
 during this time, the affected recipe and diagnostics will be retired. This means the recipe and diagnostic code are
 removed from the ESMValTool main branch by the release manager and thus will not be included in future releases.

--- a/doc/sphinx/source/community/broken_recipe_policy.rst
+++ b/doc/sphinx/source/community/broken_recipe_policy.rst
@@ -1,15 +1,15 @@
 Broken recipe policy
 ====================
 
-Recipes might stop to work properly because of different reasons. Among those is, for instance, the withdrawal of datasets
-used by the recipe, continued development of the ESMValTool introducing new features or retiring old ones as well as
+Recipes might stop to work for different reasons. Among those are, for instance, withdrawal of datasets
+used by the recipe, continued development of the ESMValTool including new features or retiring old ones as well as
 changes to Python or used dependencies such as library functions.
 In such cases, the :ref:`recipe maintainer<Maintaining a recipe>` is contacted by the technical core development team to find
-a solution, fixing the affected recipe and checking the scientific validity of the fix. If no recipe maintainer is available,
-such recipes will be flagged by the release manager during the
-:ref:`Release schedule and procedure for ESMValCore and ESMValTool release procedure` as "broken".
-For this, the affected recipe is listed under "broken recipes" in the :ref:`Changelog`, together with the version number of the
-last release in which the recipe was still working.
+a solution, fixing the affected recipe and checking the scientific output after applying the fix. If no recipe maintainer is
+available, such recipes will be flagged by the release manager during the
+:ref:`preparation of a new release<Release schedule and procedure for ESMValCore and ESMValTool release procedure>` as "broken".
+For this, the affected recipe will be listed under "broken recipes" in the :ref:`Changelog`, together with the version
+number of the last known release in which the recipe was still working.
 If a recipe continues to be broken for three releases of the ESMValTool (about one year) and no recipe maintainer could be found
 during this time, the affected recipe and diagnostics will be retired. This means the recipe and diagnostic code are
 removed from the ESMValTool main branch by the release manager and thus will not be included in future releases.

--- a/doc/sphinx/source/community/index.rst
+++ b/doc/sphinx/source/community/index.rst
@@ -25,6 +25,7 @@ help, e.g. on our
 
 		Contributing code and documentation <code_documentation>
 		Contributing a diagnostic or recipe <diagnostic>
+		Broken recipe policy <broken_recipe_policy>
 		Contributing a dataset <dataset>
 		Contributing a review <review>
 		Upgrading a namelist to a recipe <upgrading>


### PR DESCRIPTION
@ESMValGroup/esmvaltool-developmentteam

Following the discussions at the ESMValTool workshop in June 2022, we decided to draft a policy on how to deal with unmaintained broken recipes. This is a first attempt to define what and when happens to such recipes. The draft is now open for discussion. If possible, please suggest concrete changes to the text.