### PR TITLE
Add the outline of a climatological tropopause to the zonalmean_profile plots

### DIFF
--- a/doc/sphinx/source/recipes/recipe_perfmetrics.rst
+++ b/doc/sphinx/source/recipes/recipe_perfmetrics.rst
@@ -61,6 +61,34 @@ User settings in recipe
    * zonal_ymin: for plot_type zonal only, minimum pressure level on the y-axis (default: 5. hPa)
    * latlon_cmap: for plot_type latlon only, chosen color table (default: "amwg_blueyellowred")
    * plot_units: plotting units (if different from standard CMOR units)
+   * add_tropopause: adds an outline of a climatological tropopause to the zonal plot (default: False)
+
+   *Special optional plot configurations*
+
+     It is possible to make some specific customizations to the plots (zonal
+     only).
+
+     This includes for example specific tickmark labels of the axes.
+
+     Those special customizations can be done by adding ncl plotting resources
+     combined with prefix "res_" as optional settings of the main script in the
+     recipe.
+
+     Note that this requires to be familiar with the ncl plotting routines for
+     pressure vs height plots
+     (https://www.ncl.ucar.edu/Document/Graphics/Interfaces/gsn_csm_pres_hgt.shtml)
+     and the corresponding resources.
+
+     The following shows an example on customizing the latitude tickmarks so
+     that a degree sign and and empty space is used for the labels:
+
+     ```
+     # copernicus style of latitude tickmarks
+     res_tmXBMode: "Explicit"
+     res_tmXBValues: [-60, -30, 0, 30, 60]
+     res_tmXBLabels: ["60~F35~J~F21~ S", "30~F35~J~F21~ S", "0~F35~J", "30~F35~J~F21~ N", "60~F35~J~F21~ N"]
+     ```
+
 
    *Required settings (variables)*
 

--- a/esmvaltool/diag_scripts/perfmetrics/zonal.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/zonal.ncl
@@ -111,6 +111,7 @@ begin
     plot_var@res_trYMinF = diag_script_info@zonal_ymin
     plot_var@res_gsnLeftString = \
       plot_var@long_name + " [" + format_units(plot_var@units) + "]"
+    copy_VarMeta(diag_script_info, plot_var)
     wks = gsn_open_wks(file_type, plotpath_abs)
     gsn_define_colormap(wks, diag_script_info@zonal_cmap)
     plot = zonalmean_profile(wks, plot_var, var0)

--- a/esmvaltool/diag_scripts/shared/plot/zonalmean_profile.ncl
+++ b/esmvaltool/diag_scripts/shared/plot/zonalmean_profile.ncl
@@ -105,6 +105,22 @@ begin
   plot = gsn_csm_pres_hgt(wks, data, res)
   plot@outfile = wks@name
 
+  ; Add the outline of the climatological tropopause
+  if (isatt(data, "add_tropopause")) then
+    if data@add_tropopause then
+      xyres = True
+      xyres@gsLineColor="brown"
+      xyres@gsLineDashPattern = 1
+      xyres@gsLineThicknessF=3.
+      lat = data&lat
+      tp := ( 300. - 215. * (cos(lat/180. * get_pi("f")))^2 )
+      str = unique_string("tropopause")
+      plot@$str$ = gsn_add_polyline(wks, plot, lat, tp, xyres)
+      delete(tp)
+      delete(lat)
+    end if
+  end if
+
   leave_msg(scriptname, funcname)
   return(plot)
 


### PR DESCRIPTION
Add the outline of a climatological tropopause to the zonalmean_profile plots

## Description

Sometimes when describing a zonalmean plot it helps to have a outline of the tropopause as this makes it easier to distinguish between troposphere and stratosphere layers and point to the tropopause region in particular. 

I implemented this feature in perfmetrics/main.ncl and shared/plot/zonalmean_profile.ncl. so that it is optionally available for zonalmean plots.

The option can be chosen by the following statement in the recipe, below the chosen script.
```
scripts:  
   script1:  
      script: perfmetrics/main.ncl  
      # Add the outline of the climatological tropopause  
      add_tropopause: true
```

***Additional feature:***
The way I implemented the option to add the tropopause outline, makes it furthermore possible for the user to make some very specific changes to the plot by solely customizing the recipe.

```
     # copernicus style of latitude tickmarks
     res_tmXBMode: "Explicit"
     res_tmXBValues: [-60, -30, 0, 30, 60]
     res_tmXBLabels: ["60~F35~J~F21~ S", "30~F35~J~F21~ S", "0~F35~J", "30~F35~J~F21~ N", "60~F35~J~F21~ N"]
```

***Example plot***

This example shows, how the enhancements would show up in the plot. 

![perfmetrics_zonal_EMAC_EMAC_PSRF-2000-03-ERA5_ta_annualclim_global](https://user-images.githubusercontent.com/119339136/204770685-8afb7717-6161-413a-973b-0390306b1313.png)

- Closes #2944 
- documentation: https://docs.esmvaltool.org/en/latest/recipes/recipe_perfmetrics.html?highlight=perfmetrics

* * *

## Before you get started

- [ ] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [ ] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [ ] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [ ] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [ ] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [ ] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [ ] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added
