### PR TITLE
(tentatively) Pin scipy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - pin_scipy
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - pin_scipy
   schedule:
     - cron: '0 0 * * *'
 

--- a/environment.yml
+++ b/environment.yml
@@ -57,7 +57,7 @@ dependencies:
   - ruamel.yaml
   - scikit-image
   - scikit-learn
-  - scipy
+  - scipy >1.10  # avoid very old versions like 1.9.1
   - seaborn
   - seawater
   - shapely

--- a/environment_osx.yml
+++ b/environment_osx.yml
@@ -57,7 +57,7 @@ dependencies:
   - ruamel.yaml
   - scikit-image
   - scikit-learn
-  - scipy
+  - scipy >1.10  # avoid very old versions like 1.9.1
   - seaborn
   - seawater
   - shapely

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ REQUIREMENTS = {
         'ruamel.yaml',
         'scikit-image',
         'scikit-learn',
-        'scipy',
+        'scipy>1.10',  # avoid very old versions like 1.9.1
         # See the following issue for info on the iris pin below:
         # https://github.com/ESMValGroup/ESMValTool/issues/3239#issuecomment-1613298587
         'scitools-iris>=3.4.0',


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
- Closes #3276 

This is an attempt to bypass issues with package relations, specifically numpy and scipy, that lead to installing a one-year old scipy (1.9.1) when creating an env with python=3.9. This workaround is far from ideal but in light of the impending release 2.9.0 we don't really have much time to muck around towards better solutions. Pinning solves the problem and where 1.9.1 was picked up now 1.11.1 is in (latest).

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful
