### PR TITLE
suppress installing and reinstalling deps with pip at readthedocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
     python: "mambaforge-4.10"
   jobs:
     post_create_environment:
-      - pip install -e .[develop]
+      - pip install . --no-deps
 
 # Declare the requirements required to build your docs
 conda:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,13 +16,6 @@ conda:
   environment:
     environment.yml
 
-python:
-  install:
-    - method: setuptools
-      path: .
-      extra_requirements:
-        - doc
-
 # Build documentation in the doc directory with Sphinx
 sphinx:
   configuration: doc/sphinx/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,7 +18,7 @@ conda:
 
 python:
   install:
-    - method: pip
+    - method: setuptools
       path: .
       extra_requirements:
         - doc

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "mambaforge-4.10"
+  jobs:
+    post_create_environment:
+      - pip install -e .[develop]
 
 # Declare the requirements required to build your docs
 conda:


### PR DESCRIPTION
Readthedocs builds use `pip install --upgrade --upgrade-strategy eager` to install and eventually reinstall everything from the env via pip - this is discussed in https://github.com/readthedocs/readthedocs.org/issues/8890 and is not something good for many reasons, one of them, and a very recent and pertinent one is that the build will chuck a wobbly if the package versions differ from conda-forge to pypi. I am trying to fix this here via the readthedocs build conf file.

**EDIT** by some miracle I found the magic incantation to get this done, and supported by the Readthedocs API too - @bouweandela do you recommend using `pip install -e .[doc]` instead of `pip install -e .[develop]`?

Docs built with this PR: https://esmvaltool--2913.org.readthedocs.build/en/2913/
Closes #2903 once and for all