### PR TITLE
[Release v2.8.0 or new esmvalcore release] Replace deprecated `esmvalcore._data_finder` module with `esmvalcore.local` - 

### DIFF
--- a/.github/workflows/test-development.yml
+++ b/.github/workflows/test-development.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - main
+      - replace_data_finder_module_with_local
   schedule:
     - cron: '0 0 * * *'
 

--- a/esmvaltool/diag_scripts/monitor/monitor_base.py
+++ b/esmvaltool/diag_scripts/monitor/monitor_base.py
@@ -6,7 +6,7 @@ import os
 import cartopy
 import matplotlib.pyplot as plt
 import yaml
-from esmvalcore._data_finder import _replace_tags
+from esmvalcore.local import _replace_tags
 from iris.analysis import MEAN
 from mapgenerator.plotting.timeseries import PlotSeries
 

--- a/tests/integration/test_recipe_filler.py
+++ b/tests/integration/test_recipe_filler.py
@@ -1,4 +1,4 @@
-"""Tests for _data_finder.py."""
+"""Tests for recipe_filler.py."""
 import contextlib
 import os
 import shutil

--- a/tests/integration/test_recipes_loading.py
+++ b/tests/integration/test_recipes_loading.py
@@ -7,7 +7,7 @@ import yaml
 
 import esmvalcore
 import esmvalcore._config
-import esmvalcore._data_finder
+import esmvalcore.local
 import esmvalcore._recipe
 import esmvalcore.cmor.check
 import esmvaltool
@@ -43,13 +43,13 @@ RECIPES, IDS = _get_recipes()
 def test_recipe_valid(recipe_file, config_user, monkeypatch):
     """Check that recipe files are valid ESMValTool recipes."""
     # Mock input files
-    find_files = create_autospec(esmvalcore._data_finder.find_files,
+    find_files = create_autospec(esmvalcore.local.find_files,
                                  spec_set=True)
     find_files.side_effect = lambda *_, **__: [
         'test_0001-1849.nc',
         'test_1850-9999.nc',
     ]
-    monkeypatch.setattr(esmvalcore._data_finder, 'find_files', find_files)
+    monkeypatch.setattr(esmvalcore.local, 'find_files', find_files)
 
     # Mock vertical levels
     levels = create_autospec(esmvalcore._recipe.get_reference_levels,

--- a/tests/system/data_simulator.py
+++ b/tests/system/data_simulator.py
@@ -12,7 +12,7 @@ from esmvalcore._recipe import read_recipe_file
 
 def get_input_filename(variable, rootpath, drs):
     """Get a valid input filename."""
-    # TODO: implement this according to esmvalcore._data_finder.py
+    # TODO: implement this according to esmvalcore.local.py
     # or patch get_input_filelist there.
     return tempfile.NamedTemporaryFile().name + '.nc'
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description - DO NOT MERGE YET - requires updated release of ESMValCore (either main or bugfix release)

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

Full development [tests](https://github.com/ESMValGroup/ESMValTool/actions/runs/3700092776/jobs/6268172529) ie both esmvaltool and esmvalcore installed from source fail due to the deprecation of `esmvalcore._data_finder` module from ESMValCore dev 2.8dev via https://github.com/ESMValGroup/ESMValCore/pull/1835

- Closes #2973 
* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful
