### PR TITLE
Increase esmvalcore version to 2.7.0 in environment files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - up_esmvalcore_version
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - up_esmvalcore_version
   schedule:
     - cron: '0 0 * * *'
 

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - ecmwf-api-client
   - eofs
   - esmpy
-  - esmvalcore 2.6.*
+  - esmvalcore 2.7.*
   - fiona
   - fire
   - gdal

--- a/environment_osx.yml
+++ b/environment_osx.yml
@@ -22,7 +22,7 @@ dependencies:
   - ecmwf-api-client
   - eofs
   - esmpy
-  - esmvalcore 2.6.*
+  - esmvalcore 2.7.*
   - fiona
   - fire
   - gdal


### PR DESCRIPTION
We released 2.7.0 yesterday so we need change the dynamical pins in the environment files. Running a GA test just to extra sure, so pls don't merge before it finishes and I have removed the feature branch name from the GA workflow :beer: Note to myself is to have the feedstock meta file updated too!