### PR TITLE
[condalock] try modernize lock creation script and repair lock generation

### DIFF
--- a/.github/workflows/create-condalock-file.yml
+++ b/.github/workflows/create-condalock-file.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           auto-update-conda: true
           activate-environment: esmvaltool-fromlock
-          python-version: "3.10.10"
+          python-version: "3.10"
           miniforge-version: "latest"
           miniforge-variant: Mambaforge
           use-mamba: true
@@ -42,7 +42,10 @@ jobs:
           python --version
       - name: Install conda-lock
         shell: bash -l {0}
-        run: mamba install -y conda-lock==1.4
+        run: mamba install -y conda-lock
+      - name: Check version of conda-lock
+        shell: bash -l {0}
+        run: conda-lock --version
       - name: Create conda lock file for linux-64
         shell: bash -l {0}
         run: conda-lock lock --platform linux-64 -f environment.yml --mamba --kind explicit

--- a/.github/workflows/create-condalock-file.yml
+++ b/.github/workflows/create-condalock-file.yml
@@ -4,10 +4,9 @@ on:
   # Trigger on push on main or other branch for testing
   # NOTE that push: main will create the file very often
   # and hence lots of automated PRs
-  push:
-    branches:
+  # push:
+  #   branches:
   #     - condalock-update
-      - fix_condalock_again
   schedule:
     - cron: '0 4 */10 * *'
 

--- a/.github/workflows/create-condalock-file.yml
+++ b/.github/workflows/create-condalock-file.yml
@@ -4,9 +4,10 @@ on:
   # Trigger on push on main or other branch for testing
   # NOTE that push: main will create the file very often
   # and hence lots of automated PRs
-  # push:
-  #   branches:
+  push:
+    branches:
   #     - condalock-update
+      - fix_condalock_again
   schedule:
     - cron: '0 4 */10 * *'
 
@@ -22,9 +23,10 @@ jobs:
         with:
           auto-update-conda: true
           activate-environment: esmvaltool-fromlock
-          python-version: "3.10"
-          miniconda-version: "latest"
-          channels: conda-forge
+          python-version: "3.10.10"
+          miniforge-version: "latest"
+          miniforge-variant: Mambaforge
+          use-mamba: true
       - name: Show conda config
         shell: bash -l {0}
         run: |
@@ -40,7 +42,7 @@ jobs:
           python --version
       - name: Install conda-lock
         shell: bash -l {0}
-        run: conda install -y conda-lock
+        run: mamba install -y conda-lock==1.4
       - name: Create conda lock file for linux-64
         shell: bash -l {0}
         run: conda-lock lock --platform linux-64 -f environment.yml --mamba --kind explicit
@@ -53,7 +55,7 @@ jobs:
       - shell: bash -l {0}
         run: conda create --name esmvaltool-fromlock --file conda-linux-64.lock
       - shell: bash -l {0}
-        run: conda install -y -c conda-forge pip
+        run: mamba install -y pip
       - shell: bash -l {0}
         run: which python
       - shell: bash -l {0}


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

Complete overhaul of the conda lock file generation: now we are using mamba and Mambaforge, and all stuff is getting installed, and env created with mamba. Day/night improvement in performance - lock file gets generated in less than 2 minutes, pip installs in seconds etc. [GA run](https://github.com/ESMValGroup/ESMValTool/actions/runs/4938212840/jobs/8827671472) fails correctly at the auto PR step - but before that it does what's written on the tin, and does it fast and nice :grin: 

- Closes #3147

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful
