### PR TITLE
Fix `esmvaltool.utils.testing.regression.compare` module to run with Python<3.10 too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - fix_compare
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - fix_compare
   schedule:
     - cron: '0 0 * * *'
 

--- a/esmvaltool/utils/testing/regression/compare.py
+++ b/esmvaltool/utils/testing/regression/compare.py
@@ -348,8 +348,8 @@ def get_recipe_name_from_dir(recipe_dir: Path) -> str:
 def get_recipe_name_from_file(filename: Path) -> str:
     """Extract recipe name from arbitrary recipe output file."""
     # Iterate starting from the root dir to avoid false matches
-    for parent in filename.parents[::-1]:
-        recipe_match = re.search(RECIPE_DIR_PATTERN, str(parent))
+    for path, _, _ in os.walk(os.path.dirname(filename)):
+        recipe_match = re.search(RECIPE_DIR_PATTERN, str(path))
         if recipe_match is not None:
             return recipe_match['recipe_name']
     raise ValueError(f"Failed to extract recipe name from file {filename}")

--- a/esmvaltool/utils/testing/regression/compare.py
+++ b/esmvaltool/utils/testing/regression/compare.py
@@ -348,8 +348,8 @@ def get_recipe_name_from_dir(recipe_dir: Path) -> str:
 def get_recipe_name_from_file(filename: Path) -> str:
     """Extract recipe name from arbitrary recipe output file."""
     # Iterate starting from the root dir to avoid false matches
-    for path, _, _ in os.walk(os.path.dirname(filename)):
-        recipe_match = re.search(RECIPE_DIR_PATTERN, str(path))
+    for parent in list(filename.parents)[::1]:
+        recipe_match = re.search(RECIPE_DIR_PATTERN, str(parent))
         if recipe_match is not None:
             return recipe_match['recipe_name']
     raise ValueError(f"Failed to extract recipe name from file {filename}")

--- a/tests/unit/utils/test_compare.py
+++ b/tests/unit/utils/test_compare.py
@@ -10,5 +10,7 @@ def test_get_recipe_name_from_file(tmp_path):
     """Test the string extractor for recipe name."""
     path_to_file = tmp_path / "recipe_python_20220317_162441" / "run"
     os.makedirs(path_to_file)
-    expected = get_recipe_name_from_file(path_to_file)
-    assert expected == "name_from_file0/recipe_python"
+    obtained = get_recipe_name_from_file(path_to_file)
+    print("Obtained: %s", obtained)
+    print("Expected: name_from_file0/recipe_python")
+    assert obtained == "name_from_file0/recipe_python"

--- a/tests/unit/utils/test_compare.py
+++ b/tests/unit/utils/test_compare.py
@@ -1,0 +1,14 @@
+"""Test the esmvaltool.utils.testing.regression.compare module."""
+import os
+
+from esmvaltool.utils.testing.regression.compare import (
+    get_recipe_name_from_file
+)
+
+
+def test_get_recipe_name_from_file(tmp_path):
+    """Test the string extractor for recipe name."""
+    path_to_file = tmp_path / "recipe_python_20220317_162441" / "run"
+    os.makedirs(path_to_file)
+    expected = get_recipe_name_from_file(path_to_file)
+    assert expected == "name_from_file0/recipe_python"


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

This should first test the behaviour raised by @KatherineTomkins in #2763 namely `esmvaltool.utils.testing.regression.compare` fails for Python<3.10, then fix the utility so it works with lower Python versions too.

Steps:
- **Issue replication** indeed the issue reported in #2763 can be replicated for an env with Python<3.10, see eg [here](https://github.com/ESMValGroup/ESMValTool/runs/8090768329?check_suite_focus=true)
- **Issue fixing** fixed with oldschool `os.walk()` and `os.path()` see eg [here](https://github.com/ESMValGroup/ESMValTool/runs/8091478943?check_suite_focus=true)
- Test current implement via unit test: yep

- Closes #2763 

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

