### PR TITLE
Fix option showyears in cloud diags

### DIFF
--- a/esmvaltool/diag_scripts/clouds/clouds.ncl
+++ b/esmvaltool/diag_scripts/clouds/clouds.ncl
@@ -461,11 +461,31 @@ begin
     ; if desired, add years to plot title
     years_str = ""
     if (diag_script_info@showyears) then
-      years_str = " (" + var0_info@start_year
-      if (var0_info@start_year .ne. var0_info@end_year) then
-        years_str = years_str + "-" + var0_info@end_year
+      year0 = "-1"
+      if (isatt(var0_info, "start_year") .and.  \
+          isatt(var0_info, "end_year")) then
+        year0 = var0_info@start_year
+        year1 = var0_info@end_year
+      else
+        ; try attribute timerange
+        if (isatt(var0_info, "timerange")) then
+          years = tostring(str_split(var0_info@timerange, "/"))
+          year0 = years(0)
+          if (dimsizes(years) .gt. 1) then
+            year1 = years(1)
+          else
+            year1 = year0
+          end if
+        end if
       end if
-      years_str = years_str + ")"
+
+      if (year0 .ne. "-1") then
+        years_str = " (" + year0
+        if (year0 .ne. year1) then
+          years_str = years_str + "-" + year1
+        end if
+        years_str = years_str + ")"
+      end if
     end if
 
 ;    res@tiMainOn             = False
@@ -836,6 +856,7 @@ begin
         dres@tiMainString =  refname + " uncertainty" + years_str
         rmsd(imod, :) = rmsd@_FillValue
         bias(imod, :) = bias@_FillValue
+        corr(imod, :) = corr@_FillValue
       else
         continue
       end if

--- a/esmvaltool/diag_scripts/clouds/clouds.ncl
+++ b/esmvaltool/diag_scripts/clouds/clouds.ncl
@@ -60,6 +60,7 @@
 ;   none
 ;
 ; Modification history
+;   20230126-lauer_axel: fixed problem with option showyears
 ;   20230117-lauer_axel: added support for ICON (code from Manuel)
 ;   20211021-lauer_axel: added output of basic statistics as ascii files
 ;   20211006-lauer_axel: removed write_plots
@@ -460,28 +461,30 @@ begin
 
     ; if desired, add years to plot title
     years_str = ""
+
     if (diag_script_info@showyears) then
-      year0 = "-1"
-      if (isatt(var0_info, "start_year") .and.  \
-          isatt(var0_info, "end_year")) then
+      year0 = ""
+      year1 = ""
+      if (isatt(var0_info, "start_year"))
         year0 = var0_info@start_year
+      end if
+      if (isatt(var0_info, "end_year"))
         year1 = var0_info@end_year
-      else
-        ; try attribute timerange
+      end if
+
+      if (year0 .eq. "") then  ; try attribute timerange
         if (isatt(var0_info, "timerange")) then
-          years = tostring(str_split(var0_info@timerange, "/"))
+          years = str_split(tostring(var0_info@timerange), "/")
           year0 = years(0)
           if (dimsizes(years) .gt. 1) then
             year1 = years(1)
-          else
-            year1 = year0
           end if
         end if
       end if
 
-      if (year0 .ne. "-1") then
+      if (year0 .ne. "") then
         years_str = " (" + year0
-        if (year0 .ne. year1) then
+        if ((year1 .ne. "") .and. (year1 .ne. year0)) then
           years_str = years_str + "-" + year1
         end if
         years_str = years_str + ")"

--- a/esmvaltool/diag_scripts/clouds/clouds_zonal.ncl
+++ b/esmvaltool/diag_scripts/clouds/clouds_zonal.ncl
@@ -334,11 +334,31 @@ begin
     ; if desired, add years to plot title
     years_str = ""
     if (diag_script_info@showyears) then
-      years_str = " (" + variable_info[0]@start_year
-      if (variable_info[0]@start_year .ne. variable_info[0]@end_year) then
-        years_str = years_str + "-" + variable_info[0]@end_year
+      year0 = "-1"
+      if (isatt(var0_info, "start_year") .and.  \
+          isatt(var0_info, "end_year")) then
+        year0 = var0_info@start_year
+        year1 = var0_info@end_year
+      else
+        ; try attribute timerange
+        if (isatt(var0_info, "timerange")) then
+          years = tostring(str_split(var0_info@timerange, "/"))
+          year0 = years(0)
+          if (dimsizes(years) .gt. 1) then
+            year1 = years(1)
+          else
+            year1 = year0
+          end if
+        end if
       end if
-      years_str = years_str + ")"
+
+      if (year0 .ne. "-1") then
+        years_str = " (" + year0
+        if (year0 .ne. year1) then
+          years_str = years_str + "-" + year1
+        end if
+        years_str = years_str + ")"
+      end if
     end if
 
 ;    res@tiMainOn             = False

--- a/esmvaltool/diag_scripts/clouds/clouds_zonal.ncl
+++ b/esmvaltool/diag_scripts/clouds/clouds_zonal.ncl
@@ -47,6 +47,7 @@
 ;   none
 ;
 ; Modification history
+;   20230126-lauer_axel: fixed problem with option showyears
 ;   20230117-lauer_axel: added support for ICON (code from Manuel)
 ;   20200211-lauer_axel: written.
 ;
@@ -334,27 +335,28 @@ begin
     ; if desired, add years to plot title
     years_str = ""
     if (diag_script_info@showyears) then
-      year0 = "-1"
-      if (isatt(var0_info, "start_year") .and.  \
-          isatt(var0_info, "end_year")) then
+      year0 = ""
+      year1 = ""
+      if (isatt(var0_info, "start_year"))
         year0 = var0_info@start_year
+      end if
+      if (isatt(var0_info, "end_year"))
         year1 = var0_info@end_year
-      else
-        ; try attribute timerange
+      end if
+
+      if (year0 .eq. "") then  ; try attribute timerange
         if (isatt(var0_info, "timerange")) then
-          years = tostring(str_split(var0_info@timerange, "/"))
+          years = str_split(tostring(var0_info@timerange), "/")
           year0 = years(0)
           if (dimsizes(years) .gt. 1) then
             year1 = years(1)
-          else
-            year1 = year0
           end if
         end if
       end if
 
-      if (year0 .ne. "-1") then
+      if (year0 .ne. "") then
         years_str = " (" + year0
-        if (year0 .ne. year1) then
+        if ((year1 .ne. "") .and. (year1 .ne. year0)) then
           years_str = years_str + "-" + year1
         end if
         years_str = years_str + ")"


### PR DESCRIPTION
## Description

This purely technical PR fixes a problem with the newly added option `showyears` introduced to the two cloud diagnostics `clouds.ncl` and `clouds_zonal.ncl`. The current implementation of this option does not handle cases properly in which the variable_info attributes `start_year` and/or `end_year` are not defined. Without the fix, the two diagnostics might crash if  `start_year` and/or `end_year` are not defined.

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful