### PR TITLE
Removed `fx_variables` in recipe_mpqb_xch4 and recipe_lauer22jclim_fig8

### DIFF
--- a/esmvaltool/recipes/clouds/recipe_lauer22jclim_fig8_dyn.yml
+++ b/esmvaltool/recipes/clouds/recipe_lauer22jclim_fig8_dyn.yml
@@ -30,8 +30,6 @@ preprocessors:
       units: "Pa min-1"
     mask_landsea:
       mask_out: land
-      fx_variables:
-        sftlf:
     extract_levels:
       levels: 50000
       scheme: linear
@@ -51,8 +49,6 @@ preprocessors:
     #   end_latitude: 30
     mask_landsea:
       mask_out: land
-      fx_variables:
-        sftlf:
     regrid:
       target_grid: 2x2
       scheme: linear

--- a/esmvaltool/recipes/mpqb/recipe_mpqb_xch4.yml
+++ b/esmvaltool/recipes/mpqb/recipe_mpqb_xch4.yml
@@ -43,8 +43,6 @@ global_mon: &global_mon
   mask_multimodel:
   area_statistics:
     operator: mean
-    fx_variables:
-      areacella:
   monthly_statistics:
     operator: mean
 
@@ -54,8 +52,6 @@ global_ann: &global_ann
   mask_multimodel:
   area_statistics:
     operator: mean
-    fx_variables:
-      areacella:
   annual_statistics:
     operator: mean
 
@@ -66,8 +62,6 @@ sh_mon: &sh_mon
   mask_multimodel:
   area_statistics:
     operator: mean
-    fx_variables:
-      areacella:
   monthly_statistics:
     operator: mean
 
@@ -78,8 +72,6 @@ sh_ann: &sh_ann
   mask_multimodel:
   area_statistics:
     operator: mean
-    fx_variables:
-      areacella:
   annual_statistics:
     operator: mean
 
@@ -90,8 +82,6 @@ nh_mon: &nh_mon
   mask_multimodel:
   area_statistics:
     operator: mean
-    fx_variables:
-      areacella:
   monthly_statistics:
     operator: mean
 
@@ -102,8 +92,6 @@ nh_ann: &nh_ann
   mask_multimodel:
   area_statistics:
     operator: mean
-    fx_variables:
-      areacella:
   annual_statistics:
     operator: mean
 


### PR DESCRIPTION
This PR adapts recipe_mpqb_xch4.yml and recipe_lauer22jclim_fig8 to comply with the new requirements (remove fx_variables) introduced in ESMValCore PR https://github.com/ESMValGroup/ESMValCore/pull/1609.

See also issue https://github.com/ESMValGroup/ESMValTool/issues/3056.

I tested the two recipes successfully. The output looks as expected.

## Checklist

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [x] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [x] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature