### PR TITLE
Fixed usage of `work_dir` in some CMORizer scripts

### DIFF
--- a/esmvaltool/cmorizers/data/formatters/datasets/cds_satellite_albedo.py
+++ b/esmvaltool/cmorizers/data/formatters/datasets/cds_satellite_albedo.py
@@ -167,7 +167,7 @@ def cmorization(in_dir, out_dir, cfg, cfg_user, start_date, end_date):
     """Cmorization func call."""
     # run the cmorization
     # Pass on the workdir to the cfg dictionary
-    cfg['work_dir'] = cfg_user['work_dir']
+    cfg['work_dir'] = cfg_user.work_dir
     # If it doesn't exist, create it
     if not os.path.isdir(cfg['work_dir']):
         logger.info("Creating working directory for regridding: %s",

--- a/esmvaltool/cmorizers/data/formatters/datasets/cds_satellite_lai_fapar.py
+++ b/esmvaltool/cmorizers/data/formatters/datasets/cds_satellite_lai_fapar.py
@@ -176,7 +176,7 @@ def cmorization(in_dir, out_dir, cfg, cfg_user, start_date, end_date):
     """Cmorization func call."""
     # run the cmorization
     # Pass on the workdir to the cfg dictionary
-    cfg['work_dir'] = cfg_user['work_dir']
+    cfg['work_dir'] = cfg_user.work_dir
     # If it doesn't exist, create it
     if not os.path.isdir(cfg['work_dir']):
         logger.info("Creating working directory for regridding: %s",

--- a/esmvaltool/cmorizers/data/formatters/datasets/cds_uerra.py
+++ b/esmvaltool/cmorizers/data/formatters/datasets/cds_uerra.py
@@ -253,7 +253,7 @@ def cmorization(in_dir, out_dir, cfg, cfg_user, start_date, end_date):
     """Cmorization func call."""
     # run the cmorization
     # Pass on the workdir to the cfg dictionary
-    cfg['work_dir'] = cfg_user['work_dir']
+    cfg['work_dir'] = cfg_user.work_dir
     # If it doesn't exist, create it
     if not os.path.isdir(cfg['work_dir']):
         logger.info("Creating working directory for "

--- a/esmvaltool/cmorizers/data/formatters/datasets/grace.py
+++ b/esmvaltool/cmorizers/data/formatters/datasets/grace.py
@@ -159,7 +159,7 @@ def _cmorize_dataset(in_file, var, cfg, out_dir):
 
 def cmorization(in_dir, out_dir, cfg, cfg_user, start_date, end_date):
     """Cmorization func call."""
-    cfg['work_dir'] = cfg_user['work_dir']
+    cfg['work_dir'] = cfg_user.work_dir
     # Pass on some parameters to cfg file
     cfg['rawobsdir'] = cfg_user['rootpath']['RAWOBS'][0]
     cfg['in_dir'] = in_dir


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description
This PR updates the usage of `work_dir` due to changes in the Core config so that these CMORizers can be run again with the latest Core. Affected datasets are: `CDS-SATELLITE-ALBEDO`, `CDS-SATELLITE-LAI-FAPAR`, `CDS-UERRA`, and `GRACE`.
<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
- Closes #3191 
- Link to documentation: N/A

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated data reformatting script](https://docs.esmvaltool.org/en/latest/develop/dataset.html)

- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/dataset.html#dataset-documentation) is available
- [x] [🛠][1] The dataset has been [added to the CMOR check recipe](https://docs.esmvaltool.org/en/latest/community/dataset.html#testing)
- [x] [🧪][2] Numbers and units of the data look [physically meaningful](https://docs.esmvaltool.org/en/latest/community/dataset.html#scientific-sanity-check)

***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
