### PR TITLE
Updated figure settings to account for newer matplotlib version.

### DIFF
--- a/esmvaltool/diag_scripts/cmug_h2o/diag_tropopause.py
+++ b/esmvaltool/diag_scripts/cmug_h2o/diag_tropopause.py
@@ -217,6 +217,10 @@ def plot_tp_map(cfg, mean_cube, titlestr, variable, listdata):
                               _get_provenance_record(listdata,
                                                      titlestr + variable,
                                                      ['other'], ['global']))
+        provenance_logger.log(get_plot_filename(figname, cfg),
+                              _get_provenance_record(listdata,
+                                                     titlestr + variable,
+                                                     ['other'], ['global']))
 
 
 def main(cfg):

--- a/esmvaltool/diag_scripts/cmug_h2o/diag_tropopause.py
+++ b/esmvaltool/diag_scripts/cmug_h2o/diag_tropopause.py
@@ -144,7 +144,7 @@ def find_min(data, data_min, axis):
 def plot_tp_map(cfg, mean_cube, titlestr, variable, listdata):
     """Plot contour map."""
     # create figure and axes instances
-    
+
     subplot_kw = {'projection': cart.PlateCarree(central_longitude=0.0)}
     fig, axx = plt.subplots(figsize=(7, 5), subplot_kw=subplot_kw)
     axx.set_extent([-180, 180, -90, 90], cart.PlateCarree())

--- a/esmvaltool/diag_scripts/cmug_h2o/diag_tropopause.py
+++ b/esmvaltool/diag_scripts/cmug_h2o/diag_tropopause.py
@@ -144,8 +144,9 @@ def find_min(data, data_min, axis):
 def plot_tp_map(cfg, mean_cube, titlestr, variable, listdata):
     """Plot contour map."""
     # create figure and axes instances
-    fig, axx = plt.subplots(figsize=(7, 5))
-    axx = plt.axes(projection=cart.PlateCarree())
+    
+    subplot_kw = {'projection': cart.PlateCarree(central_longitude=0.0)}
+    fig, axx = plt.subplots(figsize=(7, 5), subplot_kw=subplot_kw)
     axx.set_extent([-180, 180, -90, 90], cart.PlateCarree())
 
     data_c, lon_c = add_cyclic_point(mean_cube.data,

--- a/esmvaltool/diag_scripts/cmug_h2o/diag_tropopause_zonalmean.py
+++ b/esmvaltool/diag_scripts/cmug_h2o/diag_tropopause_zonalmean.py
@@ -284,6 +284,8 @@ def plot_zonal_mean(cfg, mean_cube, dataname, titlestr, variable):
                 pformat(provenance_record))
     with ProvenanceLogger(cfg) as provenance_logger:
         provenance_logger.log(diagnostic_file, provenance_record)
+        provenance_logger.log(get_plot_filename(figname, cfg),
+                              provenance_record)
 
 
 def plot_zonal_timedev(cfg, mean_cube, dataname, titlestr, variable):
@@ -340,6 +342,8 @@ def plot_zonal_timedev(cfg, mean_cube, dataname, titlestr, variable):
                 pformat(provenance_record))
     with ProvenanceLogger(cfg) as provenance_logger:
         provenance_logger.log(diagnostic_file, provenance_record)
+        provenance_logger.log(get_plot_filename(figname, cfg),
+                              provenance_record)
 
 
 def plot_profiles(cfg, profiles, available_vars_min_tas, available_datasets):
@@ -400,6 +404,8 @@ def plot_profiles(cfg, profiles, available_vars_min_tas, available_datasets):
                     pformat(provenance_record))
         with ProvenanceLogger(cfg) as provenance_logger:
             provenance_logger.log(diagnostic_file, provenance_record)
+            provenance_logger.log(get_plot_filename(figname, cfg),
+                                  provenance_record)
 
 
 def main(cfg):

--- a/esmvaltool/diag_scripts/deangelis15nat/deangelisf2ext.py
+++ b/esmvaltool/diag_scripts/deangelis15nat/deangelisf2ext.py
@@ -366,6 +366,8 @@ def plot_slope_regression(cfg, data_dict):
                 pformat(provenance_record))
     with ProvenanceLogger(cfg) as provenance_logger:
         provenance_logger.log(diagnostic_file, provenance_record)
+        provenance_logger.log(get_plot_filename('fig2a', cfg),
+                              provenance_record)
 
     fig, axx = plt.subplots(figsize=(7, 7))
 
@@ -537,6 +539,8 @@ def plot_slope_regression_all(cfg, data_dict, available_vars):
                 pformat(provenance_record))
     with ProvenanceLogger(cfg) as provenance_logger:
         provenance_logger.log(diagnostic_file, provenance_record)
+        provenance_logger.log(get_plot_filename('exfig2a', cfg),
+                              provenance_record)
 
 
 def plot_rlnst_regression(cfg, dataset_name, data, variables, regs):
@@ -670,6 +674,7 @@ def plot_rlnst_regression(cfg, dataset_name, data, variables, regs):
                 pformat(provenance_record))
     with ProvenanceLogger(cfg) as provenance_logger:
         provenance_logger.log(diagnostic_file, provenance_record)
+        provenance_logger.log(filepath, provenance_record)
 
 
 def substract_and_reg_deangelis2(cfg, data, var):

--- a/esmvaltool/diag_scripts/deangelis15nat/deangelisf2ext.py
+++ b/esmvaltool/diag_scripts/deangelis15nat/deangelisf2ext.py
@@ -36,6 +36,7 @@ from pprint import pformat
 import iris
 import iris.coord_categorisation as cat
 import matplotlib.pyplot as plt
+import matplotlib.transforms as mpltrans
 import numpy as np
 from scipy import stats
 
@@ -609,8 +610,7 @@ def plot_rlnst_regression(cfg, dataset_name, data, variables, regs):
                       'label': yreg_dict["lab_hfss"]},
                      {'color': 'tab:gray',
                       'linestyle': '-'}],
-        save_kwargs={'bbox_inches': 'tight',
-                     'orientation': 'landscape'},
+        save_kwargs={'bbox_inches': mpltrans.Bbox.from_extents(0, -1, 6.5, 6)},
         axes_functions={'set_title': dataset_name,
                         'set_xlabel': '2−m temperature (tas)' +
                                       'global−mean annual anomaly (' +

--- a/esmvaltool/diag_scripts/deangelis15nat/deangelisf3f4.py
+++ b/esmvaltool/diag_scripts/deangelis15nat/deangelisf3f4.py
@@ -345,6 +345,8 @@ def plot_deangelis_fig3a(cfg, dataset_name, data, reg_prw, reg_obs):
                 pformat(provenance_record))
     with ProvenanceLogger(cfg) as provenance_logger:
         provenance_logger.log(diagnostic_file, provenance_record)
+        provenance_logger.log(get_plot_filename('fig3a_' + dataset_name, cfg),
+                              provenance_record)
 
 
 def plot_deangelis_fig4(cfg, data_model, mdrsnstdts, prw):
@@ -457,6 +459,8 @@ def plot_deangelis_fig4(cfg, data_model, mdrsnstdts, prw):
                 pformat(provenance_record))
     with ProvenanceLogger(cfg) as provenance_logger:
         provenance_logger.log(diagnostic_file, provenance_record)
+        provenance_logger.log(get_plot_filename('fig4', cfg),
+                              provenance_record)
 
 
 def plot_deangelis_fig3b4(cfg, data_model, reg_prw_obs):
@@ -574,6 +578,8 @@ def plot_deangelis_fig3b4(cfg, data_model, reg_prw_obs):
                 pformat(provenance_record))
     with ProvenanceLogger(cfg) as provenance_logger:
         provenance_logger.log(diagnostic_file, provenance_record)
+        provenance_logger.log(get_plot_filename('fig3b', cfg),
+                              provenance_record)
 
     # Fig 4
     plot_deangelis_fig4(cfg, data_model, mdrsnstdts, prw)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
Due to a new matplotlib version, the bounding box for one type of figures from recipe_deangelis15nat.yml, diagnositc deangelisf2ext.py did not match the plot size anymore (because of long axis labels). Therefore, an explicit bbox size needs to be included in deangelisf2ext.py.
For recipe_cmug_h2o.yml, diag_tropopause.py a wrong figure frame is drawn (already since V2.7, I overlooked it there) for a map plot and needs to be removed.
- Closes #3132 
- Link to documentation: (no changes in documentation)

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [x] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [x] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [x] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [x] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added

***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
