### PR TITLE
Merra2 cmorizer convert vertical level coordinate units from hPa to Pa

### DIFF
--- a/esmvaltool/cmorizers/data/formatters/datasets/merra2.py
+++ b/esmvaltool/cmorizers/data/formatters/datasets/merra2.py
@@ -139,6 +139,16 @@ def _fix_coordinates(cube, definition):
             coord = cube.coord(axis=axis)
             if axis == 'T':
                 coord.convert_units('days since 1850-1-1 00:00:00.0')
+            elif axis == 'Z':
+                if coord.units == "hPa":
+                    coord.convert_units('Pa')
+                else:
+                    try:
+                        coord.convert_units('Pa')
+                    except ValueError as exc:
+                        logger.error("Attempting to convert units for coordinate "
+                                     "%s to hPa", coord)
+                        raise exc
             coord.standard_name = coord_def.standard_name
             coord.var_name = coord_def.out_name
             coord.long_name = coord_def.long_name

--- a/tests/unit/cmorizers/obs/test_merra2.py
+++ b/tests/unit/cmorizers/obs/test_merra2.py
@@ -26,7 +26,7 @@ def _create_sample_cube():
     zcoord = iris.coords.DimCoord([0.5, 5., 50.],
                                   long_name='vertical level',
                                   var_name='lev',
-                                  units='m',
+                                  units='hPa',
                                   attributes={'positive': 'down'})
     lons = iris.coords.DimCoord([1.5, 2.5],
                                 standard_name='longitude',
@@ -265,7 +265,11 @@ def test_vertical_levels(tmp_path):
     cube_3 = _create_sample_cube()
     cube_3.var_name = "T2M"
     cube_3.units = Unit('K')
-    cubes = iris.cube.CubeList([cube_1, cube_2, cube_3])
+    cube_4 = _create_sample_cube()
+    cube_4.var_name = "H"
+    cube_4.units = Unit('m')
+    cube_4.coord("vertical level").units = "m"
+    cubes = iris.cube.CubeList([cube_1, cube_2, cube_3, cube_4])
     iris.save(cubes, str(path_cubes))
     var_1 = {
         'short_name': 'va',
@@ -282,6 +286,11 @@ def test_vertical_levels(tmp_path):
         'mip': 'Amon', 'raw': 'T2M',
         'file': 'MERRA2_???.tavgM_2d_slv_Nx.{year}??.nc4'
     }
+    var_4 = {
+        'short_name': 'zg',
+        'mip': 'Amon', 'raw': 'H',
+        'file': 'MERRA2_???.instM_3d_ana_Np.{year}??.nc4'
+    }
     in_files = str(tmp_path / "cubes.nc")
     cfg = read_cmor_config("MERRA2")
 
@@ -293,8 +302,9 @@ def test_vertical_levels(tmp_path):
     print(cmorized_cube,
           cmorized_cube.coord("air_pressure"))
     assert cmorized_cube.coord("air_pressure").has_bounds()
+    assert cmorized_cube.coord("air_pressure").units == "Pa"
     np.testing.assert_array_equal(cmorized_cube.coord("air_pressure").points,
-                                  [0.5, 5., 50.])
+                                  [50., 500., 5000.])
 
     # extract uas
     _extract_variable(in_files, var_2, cfg, tmp_path)
@@ -313,3 +323,9 @@ def test_vertical_levels(tmp_path):
     print(cmorized_cube)
     np.testing.assert_array_equal(cmorized_cube.coord("height").points,
                                   [2.])
+
+    # extract zg failed
+    with pytest.raises(ValueError) as exc:
+        _extract_variable(in_files, var_4, cfg, tmp_path)
+    expected_exc = "Unable to convert from 'Unit('m')' to 'Unit('Pa')'"
+    assert expected_exc in str(exc)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

@glpotter raised this in https://github.com/ESMValGroup/ESMValTool/issues/2978 and gave us an example too. This PR fixes the units in the case when the vertical level coordinate is in hPa, changing it to Pa, and tries to convert any other possible vertical level unit to Pa; if it fails it spits an error for he user to get their ducks in one line :duck: 

- Closes #2978 

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [ ] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [ ] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated data reformatting script](https://docs.esmvaltool.org/en/latest/develop/dataset.html)

- [ ] [🧪][2] Numbers and units of the data look [physically meaningful](https://docs.esmvaltool.org/en/latest/community/dataset.html#scientific-sanity-check)

