### PR TITLE
Fix bug when using log-scale y-axis for ocean transects.

### DIFF
--- a/esmvaltool/diag_scripts/ocean/diagnostic_transects.py
+++ b/esmvaltool/diag_scripts/ocean/diagnostic_transects.py
@@ -261,7 +261,7 @@ def make_transects_plots(
         qplt.contourf(cube, 15, linewidth=0, rasterized=True)
 
         if set_y_logscale:
-            plt.axes().set_yscale('log')
+            plt.gca().set_yscale('log')
 
         if region:
             region_title = region
@@ -383,7 +383,7 @@ def make_transect_contours(
 
         # Determine y log scale.
         if determine_set_y_logscale(cfg, metadata):
-            plt.axes().set_yscale('log')
+            plt.gca().set_yscale('log')
 
         add_sea_floor(cube)
 
@@ -517,7 +517,7 @@ def multi_model_contours(
             }
 
             if set_y_logscale:
-                plt.axes().set_yscale('log')
+                plt.gca().set_yscale('log')
 
             title = metadatas[filename]['long_name']
             units = str(model_cubes[filename][region].units)


### PR DESCRIPTION
Using `plt.axes().set_ylogscale('log')` creates a new axes on top of the original figure. Replace with `plt.gca().set_yscale('log')` to adjust the existing figure axes to log scale.

<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
- Closes #2858 
- Link to documentation:

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [ ] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [ ] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [ ] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [ ] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [ ] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [ ] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [ ] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [ ] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added

### [New or updated data reformatting script](https://docs.esmvaltool.org/en/latest/develop/dataset.html)

- [ ] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/dataset.html#dataset-documentation) is available
- [ ] [🛠][1] The dataset has been [added to the CMOR check recipe](https://docs.esmvaltool.org/en/latest/community/dataset.html#testing)
- [ ] [🧪][2] Numbers and units of the data look [physically meaningful](https://docs.esmvaltool.org/en/latest/community/dataset.html#scientific-sanity-check)

***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
