### PR TITLE
Fix call of output_type in aux_plotting.ncl

### DIFF
--- a/esmvaltool/diag_scripts/shared/plot/aux_plotting.ncl
+++ b/esmvaltool/diag_scripts/shared/plot/aux_plotting.ncl
@@ -6,8 +6,8 @@
 ;
 ; Contents:
 ;
-;    procedure create_legend_lines
 ;    function output_type
+;    procedure create_legend_lines
 ;    procedure copy_VarAtt_sel
 ;    function panelling
 ;    function get_plot_dir

--- a/esmvaltool/diag_scripts/shared/plot/aux_plotting.ncl
+++ b/esmvaltool/diag_scripts/shared/plot/aux_plotting.ncl
@@ -38,6 +38,41 @@ load "$diag_scripts/../interface_scripts/auxiliary.ncl"
 load "$diag_scripts/../interface_scripts/logging.ncl"
 
 ; #############################################################################
+undef("output_type")
+function output_type()
+;
+; Arguments
+;
+; Return value
+;    A string with the output file type
+;
+; Description
+;    Provides a default, if file type is not explicitly specified
+;
+; Caveats
+;
+; Modification history
+;    20131028-gottschaldt_klaus-dirk: written.
+;
+local funcname, scriptname, file_type
+begin
+
+  funcname = "output_type"
+  scriptname = "diag_scripts/shared/plot/aux_plotting.ncl"
+  enter_msg(scriptname, funcname)
+
+  file_type = config_user_info@output_file_type
+  if (ismissing(file_type)) then
+    file_type = "ps"
+  end if
+  file_type = str_lower(file_type)
+
+  leave_msg(scriptname, funcname)
+  return(file_type)
+
+end
+
+; #############################################################################
 undef("create_legend_lines")
 procedure create_legend_lines(labels:string, \
                               styles, \
@@ -75,7 +110,8 @@ begin
   enter_msg(scriptname, funcname)
 
   ; Open workstation
-  wks_legend = gsn_open_wks(output_type, outfile)
+  file_type = output_type()
+  wks_legend = gsn_open_wks(file_type, outfile)
 
   ; General resources
   res = True
@@ -175,41 +211,6 @@ begin
   frame(wks_legend)
 
   leave_msg(scriptname, funcname)
-
-end
-
-; #############################################################################
-undef("output_type")
-function output_type()
-;
-; Arguments
-;
-; Return value
-;    A string with the output file type
-;
-; Description
-;    Provides a default, if file type is not explicitly specified
-;
-; Caveats
-;
-; Modification history
-;    20131028-gottschaldt_klaus-dirk: written.
-;
-local funcname, scriptname, file_type
-begin
-
-  funcname = "output_type"
-  scriptname = "diag_scripts/shared/plot/aux_plotting.ncl"
-  enter_msg(scriptname, funcname)
-
-  file_type = config_user_info@output_file_type
-  if (ismissing(file_type)) then
-    file_type = "ps"
-  end if
-  file_type = str_lower(file_type)
-
-  leave_msg(scriptname, funcname)
-  return(file_type)
 
 end
 


### PR DESCRIPTION
## Description

Fix call of output_type in aux_plotting.ncl as it appears in the release testing for v2.8.0 (see Issue #3076).

This lead to the broken recipe_perfmetrics_CMIP5.yml.

* * *

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [x] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [x] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [x] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [x] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added