### PR TITLE
Pin `netcdf4 != 1.6.1` since that is spitting large numbers of SegFaults

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
   - matplotlib-base
   - natsort
   - nc-time-axis
-  - netCDF4
+  - netCDF4!=1.6.1  # https://github.com/ESMValGroup/ESMValCore/pull/1724
   - numpy
   - openpyxl
   - pandas

--- a/environment_osx.yml
+++ b/environment_osx.yml
@@ -34,7 +34,7 @@ dependencies:
   - matplotlib-base
   - natsort
   - nc-time-axis
-  - netCDF4
+  - netCDF4!=1.6.1  # https://github.com/ESMValGroup/ESMValCore/pull/1724
   - numpy
   - openpyxl
   - pandas

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ REQUIREMENTS = {
         'matplotlib',
         'natsort',
         'nc-time-axis',
-        'netCDF4!=1.6.1',  # https://github.com/ESMValGroup/ESMValCore/pull/1724
+        'netCDF4!=1.6.1',  # github.com/ESMValGroup/ESMValCore/pull/1724
         'numpy',
         'openpyxl',
         'pandas',

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ REQUIREMENTS = {
         'matplotlib',
         'natsort',
         'nc-time-axis',
-        'netCDF4',
+        'netCDF4!=1.6.1',  # https://github.com/ESMValGroup/ESMValCore/pull/1724
         'numpy',
         'openpyxl',
         'pandas',


### PR DESCRIPTION
Sister issue/PR of Core's https://github.com/ESMValGroup/ESMValCore/pull/1724