### PR TITLE
Pin `matplotlib-base<3.6.01 to avoid conflict from `mapgenerator` that fails doc builds

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -31,7 +31,7 @@ dependencies:
   - joblib
   - lime
   - mapgenerator>=1.0.5
-  - matplotlib-base
+  - matplotlib-base<3.6.0  # github.com/ESMValGroup/ESMValTool/issues/2800
   - natsort
   - nc-time-axis
   - netCDF4!=1.6.1  # https://github.com/ESMValGroup/ESMValCore/pull/1724

--- a/environment_osx.yml
+++ b/environment_osx.yml
@@ -31,7 +31,7 @@ dependencies:
   - joblib
   - lime
   - mapgenerator>=1.0.5
-  - matplotlib-base
+  - matplotlib-base<3.6.0  # github.com/ESMValGroup/ESMValTool/issues/2800
   - natsort
   - nc-time-axis
   - netCDF4!=1.6.1  # https://github.com/ESMValGroup/ESMValCore/pull/1724

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ REQUIREMENTS = {
         'joblib',
         'lime',
         'mapgenerator>=1.0.5',
-        'matplotlib',
+        'matplotlib<3.6.0',  # github.com/ESMValGroup/ESMValTool/issues/2800
         'natsort',
         'nc-time-axis',
         'netCDF4!=1.6.1',  # github.com/ESMValGroup/ESMValCore/pull/1724


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

Partially and temporarily addresses #2800 by pinning `matplotlib-base` to allow for doc and conda lock build tests to pass; of course, the real deal solution is to get the BSC `mapgenerator` package in line with the new matplotlib, but gauging from the discussion at #2800 it's not  a Grand Prix, but more of an endurance race there. **Do NOT** close #2800 when this is merged! 

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
- Closes #issue_number
- Link to documentation:

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [meh] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [ ] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [ ] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

