### PR TITLE
update `mamba` version in readthedocs configuration docs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
   jobs:
     pre_create_environment:
       - echo "Force modern conda, Python and mamba"
-      - conda run -n ${CONDA_DEFAULT_ENV} conda update -n ${CONDA_DEFAULT_ENV} conda
+      - conda update --yes --quiet --name=base --channel=defaults conda
       - conda run -n ${CONDA_DEFAULT_ENV} conda install --yes -c conda-forge "python=3.11"
       - conda run -n ${CONDA_DEFAULT_ENV} conda install --yes -c conda-forge "mamba>=1.4.8"
     post_create_environment:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,10 +13,7 @@ build:
     python: "mambaforge-4.10"
   jobs:
     pre_create_environment:
-      # solution that should work, but it doesn't (base conda too old)
-      # - conda run -n base mamba install --yes --channel=conda-forge "mamba>=1.4.8"
-      # - conda run -n base mamba --version
-      # solution from RTD docs example
+      # update mamba
       - mamba update --yes --quiet --name=base mamba
       - mamba --version
     post_create_environment:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ build:
   os: ubuntu-22.04
   tools:
     # this is very old; needs immediate update
-    python: "miniconda3-4.7"
+    python: "mambaforge-4.10"
   jobs:
     pre_create_environment:
       - echo "Force modern mamba"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,15 +10,15 @@ build:
   os: ubuntu-22.04
   tools:
     # this is very old; needs immediate update
-    python: "miniconda3-4.7"  # "mambaforge-4.10"
+    python: "mambaforge-4.10"
   jobs:
     pre_create_environment:
       # solution that should work, but it doesn't (base conda too old)
       # - conda run -n base mamba install --yes --channel=conda-forge "mamba>=1.4.8"
       # - conda run -n base mamba --version
       # solution from RTD docs example
-      - conda update --yes --quiet --name=base --channel=defaults conda
-      - conda --version
+      - mamba update --yes --quiet --name=base mamba
+      - mamba --version
     post_create_environment:
       # use conda run executable wrapper to have all env variables
       - conda run -n ${CONDA_DEFAULT_ENV} mamba --version

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,8 @@ build:
   jobs:
     pre_create_environment:
       - echo "Force conda update and modern mamba"
-      - conda update --yes --quiet --name=base --channel=conda-forge conda && conda install -c conda-forge "mamba>=1.4.8"
+      - conda update --yes --quiet --name=base --channel=conda-forge conda
+      - conda run -n base conda install -c conda-forge "mamba>=1.4.8"
     post_create_environment:
       # use conda run executable wrapper to have all env variables
       - conda run -n ${CONDA_DEFAULT_ENV} pip install . --no-deps

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
   jobs:
     pre_create_environment:
       - echo "Force modern mamba"
-      - conda install --yes -c conda-forge "mamba>=1.4.8"
+      - conda run -n ${CONDA_DEFAULT_ENV} conda install --yes -c conda-forge "mamba>=1.4.8"
     post_create_environment:
       # use conda run executable wrapper to have all env variables
       - conda run -n ${CONDA_DEFAULT_ENV} pip install . --no-deps

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,11 +9,14 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
+    # this is very old! July 2023 version: 23.1.0-4
     python: "mambaforge-4.10"
   jobs:
+    pre_create_environment:
+      - echo "Force modern mamba"
+      - conda install -c conda-forge "mamba>=1.4.8"
     post_create_environment:
       # use conda run executable wrapper to have all env variables
-      - conda install -c conda-forge "mamba>=1.4.8"
       - conda run -n ${CONDA_DEFAULT_ENV} pip install . --no-deps
 
 # Declare the requirements required to build your docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,10 +9,11 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "mambaforge-23.1.0-4"
+    python: "mambaforge-4.10"
   jobs:
     post_create_environment:
       # use conda run executable wrapper to have all env variables
+      - conda install -c conda-forge "mamba>=1.4.8"
       - conda run -n ${CONDA_DEFAULT_ENV} pip install . --no-deps
 
 # Declare the requirements required to build your docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
   jobs:
     pre_create_environment:
       - echo "Force modern mamba"
-      - conda install -c conda-forge "mamba>=1.4.8"
+      - conda run -n ${CONDA_DEFAULT_ENV} conda install -c conda-forge "mamba>=1.4.8"
     post_create_environment:
       # use conda run executable wrapper to have all env variables
       - conda run -n ${CONDA_DEFAULT_ENV} pip install . --no-deps

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,9 +13,8 @@ build:
     python: "miniconda3-4.7"
   jobs:
     pre_create_environment:
-      - echo "Force conda update and modern mamba"
-      - conda update --yes --quiet --name=base --channel=conda-forge conda
-      - conda run -n base conda install -c conda-forge "mamba>=1.4.8"
+      - echo "Force modern mamba"
+      - conda install --yes -c conda-forge "mamba>=1.4.8"
     post_create_environment:
       # use conda run executable wrapper to have all env variables
       - conda run -n ${CONDA_DEFAULT_ENV} pip install . --no-deps

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,8 +14,7 @@ build:
   jobs:
     pre_create_environment:
       - echo "Force conda update and modern mamba"
-      - conda update --yes --quiet --name=base --channel=conda-forge conda
-      - conda install -c conda-forge "mamba>=1.4.8"
+      - conda update --yes --quiet --name=base --channel=conda-forge conda && conda install -c conda-forge "mamba>=1.4.8"
     post_create_environment:
       # use conda run executable wrapper to have all env variables
       - conda run -n ${CONDA_DEFAULT_ENV} pip install . --no-deps

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ build:
   os: ubuntu-22.04
   tools:
     # this is very old; needs immediate update
-    python: "mambaforge-4.10"
+    python: "miniconda3-4.7"
   jobs:
     pre_create_environment:
       - echo "Force modern mamba"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,9 +14,11 @@ build:
   jobs:
     pre_create_environment:
       - echo "Force modern conda, Python and mamba"
-      - conda run -n base mamba install --yes --channel=conda-forge "mamba>=1.4"
+      - conda run -n base mamba install --yes --channel=conda-forge "mamba>=1.4.8"
+      - conda run -n base mamba --version
     post_create_environment:
       # use conda run executable wrapper to have all env variables
+      - conda run -n ${CONDA_DEFAULT_ENV} mamba --version
       - conda run -n ${CONDA_DEFAULT_ENV} pip install . --no-deps
 
 # Declare the requirements required to build your docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
   jobs:
     pre_create_environment:
       - echo "Force modern conda, Python and mamba"
-      - conda run -n ${CONDA_DEFAULT_ENV} mamba install --yes --channel=conda-forge "mamba>=1.4"
+      - conda run -n base mamba install --yes --channel=conda-forge "mamba>=1.4"
     post_create_environment:
       # use conda run executable wrapper to have all env variables
       - conda run -n ${CONDA_DEFAULT_ENV} pip install . --no-deps

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,12 +10,15 @@ build:
   os: ubuntu-22.04
   tools:
     # this is very old; needs immediate update
-    python: "mambaforge-4.10"
+    python: "miniconda3-4.7"  # "mambaforge-4.10"
   jobs:
     pre_create_environment:
-      - echo "Force modern conda, Python and mamba"
-      - conda run -n base mamba install --yes --channel=conda-forge "mamba>=1.4.8"
-      - conda run -n base mamba --version
+      # solution that should work, but it doesn't (base conda too old)
+      # - conda run -n base mamba install --yes --channel=conda-forge "mamba>=1.4.8"
+      # - conda run -n base mamba --version
+      # solution from RTD docs example
+      - conda update --yes --quiet --name=base --channel=defaults conda
+      - conda --version
     post_create_environment:
       # use conda run executable wrapper to have all env variables
       - conda run -n ${CONDA_DEFAULT_ENV} mamba --version

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
   jobs:
     pre_create_environment:
       - echo "Force modern conda, Python and mamba"
-      - mamba install --yes --channel=conda-forge "mamba>=1.4"
+      - conda run -n ${CONDA_DEFAULT_ENV} mamba install --yes --channel=conda-forge "mamba>=1.4"
     post_create_environment:
       # use conda run executable wrapper to have all env variables
       - conda run -n ${CONDA_DEFAULT_ENV} pip install . --no-deps

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,9 @@ build:
     python: "miniconda3-4.7"
   jobs:
     pre_create_environment:
-      - echo "Force modern mamba"
+      - echo "Force modern conda, Python and mamba"
+      - conda run -n ${CONDA_DEFAULT_ENV} conda update -n ${CONDA_DEFAULT_ENV} conda
+      - conda run -n ${CONDA_DEFAULT_ENV} conda install --yes -c conda-forge "python=3.11"
       - conda run -n ${CONDA_DEFAULT_ENV} conda install --yes -c conda-forge "mamba>=1.4.8"
     post_create_environment:
       # use conda run executable wrapper to have all env variables

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "mambaforge-4.10"
+    python: "mambaforge-23.1.0-4"
   jobs:
     post_create_environment:
       # use conda run executable wrapper to have all env variables

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,8 +9,8 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    # this is very old; needs immediate update
-    python: "mambaforge-4.10"
+    # updated in https://github.com/readthedocs/readthedocs.org/pull/10572
+    python: "mambaforge-22.9"
   jobs:
     pre_create_environment:
       # update mamba

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,12 +10,11 @@ build:
   os: ubuntu-22.04
   tools:
     # this is very old; needs immediate update
-    python: "miniconda3-4.7"
+    python: "mambaforge-4.10"
   jobs:
     pre_create_environment:
       - echo "Force modern conda, Python and mamba"
-      - conda update --yes --quiet --name=base --channel=defaults conda
-      - conda update --yes --quiet --name=base --channel=conda-forge "mamba>=1.4"
+      - mamba install --yes --channel=conda-forge "mamba>=1.4"
     post_create_environment:
       # use conda run executable wrapper to have all env variables
       - conda run -n ${CONDA_DEFAULT_ENV} pip install . --no-deps

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,11 +9,11 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    # updated in https://github.com/readthedocs/readthedocs.org/pull/10572
+    # updated and deployed from Aug 1, 2023
     python: "mambaforge-22.9"
   jobs:
     pre_create_environment:
-      # update mamba
+      # update mamba just in case
       - mamba update --yes --quiet --name=base mamba
       - mamba --version
     post_create_environment:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,8 +15,7 @@ build:
     pre_create_environment:
       - echo "Force modern conda, Python and mamba"
       - conda update --yes --quiet --name=base --channel=defaults conda
-      - conda run -n ${CONDA_DEFAULT_ENV} conda install --yes -c conda-forge "python=3.11"
-      - conda run -n ${CONDA_DEFAULT_ENV} conda install --yes -c conda-forge "mamba>=1.4.8"
+      - conda update --yes --quiet --name=base --channel=conda-forge "mamba>=1.4"
     post_create_environment:
       # use conda run executable wrapper to have all env variables
       - conda run -n ${CONDA_DEFAULT_ENV} pip install . --no-deps

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,12 +9,13 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    # this is very old! July 2023 version: 23.1.0-4
-    python: "mambaforge-4.10"
+    # this is very old; needs immediate update
+    python: "miniconda3-4.7"
   jobs:
     pre_create_environment:
-      - echo "Force modern mamba"
-      - conda run -n ${CONDA_DEFAULT_ENV} conda install -c conda-forge "mamba>=1.4.8"
+      - echo "Force conda update and modern mamba"
+      - conda update --yes --quiet --name=base --channel=conda-forge conda
+      - conda install -c conda-forge "mamba>=1.4.8"
     post_create_environment:
       # use conda run executable wrapper to have all env variables
       - conda run -n ${CONDA_DEFAULT_ENV} pip install . --no-deps


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->


Because tis ye olde and the builde tis slowle

Closes #3311 

As an extra to this, the RTD dev and meself had a conversation in https://github.com/readthedocs/readthedocs.org/issues/10564 and it looks like they're updating their packaged mambaforge in https://github.com/readthedocs/readthedocs.org/pull/10572 - but us having a mamba update right before env gets created is not going to hurt, if at all, will do good even after RTD updated their mambaforge. Great to talk to @humitos as usual - very nice folk at RTD GH :beer: 

Performance-wise - we are now building docs start to finish in about the same time as before (possibly even quicker, but the mamba update is always good to have, and for some reason we can't shake the 500 odd seconds it takes to build the env - the bulk of all the time spent for an RTD build)

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->


## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful
