### PR TITLE
(long term) fix for recipe test with esmvalcore interface testing

### DIFF
--- a/.github/workflows/test-development.yml
+++ b/.github/workflows/test-development.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - main
+      - fix_tests_with_core_dev
   schedule:
     - cron: '0 0 * * *'
 

--- a/esmvaltool/cmorizers/data/formatters/datasets/merra2.py
+++ b/esmvaltool/cmorizers/data/formatters/datasets/merra2.py
@@ -146,8 +146,8 @@ def _fix_coordinates(cube, definition):
                     try:
                         coord.convert_units('Pa')
                     except ValueError as exc:
-                        logger.error("Attempting to convert units for coordinate "
-                                     "%s to hPa", coord)
+                        logger.error("Attempting to convert units for "
+                                     "coordinate %s to hPa", coord)
                         raise exc
             coord.standard_name = coord_def.standard_name
             coord.var_name = coord_def.out_name

--- a/esmvaltool/cmorizers/data/formatters/datasets/merra2.py
+++ b/esmvaltool/cmorizers/data/formatters/datasets/merra2.py
@@ -139,6 +139,16 @@ def _fix_coordinates(cube, definition):
             coord = cube.coord(axis=axis)
             if axis == 'T':
                 coord.convert_units('days since 1850-1-1 00:00:00.0')
+            elif axis == 'Z':
+                if coord.units == "hPa":
+                    coord.convert_units('Pa')
+                else:
+                    try:
+                        coord.convert_units('Pa')
+                    except ValueError as exc:
+                        logger.error("Attempting to convert units for coordinate "
+                                     "%s to hPa", coord)
+                        raise exc
             coord.standard_name = coord_def.standard_name
             coord.var_name = coord_def.out_name
             coord.long_name = coord_def.long_name

--- a/tests/integration/test_recipes_loading.py
+++ b/tests/integration/test_recipes_loading.py
@@ -69,16 +69,8 @@ def test_recipe_valid(recipe_file, config_user, mocker):
     )
 
     # Mock vertical levels
-    if core_ver.split(".")[0] == "2" and core_ver.split(".")[1] == "8":
-        import esmvalcore._recipe.recipe
-        mocker.patch.object(
-            esmvalcore._recipe.recipe,
-            'get_reference_levels',
-            autospec=True,
-            spec_set=True,
-            side_effect=lambda *_, **__: [1, 2],
-        )
-    else:
+    # Account for module change after esmvalcore=2.7
+    if core_ver.split(".")[0] == "2" and int(core_ver.split(".")[1]) < 8:
         import esmvalcore._recipe
         mocker.patch.object(
             esmvalcore._recipe,
@@ -87,14 +79,34 @@ def test_recipe_valid(recipe_file, config_user, mocker):
             spec_set=True,
             side_effect=lambda *_, **__: [1, 2],
         )
+    else:
+        import esmvalcore._recipe.recipe
+        mocker.patch.object(
+            esmvalcore._recipe.recipe,
+            'get_reference_levels',
+            autospec=True,
+            spec_set=True,
+            side_effect=lambda *_, **__: [1, 2],
+        )
 
     # Mock valid NCL version
-    mocker.patch.object(
-        esmvalcore._recipe_checks,
-        'ncl_version',
-        autospec=True,
-        spec_set=True,
-    )
+    # Account for module change after esmvalcore=2.7
+    if core_ver.split(".")[0] == "2" and int(core_ver.split(".")[1]) < 8:
+        import esmvalcore._recipe_checks
+        mocker.patch.object(
+            esmvalcore._recipe_checks,
+            'ncl_version',
+            autospec=True,
+            spec_set=True,
+        )
+    else:
+        import esmvalcore._recipe.check
+        mocker.patch.object(
+            esmvalcore._recipe.check,
+            'ncl_version',
+            autospec=True,
+            spec_set=True,
+        )
 
     # Mock interpreters installed
     def which(executable):
@@ -121,4 +133,8 @@ def test_recipe_valid(recipe_file, config_user, mocker):
             filename.parent.mkdir(parents=True, exist_ok=True)
             filename.touch()
 
-    esmvalcore._recipe.read_recipe_file(recipe_file, config_user)
+    # Account for module change after esmvalcore=2.7
+    if core_ver.split(".")[0] == "2" and int(core_ver.split(".")[1]) < 8:
+        esmvalcore._recipe.read_recipe_file(recipe_file, config_user)
+    else:
+        esmvalcore._recipe.recipe.read_recipe_file(recipe_file, config_user)

--- a/tests/integration/test_recipes_loading.py
+++ b/tests/integration/test_recipes_loading.py
@@ -3,13 +3,13 @@ from pathlib import Path
 
 import esmvalcore
 import esmvalcore._config
-import esmvalcore._recipe
 import esmvalcore.cmor.check
 import pytest
 import yaml
 
 import esmvaltool
 
+from esmvalcore import __version__ as core_ver
 from .test_diagnostic_run import write_config_user_file
 
 
@@ -69,13 +69,24 @@ def test_recipe_valid(recipe_file, config_user, mocker):
     )
 
     # Mock vertical levels
-    mocker.patch.object(
-        esmvalcore._recipe,
-        'get_reference_levels',
-        autospec=True,
-        spec_set=True,
-        side_effect=lambda *_, **__: [1, 2],
-    )
+    if core_ver.split(".")[0] == "2" and core_ver.split(".")[1] == "8":
+        import esmvalcore._recipe.recipe
+        mocker.patch.object(
+            esmvalcore._recipe.recipe,
+            'get_reference_levels',
+            autospec=True,
+            spec_set=True,
+            side_effect=lambda *_, **__: [1, 2],
+        )
+    else:
+        import esmvalcore._recipe
+        mocker.patch.object(
+            esmvalcore._recipe,
+            'get_reference_levels',
+            autospec=True,
+            spec_set=True,
+            side_effect=lambda *_, **__: [1, 2],
+        )
 
     # Mock valid NCL version
     mocker.patch.object(

--- a/tests/unit/cmorizers/obs/test_merra2.py
+++ b/tests/unit/cmorizers/obs/test_merra2.py
@@ -26,7 +26,7 @@ def _create_sample_cube():
     zcoord = iris.coords.DimCoord([0.5, 5., 50.],
                                   long_name='vertical level',
                                   var_name='lev',
-                                  units='m',
+                                  units='hPa',
                                   attributes={'positive': 'down'})
     lons = iris.coords.DimCoord([1.5, 2.5],
                                 standard_name='longitude',
@@ -265,7 +265,11 @@ def test_vertical_levels(tmp_path):
     cube_3 = _create_sample_cube()
     cube_3.var_name = "T2M"
     cube_3.units = Unit('K')
-    cubes = iris.cube.CubeList([cube_1, cube_2, cube_3])
+    cube_4 = _create_sample_cube()
+    cube_4.var_name = "H"
+    cube_4.units = Unit('m')
+    cube_4.coord("vertical level").units = "m"
+    cubes = iris.cube.CubeList([cube_1, cube_2, cube_3, cube_4])
     iris.save(cubes, str(path_cubes))
     var_1 = {
         'short_name': 'va',
@@ -282,6 +286,11 @@ def test_vertical_levels(tmp_path):
         'mip': 'Amon', 'raw': 'T2M',
         'file': 'MERRA2_???.tavgM_2d_slv_Nx.{year}??.nc4'
     }
+    var_4 = {
+        'short_name': 'zg',
+        'mip': 'Amon', 'raw': 'H',
+        'file': 'MERRA2_???.instM_3d_ana_Np.{year}??.nc4'
+    }
     in_files = str(tmp_path / "cubes.nc")
     cfg = read_cmor_config("MERRA2")
 
@@ -293,8 +302,9 @@ def test_vertical_levels(tmp_path):
     print(cmorized_cube,
           cmorized_cube.coord("air_pressure"))
     assert cmorized_cube.coord("air_pressure").has_bounds()
+    assert cmorized_cube.coord("air_pressure").units == "Pa"
     np.testing.assert_array_equal(cmorized_cube.coord("air_pressure").points,
-                                  [0.5, 5., 50.])
+                                  [50., 500., 5000.])
 
     # extract uas
     _extract_variable(in_files, var_2, cfg, tmp_path)
@@ -313,3 +323,9 @@ def test_vertical_levels(tmp_path):
     print(cmorized_cube)
     np.testing.assert_array_equal(cmorized_cube.coord("height").points,
                                   [2.])
+
+    # extract zg failed
+    with pytest.raises(ValueError) as exc:
+        _extract_variable(in_files, var_4, cfg, tmp_path)
+    expected_exc = "Unable to convert from 'Unit('m')' to 'Unit('Pa')'"
+    assert expected_exc in str(exc)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

esmvalcore's `_recipe.py` has become a submodule in its own right in `esmvalcore>=2.8` and we should account for that when we test the recipe loading and interaction with `esmvalcore` in `tests/integration/test_recipes_loading.py`

- Closes #3018 

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [ ] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [ ] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

