### PR TITLE
Realize data for scalar cube in `recipe_carvalhais14nat` to avert issue from dask latest (2023.6.0)

### DIFF
--- a/esmvaltool/diag_scripts/land_carbon_cycle/diag_global_turnover.py
+++ b/esmvaltool/diag_scripts/land_carbon_cycle/diag_global_turnover.py
@@ -737,7 +737,12 @@ def main(diag_config):
         tau_global = ctotal_global / gpp_global
         tau_global.convert_units('yr')
 
-        global_tau_mod['global'][model_name] = float(tau_global.core_data())
+        # since dask=2023.3 there is an issue with converting the core_data()
+        # to float; I have not managed to pinpoint the issue neither in dask
+        # nor in iris, since minimal test cases are not reproducing it
+        # this is a scalar cube so no big mem issue by realizing the data
+        # global_tau_mod['global'][model_name] = float(tau_global.core_data())
+        global_tau_mod['global'][model_name] = float(tau_global.data)
 
         base_name_mod = (
             'global_{title}_{source_label}_'


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

Part of Release 2.9.0 https://github.com/ESMValGroup/ESMValTool/issues/3239

using the core_data() method introduces a strange issue from Dask (only 2023.3.0 or older behaves well); I unfortunately have not managed to reproduce the issue in a test case/minimal test example so instead am just realizing the data - there is no problem about it since that's a scalar cube with one single data point. Not nice but meh. The fix leads to the recipe still failing but this is explained in https://github.com/ESMValGroup/ESMValTool/issues/3239#issuecomment-1613173906

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [ ] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
