### PR TITLE
[Github Actions] Compress all bash shell setters into one default option per workflow

### DIFF
--- a/.github/workflows/install-from-conda.yml
+++ b/.github/workflows/install-from-conda.yml
@@ -9,6 +9,11 @@ on:
   schedule:
     - cron: '0 4 * * *'
 
+# Required shell entrypoint to have properly configured bash shell
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   linux:
     runs-on: "ubuntu-latest"
@@ -24,20 +29,16 @@ jobs:
           miniforge-version: "latest"
           miniforge-variant: Mambaforge
           use-mamba: true
-      - shell: bash -l {0}
-        run: mkdir -p conda_install_linux_artifacts_python_${{ matrix.python-version }}
+      - run: mkdir -p conda_install_linux_artifacts_python_${{ matrix.python-version }}
       - name: Record versions
-        shell: bash -l {0}
         run: |
           mamba --version 2>&1 | tee conda_install_linux_artifacts_python_${{ matrix.python-version }}/conda_version.txt
           which conda 2>&1 | tee conda_install_linux_artifacts_python_${{ matrix.python-version }}/conda_path.txt
           which mamba 2>&1 | tee -a conda_install_linux_artifacts_python_${{ matrix.python-version }}/conda_path.txt
           python -V 2>&1 | tee conda_install_linux_artifacts_python_${{ matrix.python-version }}/python_version.txt
       - name: Install ESMValTool
-        shell: bash -l {0}
         run: mamba install esmvaltool 2>&1 | tee conda_install_linux_artifacts_python_${{ matrix.python-version }}/install.txt
       - name: Verify installation
-        shell: bash -l {0}
         run: |
           esmvaltool --help
           esmvaltool version 2>&1 | tee conda_install_linux_artifacts_python_${{ matrix.python-version }}/version.txt
@@ -65,31 +66,20 @@ jobs:
 #          python-version: ${{ matrix.python-version }}
 #          miniconda-version: "latest"
 #          channels: conda-forge
-#      - shell: bash -l {0}
-#        run: mkdir -p conda_install_osx_artifacts_python_${{ matrix.python-version }}
-#      - shell: bash -l {0}
-#        run: conda --version 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/conda_version.txt
-#      - shell: bash -l {0}
-#        run: which conda 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/conda_path.txt
-#      - shell: bash -l {0}
-#        run: python -V 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/python_version.txt
+#      - run: mkdir -p conda_install_osx_artifacts_python_${{ matrix.python-version }}
+#      - run: conda --version 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/conda_version.txt
+#      - run: which conda 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/conda_path.txt
+#      - run: python -V 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/python_version.txt
 #      # ncurses needs to be from conda-forge and not main channel
 #      # for now it's turned off since we're not testing R/Julia installs
-#      # - shell: bash -l {0}
-#      #   run: conda uninstall -y ncurses
-#      # - shell: bash -l {0}
-#      #   run: conda list ncurses
-#      # - shell: bash -l {0}
-#      #   run: conda install -y conda-forge::ncurses
-#      # - shell: bash -l {0}
-#      #   run: conda list ncurses
-#      - shell: bash -l {0}
-#        #run: conda install esmvaltool --no-update-deps 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/install.txt
-#        run: conda install esmvaltool-python esmvaltool-ncl 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/install.txt
-#      - shell: bash -l {0}
-#        run: esmvaltool --help
-#      - shell: bash -l {0}
-#        run: esmvaltool version 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/version.txt
+#      # - run: conda uninstall -y ncurses
+#      # - run: conda list ncurses
+#      # - run: conda install -y conda-forge::ncurses
+#      # - run: conda list ncurses
+#      - run: conda install esmvaltool --no-update-deps 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/install.txt
+#      - run: conda install esmvaltool-python esmvaltool-ncl 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/install.txt
+#      - run: esmvaltool --help
+#      - run: esmvaltool version 2>&1 | tee conda_install_osx_artifacts_python_${{ matrix.python-version }}/version.txt
 #      - name: Upload artifacts
 #        if: ${{ always() }}  # upload artifacts even if fail
 #        uses: actions/upload-artifact@v2

--- a/.github/workflows/install-from-condalock-file.yml
+++ b/.github/workflows/install-from-condalock-file.yml
@@ -20,6 +20,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+# Required shell entrypoint to have properly configured bash shell
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   linux:
     runs-on: "ubuntu-latest"
@@ -38,68 +43,21 @@ jobs:
           python-version: ${{ matrix.python-version }}
           miniconda-version: "latest"
           channels: conda-forge
-      - shell: bash -l {0}
-        run: mkdir -p source_install_linux_artifacts_python_${{ matrix.python-version }}
-      - shell: bash -l {0}
-        run: conda --version 2>&1 | tee source_install_linux_artifacts_python_${{ matrix.python-version }}/conda_version.txt
-      - shell: bash -l {0}
-        run: which python
-      - shell: bash -l {0}
-        run: python -V 2>&1 | tee source_install_linux_artifacts_python_${{ matrix.python-version }}/python_version.txt
-      - shell: bash -l {0}
-        run: conda create --name esmvaltool-fromlock --file conda-linux-64.lock
-      - shell: bash -l {0}
-        run: which python
-      - shell: bash -l {0}
-        run: pip --version
-      - shell: bash -l {0}
-        run: pip install -e .[develop]
-      - shell: bash -l {0}
-        run: esmvaltool --help
-      - shell: bash -l {0}
-        run: esmvaltool version 2>&1 | tee source_install_linux_artifacts_python_${{ matrix.python-version }}/version.txt
-      - shell: bash -l {0}
-        run: flake8
-      - shell: bash -l {0}
-        run: pytest -n 2 -m "not installation"
+      - run: mkdir -p source_install_linux_artifacts_python_${{ matrix.python-version }}
+      - run: conda --version 2>&1 | tee source_install_linux_artifacts_python_${{ matrix.python-version }}/conda_version.txt
+      - run: which python
+      - run: python -V 2>&1 | tee source_install_linux_artifacts_python_${{ matrix.python-version }}/python_version.txt
+      - run: conda create --name esmvaltool-fromlock --file conda-linux-64.lock
+      - run: which python
+      - run: pip --version
+      - run: pip install -e .[develop]
+      - run: esmvaltool --help
+      - run: esmvaltool version 2>&1 | tee source_install_linux_artifacts_python_${{ matrix.python-version }}/version.txt
+      - run: flake8
+      - run: pytest -n 2 -m "not installation"
       - name: Upload artifacts
         if: ${{ always() }}  # upload artifacts even if fail
         uses: actions/upload-artifact@v2
         with:
           name: Source_Install_Linux_python_${{ matrix.python-version }}
           path: source_install_linux_artifacts_python_${{ matrix.python-version }}
-
-#  osx:
-#    runs-on: "macos-latest"
-#    strategy:
-#      matrix:
-#        python-version: ["3.9", "3.10", "3.11"]
-#      fail-fast: false
-#    name: OSX Python ${{ matrix.python-version }}
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: conda-incubator/setup-miniconda@v2
-#        with:
-#          activate-environment: esmvaltool
-#          environment-file: environment.yml
-#          python-version: ${{ matrix.python-version }}
-#          miniconda-version: "latest"
-#          channels: conda-forge
-#      - shell: bash -l {0}
-#        run: mkdir -p source_install_osx_artifacts_python_${{ matrix.python-version }}
-#      - shell: bash -l {0}
-#        run: conda --version 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/conda_version.txt
-#      - shell: bash -l {0}
-#        run: python -V 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/python_version.txt
-#      - shell: bash -l {0}
-#        run: pip install -e .[develop] 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/install.txt
-#      - shell: bash -l {0}
-#        run: esmvaltool --help
-#      - shell: bash -l {0}
-#        run: esmvaltool version 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/version.txt
-#      - name: Upload artifacts
-#        if: ${{ always() }}  # upload artifacts even if fail
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: Source_Install_OSX_python_${{ matrix.python-version }}
-#          path: source_install_osx_artifacts_python_${{ matrix.python-version }}

--- a/.github/workflows/install-from-source.yml
+++ b/.github/workflows/install-from-source.yml
@@ -9,6 +9,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+# Required shell entrypoint to have properly configured bash shell
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   linux:
     runs-on: "ubuntu-latest"
@@ -29,18 +34,14 @@ jobs:
           miniforge-version: "latest"
           miniforge-variant: Mambaforge
           use-mamba: true
-      - shell: bash -l {0}
-        run: mkdir -p source_install_linux_artifacts_python_${{ matrix.python-version }}
+      - run: mkdir -p source_install_linux_artifacts_python_${{ matrix.python-version }}
       - name: Record versions
-        shell: bash -l {0}
         run: |
           mamba --version 2>&1 | tee source_install_linux_artifacts_python_${{ matrix.python-version }}/conda_version.txt
           python -V 2>&1 | tee source_install_linux_artifacts_python_${{ matrix.python-version }}/python_version.txt
       - name: Install
-        shell: bash -l {0}
         run: pip install -e .[develop] 2>&1 | tee source_install_linux_artifacts_python_${{ matrix.python-version }}/install.txt
       - name: Verify installation
-        shell: bash -l {0}
         run: |
           esmvaltool --help
           esmvaltool version 2>&1 | tee source_install_linux_artifacts_python_${{ matrix.python-version }}/version.txt
@@ -70,18 +71,12 @@ jobs:
 #          python-version: ${{ matrix.python-version }}
 #          miniconda-version: "latest"
 #          channels: conda-forge
-#      - shell: bash -l {0}
-#        run: mkdir -p source_install_osx_artifacts_python_${{ matrix.python-version }}
-#      - shell: bash -l {0}
-#        run: conda --version 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/conda_version.txt
-#      - shell: bash -l {0}
-#        run: python -V 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/python_version.txt
-#      - shell: bash -l {0}
-#        run: pip install -e .[develop] 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/install.txt
-#      - shell: bash -l {0}
-#        run: esmvaltool --help
-#      - shell: bash -l {0}
-#        run: esmvaltool version 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/version.txt
+#      - run: mkdir -p source_install_osx_artifacts_python_${{ matrix.python-version }}
+#      - run: conda --version 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/conda_version.txt
+#      - run: python -V 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/python_version.txt
+#      - run: pip install -e .[develop] 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/install.txt
+#      - run: esmvaltool --help
+#      - run: esmvaltool version 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/version.txt
 #      - name: Upload artifacts
 #        if: ${{ always() }}  # upload artifacts even if fail
 #        uses: actions/upload-artifact@v2

--- a/.github/workflows/run-tests-monitor.yml
+++ b/.github/workflows/run-tests-monitor.yml
@@ -12,6 +12,11 @@ on:
   schedule:
     - cron: '0 0 * * *'  # nightly
 
+# Required shell entrypoint to have properly configured bash shell
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   linux:
     runs-on: "ubuntu-latest"
@@ -32,29 +37,22 @@ jobs:
           miniforge-version: "latest"
           miniforge-variant: Mambaforge
           use-mamba: true
-      - shell: bash -l {0}
-        run: mkdir -p test_linux_artifacts_python_${{ matrix.python-version }}
+      - run: mkdir -p test_linux_artifacts_python_${{ matrix.python-version }}
       - name: Record versions
-        shell: bash -l {0}
         run: |
           mamba --version 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/conda_version.txt
           python -V 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/python_version.txt
       - name: Install pytest-monitor
-        shell: bash -l {0}
         run: pip install pytest-monitor
       - name: Install ESMValTool
-        shell: bash -l {0}
         run: pip install -e .[develop] 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/install.txt
       - name: Install Julia dependencies
-        shell: bash -l {0}
         run: esmvaltool install Julia
       - name: Run tests
-        shell: bash -l {0}
         run: >
           pytest -n 2 -m "not installation" --db ../.pymon 2>&1
           | tee test_linux_artifacts_python_${{ matrix.python-version }}/test_report.txt
       - name: Parse monitor information
-        shell: bash -l {0}
         run: python tests/parse_pymon.py
       - name: Upload artifacts
         if: ${{ always() }}  # upload artifacts even if fail
@@ -84,28 +82,22 @@ jobs:
           use-mamba: true
       # - name: Install libomp with homebrew
       #   run: brew install libomp
-      - shell: bash -l {0}
-        run: mkdir -p test_osx_artifacts_python_${{ matrix.python-version }}
+      - run: mkdir -p test_osx_artifacts_python_${{ matrix.python-version }}
       - name: Record versions
-        shell: bash -l {0}
         run: |
           mamba --version 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/conda_version.txt
           python -V 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/python_version.txt
       - name: Install pytest-monitor
-        shell: bash -l {0}
         run: pip install pytest-monitor
       - name: Install ESMValTool
-        shell: bash -l {0}
         run: >
           pip install -e .[develop] 2>&1
           | tee test_osx_artifacts_python_${{ matrix.python-version }}/install.txt
       - name: Run tests
-        shell: bash -l {0}
         run: >
           pytest -n 2 -m "not installation" --db ../.pymon 2>&1
           | tee test_osx_artifacts_python_${{ matrix.python-version }}/test_report.txt
       - name: Parse monitor information
-        shell: bash -l {0}
         run: python tests/parse_pymon.py
       - name: Upload artifacts
         if: ${{ always() }}  # upload artifacts even if fail

--- a/.github/workflows/test-development.yml
+++ b/.github/workflows/test-development.yml
@@ -15,6 +15,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+# Required shell entrypoint to have properly configured bash shell
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   linux:
     runs-on: "ubuntu-latest"
@@ -35,31 +40,24 @@ jobs:
           miniforge-version: "latest"
           miniforge-variant: Mambaforge
           use-mamba: true
-      - shell: bash -l {0}
-        run: mkdir -p develop_test_linux_artifacts_python_${{ matrix.python-version }}
+      - run: mkdir -p develop_test_linux_artifacts_python_${{ matrix.python-version }}
       - name: Record versions
-        shell: bash -l {0}
         run: |
           mamba --version 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/conda_version.txt
           python -V 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/python_version.txt
       - name: Install ESMValTool
-        shell: bash -l {0}
         run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/install.txt
       - name: Install Julia dependencies
-        shell: bash -l {0}
         run: esmvaltool install Julia
       - name: Install development version of ESMValCore
-        shell: bash -l {0}
         run: |
           cd ..
           git clone https://github.com/ESMValGroup/ESMValCore.git
           cd ESMValCore
           pip install -e .[develop]
       - name: Run flake8
-        shell: bash -l {0}
         run: flake8
       - name: Run tests
-        shell: bash -l {0}
         run: pytest -n 2 -m "not installation" 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/test_report.txt
       - name: Upload artifacts
         if: ${{ always() }}  # upload artifacts even if fail

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+# Required shell entrypoint to have properly configured bash shell
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   linux:
     runs-on: "ubuntu-latest"
@@ -29,36 +34,28 @@ jobs:
           miniforge-version: "latest"
           miniforge-variant: Mambaforge
           use-mamba: true
-      - shell: bash -l {0}
-        run: mkdir -p test_linux_artifacts_python_${{ matrix.python-version }}
+      - run: mkdir -p test_linux_artifacts_python_${{ matrix.python-version }}
       - name: Record versions
-        shell: bash -l {0}
         run: |
           mamba --version 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/conda_version.txt
           python -V 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/python_version.txt
           # this is how to export variables to the GITHUB var environment
           echo "pver0=$(python -V)" >> $GITHUB_ENV
       - name: Install ESMValTool
-        shell: bash -l {0}
         run: pip install -e .[develop] 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/install.txt
       - name: Install Julia dependencies
-        shell: bash -l {0}
         run: esmvaltool install Julia
       - name: Export Python minor version
-        shell: bash -l {0}
         run: echo "pver1=$(python -V)" >> $GITHUB_ENV
       - name: Exit if Python minor version changed
-        shell: bash -l {0}
         if: ${{ env.pver1 != env.pver0}}
         run: |
           echo "Python minor version changed after Julia install"
           python -V
           exit 1
       - name: Run flake8
-        shell: bash -l {0}
         run: flake8
       - name: Run tests
-        shell: bash -l {0}
         run: pytest -n 2 -m "not installation" 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/test_report.txt
       - name: Upload artifacts
         if: ${{ always() }}  # upload artifacts even if fail
@@ -88,21 +85,16 @@ jobs:
           use-mamba: true
       # - name: Install libomp with homebrew
       #   run: brew install libomp
-      - shell: bash -l {0}
-        run: mkdir -p test_osx_artifacts_python_${{ matrix.python-version }}
+      - run: mkdir -p test_osx_artifacts_python_${{ matrix.python-version }}
       - name: Record versions
-        shell: bash -l {0}
         run: |
           mamba --version 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/conda_version.txt
           python -V 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/python_version.txt
       - name: Install ESMValTool
-        shell: bash -l {0}
         run: pip install -e .[develop] 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/install.txt
       - name: Run flake8
-        shell: bash -l {0}
         run: flake8
       - name: Run tests
-        shell: bash -l {0}
         run: pytest -n 2 -m "not installation" 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/test_report.txt
       - name: Upload artifacts
         if: ${{ always() }}  # upload artifacts even if fail


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

This specifies the shell definition (bash, in this case) in a defaults section of the GA workflow, and more importantly, does this only once so that everytime a new command is added (via run key), one doesn't have to keep adding the bash definition above it; this makes the workflow a lot more readable; originally suggested by @bouweandela :beer: 

Sister PR to https://github.com/ESMValGroup/ESMValCore/pull/2126

- Closes #3279 
- Link to documentation: not changed

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful
