### PR TITLE
Fix read_cmor in NCL utilities

### DIFF
--- a/esmvaltool/cmorizers/data/formatters/utilities.ncl
+++ b/esmvaltool/cmorizers/data/formatters/utilities.ncl
@@ -808,8 +808,13 @@ begin
     attv = new(n, string)
     do i = 0, n - 1
       substr = str_split(data(idxu + i), ":")
+      m = dimsizes(substr)
       attn(i) = str_squeeze(substr(0))
-      attv(i) = str_squeeze(str_join(substr(1:), ":"))
+      if (m .gt. 1) then
+        attv(i) = str_squeeze(str_join(substr(1:), ":"))
+      else
+        attv(i) = ""
+      end if
       delete(substr)
     end do
 

--- a/esmvaltool/cmorizers/data/formatters/utilities.ncl
+++ b/esmvaltool/cmorizers/data/formatters/utilities.ncl
@@ -822,7 +822,7 @@ begin
 
   out = True
   do ii = 0, dimsizes(attn) - 1
-    ; If present, do not copy the attribute 'cell_mesures' to comply with the
+    ; If present, do not copy the attribute 'cell_measures' to comply with the
     ; CF conventions:
     ;
     ; "A variable referenced by cell_measures is not required to be present in

--- a/esmvaltool/cmorizers/data/formatters/utilities.ncl
+++ b/esmvaltool/cmorizers/data/formatters/utilities.ncl
@@ -822,7 +822,21 @@ begin
 
   out = True
   do ii = 0, dimsizes(attn) - 1
-    out@$attn(ii)$ = attv(ii)
+    ; If present, do not copy the attribute "cell_mesures" to be able to comply
+    ; with the CF conventions:
+    ;
+    ; "A variable referenced by cell_measures is not required to be present in
+    ; the file containing the data variable. If the cell_measures variable is
+    ; located in another file (an "external file"), rather than in the file
+    ; where it is referenced, it must be listed in the external_variables
+    ; attribute of the referencing file (Section 2.6.3)."
+    ;
+    ; ---> As we do not have such a variable (e.g. areacella), we remove
+    ;      the attribute 'cell_measures' (if present) to comply with the CF
+    ;      conventions.
+    if (attn(ii) .ne. "cell_measures") then
+      out@$attn(ii)$ = attv(ii)
+    end if
   end do
 
   return(out)

--- a/esmvaltool/cmorizers/data/formatters/utilities.ncl
+++ b/esmvaltool/cmorizers/data/formatters/utilities.ncl
@@ -822,8 +822,8 @@ begin
 
   out = True
   do ii = 0, dimsizes(attn) - 1
-    ; If present, do not copy the attribute "cell_mesures" to be able to comply
-    ; with the CF conventions:
+    ; If present, do not copy the attribute 'cell_mesures' to comply with the
+    ; CF conventions:
     ;
     ; "A variable referenced by cell_measures is not required to be present in
     ; the file containing the data variable. If the cell_measures variable is
@@ -832,8 +832,7 @@ begin
     ; attribute of the referencing file (Section 2.6.3)."
     ;
     ; ---> As we do not have such a variable (e.g. areacella), we remove
-    ;      the attribute 'cell_measures' (if present) to comply with the CF
-    ;      conventions.
+    ;      the attribute 'cell_measures' (if present).
     if (attn(ii) .ne. "cell_measures") then
       out@$attn(ii)$ = attv(ii)
     end if

--- a/esmvaltool/cmorizers/data/formatters/utilities.ncl
+++ b/esmvaltool/cmorizers/data/formatters/utilities.ncl
@@ -803,8 +803,15 @@ begin
     idxu = ind(str_get_field(data, 1, ":").eq."! Variable attributes") + 2
     idxd = ind(str_get_field(data, 1, ":").eq. \
                "! Additional variable information") - 2
-    attn = str_squeeze(str_get_field(data(idxu:idxd), 1, ":"))
-    attv = str_squeeze(str_get_field(data(idxu:idxd), 2, ":"))
+    n = idxd - idxu + 1
+    attn = new(n, string)
+    attv = new(n, string)
+    do i = 0, n - 1
+      substr = str_split(data(idxu + i), ":")
+      attn(i) = str_squeeze(substr(0))
+      attv(i) = str_squeeze(str_join(substr(1:), ":"))
+      delete(substr)
+    end do
 
   end if
 


### PR DESCRIPTION
This PR fixes a small bug in utilities.ncl (function `read_cmor`) that prevented attributes read from CMOR tables to be copied correctly to output written by NCL CMORizer scripts.

Problem: The character `:` is used as a delimiter when parsing the attributes read from a CMOR table. If the attribute itself contains the character `:` only part of the attribute string was copied. This affected the CMOR attributes `cell_methods` and `cell_measures` that have been only partly copied to the output files, e.g. `cell_methods = "time"` instead of `cell_methods = "time: mean"`. This has been corrected now.

- Closes https://github.com/ESMValGroup/ESMValCore/issues/1875

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated data reformatting script](https://docs.esmvaltool.org/en/latest/develop/dataset.html)

- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/dataset.html#dataset-documentation) is available
- [x] [🛠][1] The dataset has been [added to the CMOR check recipe](https://docs.esmvaltool.org/en/latest/community/dataset.html#testing)
- [x] [🧪][2] Numbers and units of the data look [physically meaningful](https://docs.esmvaltool.org/en/latest/community/dataset.html#scientific-sanity-check)