### PR TITLE
Recipe Autoassess Stratosphere `recipe_autoassess_stratosphere.py`: ducktape strato metric 1 for Matplotlib=3.7.1

### DIFF
--- a/esmvaltool/diag_scripts/autoassess/stratosphere/strat_metrics_1.py
+++ b/esmvaltool/diag_scripts/autoassess/stratosphere/strat_metrics_1.py
@@ -95,7 +95,10 @@ def plot_timehgt(cube, levels, title, log=False, ax1=None):
     new_epoch = time_coord.points[0]
     new_unit_str = 'hours since {}'
     new_unit = new_unit_str.format(time_coord.units.num2date(new_epoch))
-    ax1.xaxis.axis_date()
+    # github.com/ESMValGroup/ESMValTool/issues/3088 linking to
+    # github.com/matplotlib/matplotlib/issues/25419
+    # problem in matplotlib=3.7.1
+    # ax1.xaxis.axis_date()
     ax1.xaxis.set_label(new_unit)
     ax1.xaxis.set_major_locator(mdates.YearLocator(4))
     ax1.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

Ducktape metric since there are bugzz in Matplotlib=3.7.1 but the ducktaping is not affecting neither the plots nor functionality/actual metricsm see the plots below I got with the ducktaping on. BTW only the QBO plots should suffer - but they don't :grin: 

![ERA-Interim_qbo](https://user-images.githubusercontent.com/28983971/224073536-6a80cdaf-63ae-4d4d-ab63-37c9c9fd358d.png)
vs [270 plot](https://esmvaltool.dkrz.de/shared/esmvaltool/v2.7.0/recipe_autoassess_stratosphere_20221025_141607/plots/aa_strato/autoassess_strato_test_1/MPI-ESM-MR_vs_MPI-ESM-LR/stratosphere/ERA-Interim_qbo.png)

![inmcm4_qbo](https://user-images.githubusercontent.com/28983971/224073816-27142e80-fc11-48db-91c9-b61b9695dc24.png)
vs [270 plot](https://esmvaltool.dkrz.de/shared/esmvaltool/v2.7.0/recipe_autoassess_stratosphere_20221025_141607/plots/aa_strato/autoassess_strato_test_1/MPI-ESM-MR_vs_MPI-ESM-LR/stratosphere/inmcm4_qbo.png)

![MPI-ESM-LR_qbo](https://user-images.githubusercontent.com/28983971/224074060-410ece59-0d30-4836-aed8-3b891fbc0bd4.png)
vs [270 plot](https://esmvaltool.dkrz.de/shared/esmvaltool/v2.7.0/recipe_autoassess_stratosphere_20221025_141607/plots/aa_strato/autoassess_strato_test_1/MPI-ESM-MR_vs_MPI-ESM-LR/stratosphere/MPI-ESM-LR_qbo.png)

- Closes #3088 
- Link to documentation: not needed, documentation stays the same (including plots)

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [ ] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [ ] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [ ] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [ ] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [ ] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature

