### PR TITLE
Fix version numbers of native6 datasets in recipes

### DIFF
--- a/doc/sphinx/source/input.rst
+++ b/doc/sphinx/source/input.rst
@@ -455,7 +455,7 @@ For example:
 .. code-block:: yaml
 
     datasets:
-    - {project: native6, dataset: ERA5, type: reanaly, version: '1', tier: 3, start_year: 1990, end_year: 1990}
+    - {project: native6, dataset: ERA5, type: reanaly, version: v1, tier: 3, start_year: 1990, end_year: 1990}
     - {project: ICON, dataset: ICON, exp: icon-2.6.1_atm_amip_R2B5_r1i1p1f1, mip: Amon, short_name: tas, start_year: 2000, end_year: 2014}
 
 For project ``native6``, more examples can be found in the diagnostics

--- a/esmvaltool/recipes/clouds/recipe_lauer22jclim_fig1_clim.yml
+++ b/esmvaltool/recipes/clouds/recipe_lauer22jclim_fig1_clim.yml
@@ -141,7 +141,7 @@ diagnostics:
              tier: 2, start_year: 1982, end_year: 2016}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3}
@@ -164,7 +164,7 @@ diagnostics:
              tier: 3, start_year: 1982, end_year: 2018}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3}
@@ -191,7 +191,7 @@ diagnostics:
              tier: 3, start_year: 1988, end_year: 2016}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3}
@@ -297,7 +297,7 @@ diagnostics:
              tier: 2, start_year: 1982, end_year: 2016}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3}
@@ -320,7 +320,7 @@ diagnostics:
              tier: 3, start_year: 1982, end_year: 2018}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3}
@@ -346,7 +346,7 @@ diagnostics:
              start_year: 1988, end_year: 2016}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3}

--- a/esmvaltool/recipes/clouds/recipe_lauer22jclim_fig1_clim_amip.yml
+++ b/esmvaltool/recipes/clouds/recipe_lauer22jclim_fig1_clim_amip.yml
@@ -157,7 +157,7 @@ diagnostics:
              tier: 2, start_year: 1982, end_year: 2016}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3}
@@ -180,7 +180,7 @@ diagnostics:
              tier: 3, start_year: 1982, end_year: 2018}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3}
@@ -206,7 +206,7 @@ diagnostics:
              start_year: 1988, end_year: 2016}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3}
@@ -312,7 +312,7 @@ diagnostics:
              tier: 2, start_year: 1982, end_year: 2016}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3}
@@ -335,7 +335,7 @@ diagnostics:
              tier: 3, start_year: 1982, end_year: 2018}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3}
@@ -361,7 +361,7 @@ diagnostics:
              start_year: 1988, end_year: 2016}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3}

--- a/esmvaltool/recipes/clouds/recipe_lauer22jclim_fig2_taylor.yml
+++ b/esmvaltool/recipes/clouds/recipe_lauer22jclim_fig2_taylor.yml
@@ -55,7 +55,7 @@ diagnostics:
              tier: 2, start_year: 1982, end_year: 2016}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3, start_year: 1986, end_year: 2014}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3, start_year: 1986, end_year: 2014}
@@ -75,7 +75,7 @@ diagnostics:
              tier: 3, start_year: 1982, end_year: 2018}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3, start_year: 1986, end_year: 2014}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3, start_year: 1986, end_year: 2014}
@@ -98,7 +98,7 @@ diagnostics:
              start_year: 1988, end_year: 2016}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3, start_year: 1986, end_year: 2014}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3, start_year: 1986, end_year: 2014}

--- a/esmvaltool/recipes/clouds/recipe_lauer22jclim_fig2_taylor_amip.yml
+++ b/esmvaltool/recipes/clouds/recipe_lauer22jclim_fig2_taylor_amip.yml
@@ -54,7 +54,7 @@ diagnostics:
              tier: 2, start_year: 1982, end_year: 2016}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3, start_year: 1986, end_year: 2014}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3, start_year: 1986, end_year: 2014}
@@ -74,7 +74,7 @@ diagnostics:
              tier: 3, start_year: 1982, end_year: 2018}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3, start_year: 1986, end_year: 2014}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3, start_year: 1986, end_year: 2014}
@@ -97,7 +97,7 @@ diagnostics:
              start_year: 1988, end_year: 2016}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3, start_year: 1986, end_year: 2014}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3, start_year: 1986, end_year: 2014}

--- a/esmvaltool/recipes/clouds/recipe_lauer22jclim_fig3-4_zonal.yml
+++ b/esmvaltool/recipes/clouds/recipe_lauer22jclim_fig3-4_zonal.yml
@@ -448,7 +448,7 @@ diagnostics:
         end_year: 2014
         exp: historical
     additional_datasets:
-      - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1,
          tier: 3, start_year: 1986, end_year: 2014}
       # concatenation error - {dataset: ACCESS-CM2, institute: CSIRO-ARCCSS,
       #                        ensemble: r1i1p1f1, grid: gn}
@@ -528,7 +528,7 @@ diagnostics:
         end_year: 2005
         exp: historical
     additional_datasets:
-      - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1,
          tier: 3, start_year: 1986, end_year: 2014}
       - {dataset: ACCESS1-0, ensemble: r1i1p1}
       - {dataset: ACCESS1-3, ensemble: r1i1p1}

--- a/esmvaltool/recipes/clouds/recipe_lauer22jclim_fig5_lifrac.yml
+++ b/esmvaltool/recipes/clouds/recipe_lauer22jclim_fig5_lifrac.yml
@@ -79,7 +79,7 @@ diagnostics:
         exp: historical
         reference_dataset: ERA5
         additional_datasets:
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3, start_year: 2007, end_year: 2015}
     additional_datasets:
       # concatenation error - {dataset: ACCESS-CM2, institute: CSIRO-ARCCSS,
@@ -167,7 +167,7 @@ diagnostics:
         exp: historical
         reference_dataset: ERA5
         additional_datasets:
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3, start_year: 2007, end_year: 2015}
     additional_datasets:
       # concatenation error - {dataset: ACCESS1-0, ensemble: r1i1p1}

--- a/esmvaltool/recipes/clouds/recipe_lauer22jclim_fig7_seas.yml
+++ b/esmvaltool/recipes/clouds/recipe_lauer22jclim_fig7_seas.yml
@@ -139,7 +139,7 @@ diagnostics:
              start_year: 1982, end_year: 2016}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3}
@@ -162,7 +162,7 @@ diagnostics:
              tier: 3, start_year: 1982, end_year: 2018}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3}
@@ -292,7 +292,7 @@ diagnostics:
              start_year: 1982, end_year: 2016}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3}
@@ -315,7 +315,7 @@ diagnostics:
              tier: 3, start_year: 1982, end_year: 2018}
           - {dataset: MODIS, project: OBS, type: sat, version: MYD08-M3,
              tier: 3, start_year: 2003, end_year: 2018}
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3}
           - {dataset: ERA-Interim, project: OBS6, type: reanaly, version: '1',
              tier: 3}

--- a/esmvaltool/recipes/clouds/recipe_lauer22jclim_fig8_dyn.yml
+++ b/esmvaltool/recipes/clouds/recipe_lauer22jclim_fig8_dyn.yml
@@ -172,7 +172,7 @@ diagnostics:
         end_year: 2005
         reference_dataset: ERA5
         additional_datasets:
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3, start_year: 1992, end_year: 2016}
       wap:
         preprocessor: clim500_ocean
@@ -183,7 +183,7 @@ diagnostics:
         end_year: 2005
         reference_dataset: ERA5
         additional_datasets:
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3, start_year: 1992, end_year: 2016}
       clivi:
         preprocessor: clim_ocean
@@ -279,7 +279,7 @@ diagnostics:
         end_year: 2014
         reference_dataset: ERA5
         additional_datasets:
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3, start_year: 1992, end_year: 2016}
       wap:
         preprocessor: clim500_ocean
@@ -290,7 +290,7 @@ diagnostics:
         end_year: 2014
         reference_dataset: ERA5
         additional_datasets:
-          - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+          - {dataset: ERA5, project: native6, type: reanaly, version: v1,
              tier: 3, start_year: 1992, end_year: 2016}
       clivi:
         preprocessor: clim_ocean

--- a/esmvaltool/recipes/cmorizers/recipe_daily_era5.yml
+++ b/esmvaltool/recipes/cmorizers/recipe_daily_era5.yml
@@ -23,7 +23,7 @@ documentation:
 
 datasets:
   # For the daily diagnostic, always add the next year, otherwise the last day is not cmor compatible
-  - {dataset: ERA5, project: native6, type: reanaly, version: '1', tier: 3, start_year: 1990, end_year: 1991}
+  - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3, start_year: 1990, end_year: 1991}
 
 preprocessors:
   add_one_day: &add_one_day

--- a/esmvaltool/recipes/cmorizers/recipe_era5-land.yml
+++ b/esmvaltool/recipes/cmorizers/recipe_era5-land.yml
@@ -18,7 +18,7 @@ documentation:
     - eval4cmip
 
 datasets:
-  - {dataset: ERA5-Land, project: native6, type: reanaly, version: '1',
+  - {dataset: ERA5-Land, project: native6, type: reanaly, version: v1,
      tier: 3, start_year: 1981, end_year: 1982}
 
 diagnostics:

--- a/esmvaltool/recipes/examples/recipe_check_obs.yml
+++ b/esmvaltool/recipes/examples/recipe_check_obs.yml
@@ -1492,7 +1492,7 @@ diagnostics:
         mip: fx
     additional_datasets:
       - {dataset: ERA5, project: native6, tier: 3, type: reanaly,
-         version: 1, start_year: 1990, end_year: 1990}
+         version: v1, start_year: 1990, end_year: 1990}
     scripts: null
 
 

--- a/esmvaltool/recipes/hydrology/recipe_globwat.yml
+++ b/esmvaltool/recipes/hydrology/recipe_globwat.yml
@@ -79,7 +79,7 @@ diagnostics:
     description: monthly precipitation and potential evaporation of ERA5 & ERA-Interim
     additional_datasets:
       - {dataset: ERA-Interim, project: OBS6, tier: 3, type: reanaly, version: 1}
-      - {dataset: ERA5, project: native6, type: reanaly, version: '1', tier: 3}
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
     variables:
       pr: &var_monthly
         mip: Amon

--- a/esmvaltool/recipes/hydrology/recipe_hydro_forcing.yml
+++ b/esmvaltool/recipes/hydrology/recipe_hydro_forcing.yml
@@ -28,7 +28,7 @@ documentation:
 datasets:
   - {dataset: ERA-Interim, project: OBS6, tier: 3, type: reanaly, version: 1}
   - {dataset: ERA5, project: OBS6, tier: 3, type: reanaly, version: 1}
-  - {dataset: MSWEP, project: native6, exp: historical, ensemble: r1i1p1, type: reanaly, version: 220, tier: 3}
+  - {dataset: MSWEP, project: native6, exp: historical, ensemble: r1i1p1, type: reanaly, version: v220, tier: 3}
 
 preprocessors:
   daily:

--- a/esmvaltool/recipes/ipccwg1ar6ch3/recipe_ipccwg1ar6ch3_atmosphere.yml
+++ b/esmvaltool/recipes/ipccwg1ar6ch3/recipe_ipccwg1ar6ch3_atmosphere.yml
@@ -696,7 +696,7 @@ diagnostics:
         end_year: 2014
         additional_datasets: *models_cmip6_historical
     additional_datasets:
-      - {dataset: ERA5, project: native6, type: reanaly, version: '1', tier: 3}
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
     scripts:
       fig_3_3:
         script: ipcc_ar6/model_bias.ncl
@@ -724,7 +724,7 @@ diagnostics:
         end_year: 2004
         additional_datasets: *models_cmip5_historical
     additional_datasets:
-      - {dataset: ERA5, project: native6, type: reanaly, version: '1', tier: 3}
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
     scripts:
       fig_3_3:
         script: ipcc_ar6/model_bias.ncl

--- a/esmvaltool/recipes/ipccwg1ar6ch3/recipe_ipccwg1ar6ch3_fig_3_19.yml
+++ b/esmvaltool/recipes/ipccwg1ar6ch3/recipe_ipccwg1ar6ch3_fig_3_19.yml
@@ -127,7 +127,7 @@ diagnostics:
         start_year: 1985
         end_year: 2014
     additional_datasets:
-            - {dataset: ERA5, project: native6, type: reanaly, version: 'v1', tier: 3}
+            - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
     scripts:
       clim:
         script:  ipcc_ar6/zonal_westerly_winds.ncl

--- a/esmvaltool/recipes/ipccwg1ar6ch3/recipe_ipccwg1ar6ch3_fig_3_42_a.yml
+++ b/esmvaltool/recipes/ipccwg1ar6ch3/recipe_ipccwg1ar6ch3_fig_3_42_a.yml
@@ -240,7 +240,7 @@ diagnostics:
       - {<<: *cmip6, dataset: KACE-1-0-G, grid: gr}
       - {<<: *cmip6, dataset: KIOST-ESM, grid: gr1}
       - {<<: *cmip6, dataset: MCM-UA-1-0}
-      - {dataset: ERA5, project: native6, type: reanaly, version: 'v1', tier: 3}
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
       - {dataset: NCEP-NCAR-R1, project: OBS6, type: reanaly, version: 1, tier: 2}
     scripts:
       grading: &grading_settings
@@ -381,7 +381,7 @@ diagnostics:
       - {<<: *cmip6, dataset: GISS-E2-1-G-CC}
       - {<<: *cmip6, dataset: KACE-1-0-G, grid: gr}
       - {<<: *cmip6, dataset: MCM-UA-1-0}
-      - {dataset: ERA5, project: native6, type: reanaly, version: 'v1', tier: 3}
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
       - {dataset: NCEP-NCAR-R1, project: OBS6, type: reanaly, version: 1, tier: 2}
 
 
@@ -421,7 +421,7 @@ diagnostics:
       - {<<: *cmip6, dataset: KIOST-ESM, grid: gr1}
       - {<<: *cmip6, dataset: MCM-UA-1-0}
       - {dataset: JRA-55, project: ana4mips, type: reanalysis, tier: 1}
-      - {dataset: ERA5, project: native6, type: reanaly, version: 'v1', tier: 3}
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
 
 
   lwcre:
@@ -579,7 +579,7 @@ diagnostics:
       - {<<: *cmip6, dataset: MCM-UA-1-0}
       - {dataset: AIRS, project: obs4MIPs, level: L3,
          version: RetStd-v5, tier: 1, start_year: 2003, end_year: 2010}
-      - {dataset: ERA5, project: native6, type: reanaly, version: 'v1', tier: 3}
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
 
 
   rsut:
@@ -661,7 +661,7 @@ diagnostics:
       - {<<: *cmip6, dataset: KACE-1-0-G, grid: gr}
       - {<<: *cmip6, dataset: KIOST-ESM, grid: gr1}
       - {<<: *cmip6, dataset: MCM-UA-1-0}
-      - {dataset: ERA5, project: native6, type: reanaly, version: 'v1', tier: 3}
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
       - {dataset: NCEP-NCAR-R1, project: OBS6, type: reanaly, version: 1, tier: 2}
 
 
@@ -699,7 +699,7 @@ diagnostics:
       - {<<: *cmip6, dataset: KACE-1-0-G, grid: gr}
       - {<<: *cmip6, dataset: KIOST-ESM, grid: gr1}
       - {<<: *cmip6, dataset: MCM-UA-1-0}
-      - {dataset: ERA5, project: native6, type: reanaly, version: 'v1', tier: 3}
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
       - {dataset: NCEP-NCAR-R1, project: OBS6, type: reanaly, version: 1, tier: 2}
 
 
@@ -739,7 +739,7 @@ diagnostics:
       - {<<: *cmip6, dataset: KACE-1-0-G, grid: gr}
       - {<<: *cmip6, dataset: KIOST-ESM, grid: gr1}
       - {<<: *cmip6, dataset: MCM-UA-1-0}
-      - {dataset: ERA5, project: native6, type: reanaly, version: 'v1', tier: 3}
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
       - {dataset: NCEP-NCAR-R1, project: OBS6, type: reanaly, version: 1, tier: 2}
 
 
@@ -778,7 +778,7 @@ diagnostics:
       - {<<: *cmip6, dataset: KACE-1-0-G, grid: gr}
       - {<<: *cmip6, dataset: KIOST-ESM, grid: gr1}
       - {<<: *cmip6, dataset: MCM-UA-1-0}
-      - {dataset: ERA5, project: native6, type: reanaly, version: 'v1', tier: 3}
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
       - {dataset: NCEP-NCAR-R1, project: OBS6, type: reanaly, version: 1, tier: 2}
 
 
@@ -811,7 +811,7 @@ diagnostics:
       - {<<: *cmip6, dataset: EC-Earth3-CC, grid: gr}
       - {<<: *cmip6, dataset: IPSL-CM5A2-INCA, grid: gr}
       - {<<: *cmip6, dataset: MCM-UA-1-0}
-      - {dataset: ERA5, project: native6, type: reanaly, version: 'v1', tier: 3}
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
       - {dataset: NCEP-NCAR-R1, project: OBS6, type: reanaly, version: 1, tier: 2}
 
 
@@ -846,7 +846,7 @@ diagnostics:
       - {<<: *cmip6, dataset: EC-Earth3-CC, grid: gr}
       - {<<: *cmip6, dataset: IPSL-CM5A2-INCA, grid: gr}
       - {<<: *cmip6, dataset: MCM-UA-1-0}
-      - {dataset: ERA5, project: native6, type: reanaly, version: 'v1', tier: 3}
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
       - {dataset: NCEP-NCAR-R1, project: OBS6, type: reanaly, version: 1, tier: 2}
 
 

--- a/esmvaltool/recipes/recipe_climwip_brunner2019_med.yml
+++ b/esmvaltool/recipes/recipe_climwip_brunner2019_med.yml
@@ -144,7 +144,7 @@ datasets: &model_data
 
 
 obs_data: &obs_data  # for climwip performance metrics
-  - {dataset: ERA5, project: native6, type: reanaly, version: '1', tier: 3}
+  - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
 
 preprocessors:
   climwip_general: &general

--- a/esmvaltool/recipes/recipe_climwip_brunner20esd.yml
+++ b/esmvaltool/recipes/recipe_climwip_brunner20esd.yml
@@ -73,7 +73,7 @@ datasets: &model_data
 
 
 obs_data: &obs_data  # for climwip performance metrics
-  - {dataset: ERA5, project: native6, type: reanaly, version: '1', tier: 3}
+  - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
 
 preprocessors:
   climwip_general: &general

--- a/esmvaltool/recipes/recipe_climwip_test_basic.yml
+++ b/esmvaltool/recipes/recipe_climwip_test_basic.yml
@@ -33,7 +33,7 @@ datasets: &model_data  # a minimal selection to demonstrate functionality
   - {dataset: BNU-ESM, project: CMIP5, exp: [historical, rcp85], ensemble: r1i1p1}
 
 obs_data: &obs_data  # for climwip performance metrics
-  - {dataset: ERA5, project: native6, type: reanaly, version: '1', tier: 3}
+  - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
 
 preprocessors:
   climwip_general: &general

--- a/esmvaltool/recipes/recipe_climwip_test_performance_sigma.yml
+++ b/esmvaltool/recipes/recipe_climwip_test_performance_sigma.yml
@@ -63,7 +63,7 @@ datasets: &model_data  # a selection of model to demonstrate functionality of th
   - {project: CMIP6, exp: [historical, ssp585], dataset: UKESM1-0-LL, ensemble: r(1:2)i1p1f2, grid: gn}
 
 obs_data: &obs_data  # for climwip performance metrics
-  - {dataset: ERA5, project: native6, type: reanaly, version: '1', tier: 3}
+  - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
 
 preprocessors:
   climwip_general: &general

--- a/esmvaltool/recipes/recipe_impact.yml
+++ b/esmvaltool/recipes/recipe_impact.yml
@@ -142,7 +142,7 @@ datasets:
   - {mip: Amon, project: CMIP6, exp: [historical, ssp585], dataset: UKESM1-0-LL, ensemble: r8i1p1f2, grid: gn, tag: model}
 
 observations: &observations
-  - {mip: Amon, dataset: ERA5, project: native6, type: reanaly, version: '1', tier: 3, tag: observations}
+  - {mip: Amon, dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3, tag: observations}
 
 preprocessors:
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
This PR adjusts the version numbers of `native6` datasets used in recipe, that is ERA5 (`v1`) and MSWEP (`v220`). Since `v2.7.0`, the changes ESMValGroup/ESMValCore#1835 have made it necessary to specify the correct version number of datasets. For ERA5 data, some recipes used `1` as a version number while others used `v1`. The data on Levante is organized with a `v1` and since adding a `v` is more consistent with the versioning of CMIP data, it was decided to adopt a consistent `v1` (see also discussion in #2960). Updating the recipes would enable to run more recipes for the upcoming `2.8.0` release. Incidentally, I have homogenized all the `native6` ERA5 entries to `v1` instead of `'v1'`.

- Closes #2960
- Link to documentation: https://esmvaltool--3041.org.readthedocs.build/en/3041/input.html#datasets-in-native-format

### Change required for users
Local pools of `native6` data need to be organized following this directory structure convention:
`Tier{tier}/{dataset}/{version}/{frequency}/{short_name}`, see the documentation: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/quickstart/find_data.html?highlight=native6#supported-native-reanalysis-observational-datasets

Due to the changes introduced in this pull request, the name of the "version" directory `{version}` now needs to be identical to the version numbers of `native6` datasets used in recipes: `v1` for ERA5 and `v220` for MSWEP. **If the version directory was previously named `1` or `220`, the tool will no longer be able to locate the data.** 

### Working examples
- `~/climate_data/native6/Tier3/ERA5/v1/mon/tas/`
- `~/climate_data/native6/Tier3/MSWEP/v220/day/pr/`

### Cases no longer supporter
Examples of directory structures no longer supported:
- `~/climate_data/native6/Tier3/ERA5/1/mon/tas/`
- `~/climate_data/native6/Tier3/MSWEP/220/day/pr/`



* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [x] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [x] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [x] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [x] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added

***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
