### PR TITLE
Fix for provenance records from seaice_tsline.ncl

### DIFF
--- a/esmvaltool/diag_scripts/seaice/seaice_tsline.ncl
+++ b/esmvaltool/diag_scripts/seaice/seaice_tsline.ncl
@@ -295,8 +295,8 @@ begin
   else
 
     ; Create plot variables
-    wks_ext = gsn_open_wks(file_type, config_user_info@plot_dir + out_ext)
-    wks_area = gsn_open_wks(file_type, config_user_info@plot_dir + out_area)
+    wks_ext = gsn_open_wks(file_type, plot_dir + out_ext)
+    wks_area = gsn_open_wks(file_type, plot_dir + out_area)
 
     ; Define plot resources
     res                 = True
@@ -338,7 +338,7 @@ begin
       ; but is same for both area and extent anyway
       if (diag_script_info@legend_outside) then
         val_area@legend_outside = True
-        wks_area@legendfile = config_user_info@plot_dir + out_ext + "_legend"
+        wks_area@legendfile = plot_dir + out_ext + "_legend"
       end if
     else
       diag_script_info@legend_outside = False
@@ -361,7 +361,8 @@ begin
     nc_ext = \
       ncdf_write(val_ext, config_user_info@work_dir + out_ext + ".nc")
 
-    log_provenance(nc_ext, out_ext, caption_ext, \
+    fullname = plot_dir + out_ext + "." + file_type
+    log_provenance(nc_ext, fullname, caption_ext, \
                    (/"mean", "stddev", "clim"/), domain, "times", \
                    (/"senftleben_daniel", "gottschaldt_klaus-dirk"/), \
                    "stroeve07grl", infiles)
@@ -374,7 +375,8 @@ begin
     nc_area = \
       ncdf_write(val_area, config_user_info@work_dir + out_area + ".nc")
 
-    log_provenance(nc_area, out_area, caption_area, \
+    fullname = plot_dir + out_area + "." + file_type
+    log_provenance(nc_area, fullname, caption_area, \
                    (/"mean", "stddev", "clim"/), domain, "times", \
                    (/"senftleben_daniel", "gottschaldt_klaus-dirk"/), \
                    "stroeve07grl", infiles)


### PR DESCRIPTION
Fixes the directory for the provenance records written by seaice/seaice_tsline.ncl. With this PR, the provenance records are written to the correct plot directory instead of the output root directory.

- Closes #2936

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [x] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [x] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [x] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [x] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added