### PR TITLE
Fixed wrong latitudes in NDP CMORizer

### DIFF
--- a/esmvaltool/cmorizers/data/cmor_config/NDP.yml
+++ b/esmvaltool/cmorizers/data/cmor_config/NDP.yml
@@ -1,7 +1,7 @@
 ---
 # General attributes
 filename: 'ndp017b.tar.gz'
-delta_degrees: 0.083
+delta_degrees: 0.08333
 missing_values: [-32768, -9999, -9998]
 
 # Common global attributes for Cmorizer output

--- a/esmvaltool/cmorizers/data/formatters/datasets/ndp.py
+++ b/esmvaltool/cmorizers/data/formatters/datasets/ndp.py
@@ -45,7 +45,7 @@ def _extract_variable(cmor_info, attrs, var_file, out_dir, cfg):
                                 var_name='time',
                                 long_name='time')
     lats = iris.coords.DimCoord(
-        90.0 - np.arange(array.shape[1]) * cfg['delta_degrees'],
+        83.65972 - np.arange(array.shape[1]) * cfg['delta_degrees'],
         standard_name='latitude',
         var_name='lat',
         long_name='latitude')

--- a/esmvaltool/cmorizers/data/formatters/datasets/ndp.py
+++ b/esmvaltool/cmorizers/data/formatters/datasets/ndp.py
@@ -50,7 +50,7 @@ def _extract_variable(cmor_info, attrs, var_file, out_dir, cfg):
         var_name='lat',
         long_name='latitude')
     lons = iris.coords.DimCoord(
-        180.0 + np.arange(array.shape[2]) * cfg['delta_degrees'],
+        -180.0 + np.arange(array.shape[2]) * cfg['delta_degrees'],
         standard_name='longitude',
         var_name='lon',
         long_name='longitude')


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

While looking at plots of vegetation carbon content of the dataset NDP, @bettina-gier and I realized that the latitude is shifted by about ~5° (see figure below). After looking the documentation we found that the end value of latitude should be ~83.6° instead of 90°. This PR fixes that.

![grafik](https://user-images.githubusercontent.com/32543114/194099116-15aa74c8-735d-452d-96ce-b796f9781962.png)

@remi-kazeroni We also realized that the raw data on Levante is a `.tar.gz` file, but the CMORizer expects an unzipped file. Thus, using the command `esmvaltool data format NDP` with the default `RAWOBS` path failed for me. Using my own directory and downloading the files with `esmvaltool data prepare NDP` worked.

* * *

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated data reformatting script](https://docs.esmvaltool.org/en/latest/develop/dataset.html)

- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/dataset.html#dataset-documentation) is available
- [x] [🛠][1] The dataset has been [added to the CMOR check recipe](https://docs.esmvaltool.org/en/latest/community/dataset.html#testing)
- [x] [🧪][2] Numbers and units of the data look [physically meaningful](https://docs.esmvaltool.org/en/latest/community/dataset.html#scientific-sanity-check)

***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
