### PR TITLE
Fix ordering of models in perfmetrics

### DIFF
--- a/esmvaltool/diag_scripts/perfmetrics/collect.ncl
+++ b/esmvaltool/diag_scripts/perfmetrics/collect.ncl
@@ -351,9 +351,9 @@ begin
       end if
       if (n_proj .gt. 1) then
         id2 = ind(projectnames.eq.diag_script_info@project_order(1))
-        id2_mm = (/ind(data_all&models(id2) .eq. \
+        id2_mm = (/ind(data_temp&models(id2) .eq. \
                   diag_script_info@project_order(1) + "_mean"), \
-                  ind(data_all&models(id2) .eq. \
+                  ind(data_temp&models(id2) .eq. \
                   diag_script_info@project_order(1) + "_median") /)
         if (any(ismissing(id2_mm))) then
           id2_mm = -1
@@ -368,9 +368,9 @@ begin
         end if
         if (n_proj .gt. 2) then
           id3 = ind(projectnames.eq.diag_script_info@project_order(2))
-          id3_mm = (/ind(data_all&models(id3) .eq. \
+          id3_mm = (/ind(data_temp&models(id3) .eq. \
                     diag_script_info@project_order(2) + "_mean"), \
-                    ind(data_all&models(id3) .eq. \
+                    ind(data_temp&models(id3) .eq. \
                     diag_script_info@project_order(2) + "_median") /)
           if (any(ismissing(id3_mm))) then
             id3_mm = -1


### PR DESCRIPTION
## Description

This PR fixes the ordering of models in the perfmetrics. This bug arises (#3239) as the model order in the diagnostic was now different to the one in the recipe which was not in the past.

* * *

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [x] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [x] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [x] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [x] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added

