### PR TITLE
fix indexer in Autoassess supermeans module use a tuple of `(slice(), idx, idx)`

### DIFF
--- a/esmvaltool/diag_scripts/shared/_supermeans.py
+++ b/esmvaltool/diag_scripts/shared/_supermeans.py
@@ -297,7 +297,7 @@ def time_average_by(cube, periods='time'):
     idx_obj = [None] * cube.data.ndim
     idx_obj[cube.coord_dims('time')[0]] = slice(
         None)  # [None, slice(None), None] == [np.newaxis, :, np.newaxis]
-    cube.data *= durations_cube.data[idx_obj]
+    cube.data *= durations_cube.data[tuple(idx_obj)]
 
     if periods == ['time']:  # duration weighted averaging
         cube = cube.collapsed(periods, iris.analysis.SUM)
@@ -311,7 +311,7 @@ def time_average_by(cube, periods='time'):
     if durations_cube.data.shape == ():
         cube.data /= durations_cube.data
     else:
-        cube.data /= durations_cube.data[idx_obj]
+        cube.data /= durations_cube.data[tuple(idx_obj)]
 
     # correct cell methods
     cube.cell_methods = orig_cell_methods


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

Found while running diags for release in #2833 - the indexer was a list like `list[slice(), idx, idx]` which is deprecated, and now fully retired behaviour, but a tuple of that is well liked by Numpy. Can I gets a quick a-ok here plese much? :beer: 

Closes https://github.com/ESMValGroup/ESMValTool/issues/2837

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->


## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

