### PR TITLE
Update batch script generation to run all recipes in one command

### DIFF
--- a/doc/sphinx/source/community/release_strategy/detailed_release_procedure.rst
+++ b/doc/sphinx/source/community/release_strategy/detailed_release_procedure.rst
@@ -57,11 +57,16 @@ Submit run scripts - test recipe runs
 We are now ready to start running all the available recipes, to compare output against previous release. Running is currently done
 via batch scripts submitted to a schedulers (SLURM). Generate the submission scripts using the ``generate.py`` :ref:`utility Python script <utils_generate>`.
 
-You will have to set the name of your environment, your email address (if you want to get email notifications for successful/failed jobs) and the name of the directory you want to store the log files of the jobs. A compute project from which resources are billed needs to be set, and the default partition is set to `compute`.
+You will have to set the name of your environment, your email address (if you want to get email notifications for successful/failed jobs) and the name of the directory you want to store the log files of the jobs. A compute project from which resources are billed needs to be set, and the default partition is set to `interactive`.
 More information on running jobs with SLURM on DKRZ/Levante can be found in the DKRZ `documentation
 <https://docs.dkrz.de/doc/levante/running-jobs/index.html>`_.
 
+You can also specify the path to your ``config-user.yml`` file where ``max_parallel_tasks`` can be set. The script was found to work well with ``max_parallel_tasks=8``. Some recipes need to be run with `max_parallel_tasks=1`` (large memory requirements, CMIP3 data, diagnostic issues). These recipes are listed in `ONE_TASK_RECIPES`.
+
 Some recipes need other job requirements, you can add their headers in the `SPECIAL_RECIPES` dictionary. Otherwise the header will be written following the template that is written in the lines below. If you want to exclude recipes, you can do so by uncommenting the exclude lines.
+
+Before submitting all jobs, it is recommended to first try the batch script generation with ``submit = False`` and check the generated files. If memory with special runtime requirements have been added to ESMValTool since the last release, these may need to be added to `SPECIAL_RECIPES` and/or `ONE_TASK_RECIPES`.
+Other recipes should run successfully with the default SLURM settings set in the script.
 
 The launch scripts will be saved in the same directory you execute the script from. These are named like ``launch_recipe_<name>.sh``.
 To submit these scripts to the SLURM scheduler, use the ``sbatch launch_recipe_<name>.sh`` command. You can check the status of your BATCH queue by invoking:

--- a/doc/sphinx/source/community/release_strategy/detailed_release_procedure.rst
+++ b/doc/sphinx/source/community/release_strategy/detailed_release_procedure.rst
@@ -61,12 +61,12 @@ You will have to set the name of your environment, your email address (if you wa
 More information on running jobs with SLURM on DKRZ/Levante can be found in the DKRZ `documentation
 <https://docs.dkrz.de/doc/levante/running-jobs/index.html>`_.
 
-You can also specify the path to your ``config-user.yml`` file where ``max_parallel_tasks`` can be set. The script was found to work well with ``max_parallel_tasks=8``. Some recipes need to be run with `max_parallel_tasks=1`` (large memory requirements, CMIP3 data, diagnostic issues). These recipes are listed in `ONE_TASK_RECIPES`.
+You can also specify the path to your ``config-user.yml`` file where ``max_parallel_tasks`` can be set. The script was found to work well with ``max_parallel_tasks=8``. Some recipes need to be run with ``max_parallel_tasks=1`` (large memory requirements, CMIP3 data, diagnostic issues, ...). These recipes are listed in `ONE_TASK_RECIPES`.
 
-Some recipes need other job requirements, you can add their headers in the `SPECIAL_RECIPES` dictionary. Otherwise the header will be written following the template that is written in the lines below. If you want to exclude recipes, you can do so by uncommenting the exclude lines.
+Some recipes need other job requirements, you can add their headers in the `SPECIAL_RECIPES` dictionary. Otherwise the header will be written following the template that is written in the lines below. If you want to exclude recipes, you can do so by uncommenting the `exclude` lines.
 
-Before submitting all jobs, it is recommended to first try the batch script generation with ``submit = False`` and check the generated files. If memory with special runtime requirements have been added to ESMValTool since the last release, these may need to be added to `SPECIAL_RECIPES` and/or `ONE_TASK_RECIPES`.
-Other recipes should run successfully with the default SLURM settings set in the script.
+Before submitting all jobs, it is recommended to try the batch script generation with ``submit = False`` and check the generated files. If recipes with special runtime requirements have been added to ESMValTool since the previous release, these may need to be added to `SPECIAL_RECIPES` and/or to `ONE_TASK_RECIPES`.
+Other recipes should run successfully with the default SLURM settings set in this script.
 
 The launch scripts will be saved in the same directory you execute the script from. These are named like ``launch_recipe_<name>.sh``.
 To submit these scripts to the SLURM scheduler, use the ``sbatch launch_recipe_<name>.sh`` command. You can check the status of your BATCH queue by invoking:

--- a/doc/sphinx/source/utils.rst
+++ b/doc/sphinx/source/utils.rst
@@ -242,7 +242,7 @@ The following parameters have to be set in the script in order to make it run:
 
 Optionally, the following parameters can be edited:
 
-* ``env``, *str*: Path to ``config-user.yml`` if default ``~/.esmvaltool/config-user.yml`` not used.
+* ``config_file``, *str*: Path to ``config-user.yml`` if default ``~/.esmvaltool/config-user.yml`` not used.
 * ``partition``, *str*: Name of the DKRZ partition used to run jobs. Default is ``interactive`` to minimize computing cost compared to ``compute`` for which nodes cannot be shared.
 * ``memory``, *str*: Amount of memory requested for each run. Default is ``64G`` to allow to run 4 recipes on the same node in parallel.
 * ``time``, *str*: Time limit. Default is ``04:00:00`` to increase the job priority. Jobs can run for up to 8 hours and 12 hours on the compute and interactive partitions, respectively.

--- a/doc/sphinx/source/utils.rst
+++ b/doc/sphinx/source/utils.rst
@@ -240,9 +240,15 @@ The following parameters have to be set in the script in order to make it run:
 * ``outputs``, *str*: Name of the directory in which the job outputs (.out and .err files) are going to be saved. The outputs will be saved in `/home/user/<outputs>`.
 * ``conda_path``, *str*: Full path to the `mambaforge/etc/profile.d/conda.sh` executable.
 
-The script will generate a submission script for all recipes using by default the ``compute`` queue and with a time limit of 8h. In case a recipe
+Optionally, the following parameters can be edited:
+* ``env``, *str*: Path to ``config-user.yml`` if default ``~/.esmvaltool/config-user.yml`` not used.
+* ``partition``, *str*: Name of the DKRZ partition used to run jobs. Default is ``interactive`` to minimize computing cost compared to ``compute`` where nodes cannot be shared.
+* ``memory``, *str*: Amount of memory requested for each run. Default is ``64G`` to allow to run 4 recipes on the same node in parallel.
+* ``time``, *str*: Walltime. Default is ``04:00:00``. Jobs can run for up to 8 hours and 12 hours on the compute and interactive partitions, respectively.
+
+The script will generate a submission script for all recipes using by default the ``interactive`` queue and with a time limit of 4h. In case a recipe
 may require of additional resources, they can be defined in the ``SPECIAL_RECIPES`` dictionary. The recipe name has to be given as a ``key`` in which the
-values are another dictionaries. 
+values are another dictionary. 
 The latter are used to specify the ``partition`` in which to submit the recipe, the new ``time`` limit and other ``memory`` requirements
 given by the slurm flags ``--mem``, ``--constraint`` or ``--ntasks``. In general, an entry in ``SPECIAL_RECIPES`` should be set as:
 
@@ -255,6 +261,12 @@ given by the slurm flags ``--mem``, ``--constraint`` or ``--ntasks``. In general
         'memory': '#SBATCH --mem=<custom_memory_requirement>' # --constraint or --nstasks can be used instead.
         },
    }
+
+Some recipes can only be run with `--max_parallel_tasks=1` for different reasons (memory issues, diagnostic issues, CMIP3 data used).
+These recipes need to be added to ``ONE_TASK_RECIPES``.
+
+Note that the script has been optimized to use standard SLURM settings to run most recipes and tailored runtime settings for special cases.
+It is only necessary to edit this script for recipes that have been added since the last release and cannot be run with the default settings.
 
 In the case in which ``submit`` is set to ``True``, but you want to exclude certain recipes from being submitted, their name can be added in the ``exclude`` list:
 

--- a/doc/sphinx/source/utils.rst
+++ b/doc/sphinx/source/utils.rst
@@ -241,10 +241,11 @@ The following parameters have to be set in the script in order to make it run:
 * ``conda_path``, *str*: Full path to the `mambaforge/etc/profile.d/conda.sh` executable.
 
 Optionally, the following parameters can be edited:
+
 * ``env``, *str*: Path to ``config-user.yml`` if default ``~/.esmvaltool/config-user.yml`` not used.
-* ``partition``, *str*: Name of the DKRZ partition used to run jobs. Default is ``interactive`` to minimize computing cost compared to ``compute`` where nodes cannot be shared.
+* ``partition``, *str*: Name of the DKRZ partition used to run jobs. Default is ``interactive`` to minimize computing cost compared to ``compute`` for which nodes cannot be shared.
 * ``memory``, *str*: Amount of memory requested for each run. Default is ``64G`` to allow to run 4 recipes on the same node in parallel.
-* ``time``, *str*: Walltime. Default is ``04:00:00``. Jobs can run for up to 8 hours and 12 hours on the compute and interactive partitions, respectively.
+* ``time``, *str*: Time limit. Default is ``04:00:00`` to increase the job priority. Jobs can run for up to 8 hours and 12 hours on the compute and interactive partitions, respectively.
 
 The script will generate a submission script for all recipes using by default the ``interactive`` queue and with a time limit of 4h. In case a recipe
 may require of additional resources, they can be defined in the ``SPECIAL_RECIPES`` dictionary. The recipe name has to be given as a ``key`` in which the
@@ -262,10 +263,10 @@ given by the slurm flags ``--mem``, ``--constraint`` or ``--ntasks``. In general
         },
    }
 
-Some recipes can only be run with `--max_parallel_tasks=1` for different reasons (memory issues, diagnostic issues, CMIP3 data used).
-These recipes need to be added to ``ONE_TASK_RECIPES``.
+Some recipes can only be run with ``--max_parallel_tasks=1`` for various reasons (memory issues, diagnostic issues, CMIP3 data used).
+These recipes need to be added to the ``ONE_TASK_RECIPES`` list.
 
-Note that the script has been optimized to use standard SLURM settings to run most recipes and tailored runtime settings for special cases.
+Note that the script has been optimized to use standard SLURM settings to run most recipes while minimizing the computational cost of the jobs and tailored runtime settings for resource-intensive recipes.
 It is only necessary to edit this script for recipes that have been added since the last release and cannot be run with the default settings.
 
 In the case in which ``submit`` is set to ``True``, but you want to exclude certain recipes from being submitted, their name can be added in the ``exclude`` list:

--- a/esmvaltool/utils/batch-jobs/generate.py
+++ b/esmvaltool/utils/batch-jobs/generate.py
@@ -17,7 +17,7 @@ SLURM related parameters.
 4) If new memory intensive recipes have been merged since
 the last release (e.g. IPCC recipes), you may to add them
 to `SPECIAL_RECIPES` and/or to `ONE_TASK_RECIPES`
-5) Check the generation of the batch scripts with 
+5) Check the generation of the batch scripts with
 `submit = False`. Once the batch scripts are correct, change
 to `submit = True` and rerun the script to submit all jobs
 to the SLURM scheduler.

--- a/esmvaltool/utils/batch-jobs/generate.py
+++ b/esmvaltool/utils/batch-jobs/generate.py
@@ -12,7 +12,7 @@ To use this script, follow these steps:
 - config_file
 3) SLURM settings
 This script is configured to optimize the computing
-footpring of the recipe testing. It is not necessary to edit
+footprint of the recipe testing. It is not necessary to edit
 SLURM related parameters.
 4) If new memory intensive recipes have been merged since
 the last release (e.g. IPCC recipes), you may to add them
@@ -182,7 +182,7 @@ SPECIAL_RECIPES = {
 # These recipes either use CMIP3 input data
 # (see https://github.com/ESMValGroup/ESMValCore/issues/430)
 # and recipes where tasks require the full compute node memory.
-ONE_TASK_RECIPES = {
+ONE_TASK_RECIPES = [
     'recipe_bock20jgr_fig_1-4',
     'recipe_bock20jgr_fig_6-7',
     'recipe_bock20jgr_fig_8-10',
@@ -191,20 +191,21 @@ ONE_TASK_RECIPES = {
     'recipe_ipccwg1ar6ch3_fig_3_9',
     'recipe_ipccwg1ar6ch3_fig_3_42_a',
     'recipe_ipccwg1ar6ch3_fig_3_43',
-    'recipe_check_obs'
+    'recipe_check_obs',
     'recipe_collins13ipcc',
     'recipe_lauer22jclim_fig3-4_zonal',
     'recipe_lauer22jclim_fig5_lifrac',
     'recipe_smpi',
     'recipe_smpi_4cds',
     'recipe_wenzel14jgr',
-}
+    ]
 
 
 def generate_submit():
     """Generate and submit scripts."""
     home = os.path.expanduser('~')
     # Fill the list with the names of the recipes to be excluded
+    # This includes recipes containing missing datasets
     exclude = ['recipe_schlund20jgr_gpp_abs_rcp85',
                'recipe_schlund20jgr_gpp_change_1pct',
                'recipe_schlund20jgr_gpp_change_rcp85']

--- a/esmvaltool/utils/batch-jobs/generate.py
+++ b/esmvaltool/utils/batch-jobs/generate.py
@@ -177,6 +177,7 @@ ONE_TASK_RECIPES = {
     'recipe_wenzel14jgr',
 }
 
+
 def generate_submit():
     """Generate and submit scripts."""
     home = os.path.expanduser('~')
@@ -218,7 +219,8 @@ def generate_submit():
                 # Memory requirements
                 # Full node memory (compute partition)
                 if 'compute' in SPECIAL_RECIPES[recipe.stem]['partition']:
-                    file.write(f'#SBATCH --mem=0\n')
+                    mem_req_levante = '#SBATCH --mem=0\n'
+                    file.write(mem_req_levante)
                     if 'memory' in SPECIAL_RECIPES[recipe.stem]:
                         file.write(SPECIAL_RECIPES[recipe.stem]['memory'])
                 # Shared nodes (other partitions)
@@ -241,7 +243,8 @@ def generate_submit():
             if not config_file:
                 file.write(f'esmvaltool run {str(recipe)}')
             else:
-                file.write(f'esmvaltool run --config_file {str(config_file)} {str(recipe)}')
+                file.write(f'esmvaltool run --config_file '
+                           f'{str(config_file)} {str(recipe)}')
             if recipe.stem in ONE_TASK_RECIPES:
                 file.write(' --max_parallel_tasks=1')
 

--- a/esmvaltool/utils/batch-jobs/generate.py
+++ b/esmvaltool/utils/batch-jobs/generate.py
@@ -180,7 +180,10 @@ ONE_TASK_RECIPES = {
 def generate_submit():
     """Generate and submit scripts."""
     home = os.path.expanduser('~')
-    exclude = []  # Fill the list with the names of the recipes to be excluded
+    # Fill the list with the names of the recipes to be excluded
+    exclude = ['recipe_schlund20jgr_gpp_abs_rcp85',
+               'recipe_schlund20jgr_gpp_change_1pct',
+               'recipe_schlund20jgr_gpp_change_rcp85']
     dir_recipes = Path('/'.join((esmvaltool.__path__[0], 'recipes')))
 
     for recipe in Path(dir_recipes).rglob('*.yml'):

--- a/esmvaltool/utils/batch-jobs/generate.py
+++ b/esmvaltool/utils/batch-jobs/generate.py
@@ -156,6 +156,27 @@ SPECIAL_RECIPES = {
     },
 }
 
+# These recipes either use CMIP3 input data
+# (see https://github.com/ESMValGroup/ESMValCore/issues/430)
+# and recipes where tasks require the full compute node memory.
+ONE_TASK_RECIPES = {
+    'recipe_bock20jgr_fig_1-4',
+    'recipe_bock20jgr_fig_6-7',
+    'recipe_bock20jgr_fig_8-10',
+    'recipe_flato13ipcc_figure_96',
+    'recipe_flato13ipcc_figures_938_941_cmip3',
+    'recipe_ipccwg1ar6ch3_fig_3_9',
+    'recipe_ipccwg1ar6ch3_fig_3_42_a',
+    'recipe_ipccwg1ar6ch3_fig_3_43',
+    'recipe_check_obs'
+    'recipe_collins13ipcc',
+    'recipe_lauer22jclim_fig3-4_zonal',
+    'recipe_lauer22jclim_fig5_lifrac',
+    'recipe_smpi',
+    'recipe_smpi_4cds',
+    'recipe_wenzel14jgr',
+}
+
 def generate_submit():
     """Generate and submit scripts."""
     home = os.path.expanduser('~')

--- a/esmvaltool/utils/batch-jobs/generate.py
+++ b/esmvaltool/utils/batch-jobs/generate.py
@@ -29,7 +29,12 @@ conda_path = 'PATH_TO/mambaforge/etc/profile.d/conda.sh'
 # If none, ~/.esmvaltool/config-user.yml is used
 config_file = ''
 
+# List of recipes that require non-default SLURM options set above
 SPECIAL_RECIPES = {
+    'recipe_anav13jclim': {
+        'partition': '#SBATCH --partition=compute \n',
+        'time': '#SBATCH --time=08:00:00 \n',
+    },
     'recipe_bock20jgr_fig_6-7': {
         'partition': '#SBATCH --partition=shared \n',
         'time': '#SBATCH --time=48:00:00 \n',
@@ -40,28 +45,116 @@ SPECIAL_RECIPES = {
         'time': '#SBATCH --time=48:00:00 \n',
         'memory': '#SBATCH --mem=50000 \n',
     },
-    'recipe_schlund20esd': {
+    'recipe_check_obs': {
         'partition': '#SBATCH --partition=compute \n',
-        'time': '#SBATCH --time=08:00:00 \n',
         'memory': '#SBATCH --constraint=512G \n',
+    },
+    'recipe_climate_change_hotspot': {
+        'partition': '#SBATCH --partition=compute \n',
     },
     'recipe_collins13ipcc': {
         'partition': '#SBATCH --partition=compute \n',
         'time': '#SBATCH --time=08:00:00 \n',
         'memory': '#SBATCH --constraint=512G \n',
     },
+    'recipe_eady_growth_rate': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_ecs': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_ecs_constraints': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_extreme_index': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_eyring06jgr': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_eyring13jgr_12': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_flato13ipcc_figures_938_941_cmip6': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_ipccwg1ar6ch3_atmosphere': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_ipccwg1ar6ch3_fig_3_9': {
+        'partition': '#SBATCH --partition=shared \n',
+        'time': '#SBATCH --time=15:00:00 \n',
+        'memory': '#SBATCH --mem=150000 \n',
+    },
+    'recipe_ipccwg1ar6ch3_fig_3_19': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_ipccwg1ar6ch3_fig_3_42_a': {
+        'partition': '#SBATCH --partition=compute \n',
+        'time': '#SBATCH --time=08:00:00 \n',
+        'memory': '#SBATCH --constraint=512G \n',
+    },
+    'recipe_ipccwg1ar6ch3_fig_3_42_b': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_ipccwg1ar6ch3_fig_3_43': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_lauer22jclim_fig3-4_zonal': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_lauer22jclim_fig5_lifrac': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_meehl20sciadv': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_mpqb_xch4': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_perfmetrics_CMIP5': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_perfmetrics_CMIP5_4cds': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_perfmetrics_land_CMIP5': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_russell18jgr': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_schlund20esd': {
+        'partition': '#SBATCH --partition=compute \n',
+        'time': '#SBATCH --time=08:00:00 \n',
+        'memory': '#SBATCH --constraint=512G \n',
+    },
+    'recipe_schlund20jgr_gpp_abs_rcp85': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_schlund20jgr_gpp_change_1pct': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_schlund20jgr_gpp_change_rcp85': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
     'recipe_smpi': {
-        'partition': '#SBATCH --partition=interactive \n',
-        'time': '#SBATCH --time=04:00:00 \n',
-        'memory': '#SBATCH --ntasks=8 \n',
+        'partition': '#SBATCH --partition=compute \n',
     },
     'recipe_smpi_4cds': {
-        'partition': '#SBATCH --partition=interactive \n',
-        'time': '#SBATCH --time=04:00:00 \n',
-        'memory': '#SBATCH --ntasks=8 \n',
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_tebaldi21esd': {
+        'partition': '#SBATCH --partition=compute \n',
+        'time': '#SBATCH --time=08:00:00 \n',
+    },
+    'recipe_wenzel16jclim': {
+        'partition': '#SBATCH --partition=compute \n',
+    },
+    'recipe_wenzel16nat': {
+        'partition': '#SBATCH --partition=compute \n',
     },
 }
-
 
 def generate_submit():
     """Generate and submit scripts."""

--- a/esmvaltool/utils/batch-jobs/generate.py
+++ b/esmvaltool/utils/batch-jobs/generate.py
@@ -5,14 +5,29 @@ from pathlib import Path
 
 import esmvaltool
 
+# Name of the conda environment in which esmvaltool is installed
 env = 'coretool26rc4'
+# Mail notifications when a submitted job fails or finishes
 mail = False
+# Name of the conda environment in which esmvaltool is installed
 submit = False
+# Name of the DKRZ account in which the job will be billed
 account = ''  # Select a compute project to be billed
+# Name of the directory in which the job outputs files) are saved.
+# The outputs will be saved in /home/user/<outputs>
 outputs = 'output_rc4'
+# Default Levante computing partition used
 partition = 'compute'
+# Default amount of memory used
+memory = '64G'
+# Default walltime
+time = '04:00:00'
+# Full path to the mambaforge/etc/profile.d/conda.sh executable
 # Set the path to conda
 conda_path = 'PATH_TO/mambaforge/etc/profile.d/conda.sh'
+# Full path to config_file
+# If none, ~/.esmvaltool/config-user.yml is used
+config_file = ''
 
 SPECIAL_RECIPES = {
     'recipe_bock20jgr_fig_6-7': {

--- a/esmvaltool/utils/batch-jobs/generate.py
+++ b/esmvaltool/utils/batch-jobs/generate.py
@@ -1,4 +1,27 @@
-"""Generate SLURM run scripts to run recipes."""
+"""Generate SLURM run scripts to run every recipe.
+
+To use this script, follow these steps:
+1) Edit the following parameters:
+- env
+- mail
+- submit. Try the script with false before running the jobs.
+- account
+- conda_path
+2) If needed, edit optional parameters:
+- outputs
+- config_file
+3) SLURM settings
+This script is configured to optimize the computing
+footpring of the recipe testing. It is not necessary to edit
+SLURM related parameters.
+4) If new memory intensive recipes have been merged since
+the last release (e.g. IPCC recipes), you may to add them
+to `SPECIAL_RECIPES` and/or to `ONE_TASK_RECIPES`
+5) Check the generation of the batch scripts with 
+`submit = False`. Once the batch scripts are correct, change
+to `submit = True` and rerun the script to submit all jobs
+to the SLURM scheduler.
+"""
 import os
 import subprocess
 from pathlib import Path

--- a/esmvaltool/utils/batch-jobs/generate.py
+++ b/esmvaltool/utils/batch-jobs/generate.py
@@ -17,7 +17,7 @@ account = ''  # Select a compute project to be billed
 # The outputs will be saved in /home/user/<outputs>
 outputs = 'output_rc4'
 # Default Levante computing partition used
-partition = 'compute'
+partition = 'interactive'
 # Default amount of memory used
 memory = '64G'
 # Default walltime
@@ -38,12 +38,12 @@ SPECIAL_RECIPES = {
     'recipe_bock20jgr_fig_6-7': {
         'partition': '#SBATCH --partition=shared \n',
         'time': '#SBATCH --time=48:00:00 \n',
-        'memory': '#SBATCH --mem=50000 \n',
+        'memory': '#SBATCH --mem=50G \n',
     },
     'recipe_bock20jgr_fig_8-10': {
         'partition': '#SBATCH --partition=shared \n',
         'time': '#SBATCH --time=48:00:00 \n',
-        'memory': '#SBATCH --mem=50000 \n',
+        'memory': '#SBATCH --mem=50G \n',
     },
     'recipe_check_obs': {
         'partition': '#SBATCH --partition=compute \n',
@@ -84,7 +84,7 @@ SPECIAL_RECIPES = {
     'recipe_ipccwg1ar6ch3_fig_3_9': {
         'partition': '#SBATCH --partition=shared \n',
         'time': '#SBATCH --time=15:00:00 \n',
-        'memory': '#SBATCH --mem=150000 \n',
+        'memory': '#SBATCH --mem=150G \n',
     },
     'recipe_ipccwg1ar6ch3_fig_3_19': {
         'partition': '#SBATCH --partition=compute \n',
@@ -204,22 +204,30 @@ def generate_submit():
             if not SPECIAL_RECIPES.get(recipe.stem, None):
                 # continue
                 file.write(f'#SBATCH --partition={partition}\n')
-                file.write('#SBATCH --time={time}\n')
+                file.write(f'#SBATCH --time={time}\n')
                 file.write(f'#SBATCH --mem={memory}\n')
             else:
                 file.write(SPECIAL_RECIPES[recipe.stem]['partition'])
+                # Time requirements
                 # Special time requirements
                 if 'time' in SPECIAL_RECIPES[recipe.stem]:
                     file.write(SPECIAL_RECIPES[recipe.stem]['time'])
                 # Default
                 else:
                     file.write(f'#SBATCH --time={time}\n')
-                # Special memory requirements
-                if 'memory' in SPECIAL_RECIPES[recipe.stem]:
-                    file.write(SPECIAL_RECIPES[recipe.stem]['memory'])
-                # Default (only needed for non-compute partitions)
+                # Memory requirements
+                # Full node memory (compute partition)
+                if 'compute' in SPECIAL_RECIPES[recipe.stem]['partition']:
+                    file.write(f'#SBATCH --mem=0\n')
+                    if 'memory' in SPECIAL_RECIPES[recipe.stem]:
+                        file.write(SPECIAL_RECIPES[recipe.stem]['memory'])
+                # Shared nodes (other partitions)
                 else:
-                    if 'compute' not in SPECIAL_RECIPES[recipe.stem]['partition']:
+                    # Special memory requirements
+                    if 'memory' in SPECIAL_RECIPES[recipe.stem]:
+                        file.write(SPECIAL_RECIPES[recipe.stem]['memory'])
+                    # Default
+                    else:
                         file.write(f'#SBATCH --mem={memory}\n')
             if mail:
                 file.write('#SBATCH --mail-type=FAIL,END \n')


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description
Last PR to streamline the release process as much as possible. The idea is to allow the release manager to generate batch scripts for all 150 recipes of `v2.8.0` and run them via SLURM on DKRZ/Levante in **one command**: `python ~/ESMValTool/esmvaltool/utils/batch-jobs/generate.py`. With this updated script, the RM will not need to adjust SLURM runtime parameters and numbers of parallel tasks for special recipes. All is taken care by the script. The only task would be to update this script if recipes with special computing requirements were merged into `main` after `v2.8.0`.

### Assumed
- Access to DKRZ Levante and a compute project
- Conda environment with ESMValTool
- No access to non-public files needed
- No special permissions on Levante required

### Default SLURM parameters
- partition: interactive
- wall time: 4hours
- RAM: 64 GB
- max_parallel_tasks=8

Pros: 4 recipes can be run on the same node in parallel. This uses 4 times less resources than `compute` and allows to run **all recipes for about 120 node-hours**
Cons: much less interactive nodes than compute, so longer waiting times. **Takes about 12 hours to get all recipe done**.

### Special recipes:
- those who need to be run on full compute nodes, and sometimes on fat nodes (`--constraint=512G`). In these cases `--mem=0` is added to runscripts
- longer runtimes
- those who can't run with `max_parallel_tasks=8` will use `max_parallel_tasks=1` instead

### Note

It would certainly be possible to refine this approach by defining more categories (very fast recipes, fast ones, ...). But that becomes too complicated to do manually. The goal here is only to run all recipes in one go, using reasonable amounts of computing resources. I've used milestone 2.8 but I'm fine delaying it to the next milestone if needed. Docs are missing.

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

- Link to documentation:
  - https://esmvaltool--3130.org.readthedocs.build/en/3130/community/release_strategy/detailed_release_procedure.html
  - https://esmvaltool--3130.org.readthedocs.build/en/3130/utils.html#using-the-scripts-in-utils-batch-jobs

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [ ] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful
***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
