### PR TITLE
Normalize input units prior to NCL unit conversion

### DIFF
--- a/esmvaltool/diag_scripts/shared/scaling.ncl
+++ b/esmvaltool/diag_scripts/shared/scaling.ncl
@@ -12,6 +12,42 @@
 load "$diag_scripts/../interface_scripts/logging.ncl"
 
 ; #############################################################################
+undef("normalize_units")
+function normalize_units(units[1]:string)
+;
+; Arguments
+;    units: a string of units that will be normalized.
+;
+; Return value
+;    A string of normalized units.
+;
+; Description
+;    Normalize units, i.e., split units by ".", sort them, and return
+;    concantenated units (by " "). Example: "m-2.kg.s-1" -> "kg m-2 s-1".
+;
+; Modification history
+;    20230614-schlund_manuel: written.
+;
+local funcname, scriptname, split_units, concatenated_units
+begin
+
+  funcname = "normalize_units"
+  scriptname = "diag_scripts/shared/scaling.ncl"
+  enter_msg(scriptname, funcname)
+
+  ; Split units by "." and sort if necessary
+  split_units = str_split(units, ".")
+  if (dimsizes(split_units).gt.1) then
+    sqsort(split_units)
+  end if
+
+  ; Concatenate with seperator " "
+  concatenated_units = str_join(split_units, " ")
+
+  return(concatenated_units)
+end
+
+; #############################################################################
 undef("convert_units")
 function convert_units(var:numeric,
                        units_to[1]:string)
@@ -63,6 +99,9 @@ begin
               units_from + " to " + units_to)
     return(out)
   end if
+
+  ; Normalize source units
+  units_from = normalize_units(units_from)
 
   if (units_from.eq."1") then
     if (units_to.eq."g/kg") then


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

Normalize units (i.e., replace `"."` with `" "` and sort them) prior to unit conversion. This allows NCL to parse units like `m-2.kg.s-1` (which are normalized to `kg m-2 s-1`).

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
- Closes #3224

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [x] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [x] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [x] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [x] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added

***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
