### PR TITLE
Fix perfmetrics v2.8.0

### DIFF
--- a/esmvaltool/interface_scripts/auxiliary.ncl
+++ b/esmvaltool/interface_scripts/auxiliary.ncl
@@ -523,7 +523,7 @@ function ncdf_define(ncdf, data)
 ;    20131112-gottschaldt_klaus-dirk: written.
 ;
 local funcname, scriptname, data, diag_script, var, fAtt, dimNames, dimSzs, \
-  dimUnlim, atts
+  dimUnlim, atts, i, ii, jj
 begin
 
   funcname = "ncdf_define"
@@ -657,7 +657,7 @@ function ncdf_write(data,
 ; Modification history
 ;    20131107-gottschaldt_klaus-dirk: written.
 ;
-local funcname, scriptname, data, outfile, outfile_in, ncdf, varname
+local funcname, scriptname, data, outfile, outfile_in, ncdf, varname, i, idim
 begin
 
   funcname = "ncdf_write"
@@ -838,7 +838,7 @@ function copy_CoordNames_n(var_from,
 ; Modification history
 ;    20130419-gottschaldt_klaus-dirk: written.
 ;
-local funcname, scriptname, var_from, var_to, n, rank
+local funcname, scriptname, var_from, var_to, n, rank, ii
 begin
 
   funcname = "copy_CoordNames_n"


### PR DESCRIPTION
This PR fixes a newly surfaced issue with the perfmetrics diagnostics "zonal", "latlot" and "cycle" that resulted in the diagnostics getting stuck in an infinite loop (see also https://github.com/ESMValGroup/ESMValTool/issues/3076).

As it turned out, the problem was local variables used in functions defined in `interface_scipts/auxiliary.ncl` that had the same variable name as a loop variable in the perfmetrics diagnostics mentioned above. For reasons that are still not clear to me, a call to the function `ncdf_write` (which then calls `ncdf_define)` resulted in the variable used as loop index (`ii`) being overwritten in the calling procedure. As a consequence, the calling diagnostic got stuck in an infinite loop.

Declaring the variables used within the shared functions (`interface_scipts/auxiliary.ncl`) as "local" solved this problem.

I still do not fully understand why variables used in a function would overwrite the variables with the same name in the calling procedure when not explicitly declared as "local" variables and why this problem did not emerge earlier, but this problem is fixed with this PR. With the fix, I could (again) successfully run recipe_perfmetrics_CMIP5.yml, the output looks as expected.

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
~~- [ ] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)~~
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [x] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
~~- [ ] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)~~
- [x] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [x] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added