### PR TITLE
Extension of CLARA-AVHRR, CLOUDSAT-L2 and ESACCI-CLOUD CMORizers

### DIFF
--- a/doc/sphinx/source/input.rst
+++ b/doc/sphinx/source/input.rst
@@ -252,9 +252,9 @@ A list of the datasets for which a CMORizers is available is provided in the fol
 | CERES-SYN1deg                | rlds, rldscs, rlus, rluscs, rlut, rlutcs, rsds, rsdscs, rsus, rsuscs, rsut, rsutcs (3hr)             |   3  | NCL             |
 |                              | rlds, rldscs, rlus, rlut, rlutcs, rsds, rsdt, rsus, rsut, rsutcs (Amon)                              |      |                 |
 +------------------------------+------------------------------------------------------------------------------------------------------+------+-----------------+
-| CLARA-AVHRR                  | clt, clivi, lwp (Amon)                                                                               |   3  | NCL             |
+| CLARA-AVHRR                  | clt, clivi, clwvi, lwp (Amon)                                                                        |   3  | NCL             |
 +------------------------------+------------------------------------------------------------------------------------------------------+------+-----------------+
-| CLOUDSAT-L2                  | clw, clivi, lwp (Amon)                                                                               |   3  | NCL             |
+| CLOUDSAT-L2                  | clw, clivi, clwvi, lwp (Amon)                                                                        |   3  | NCL             |
 +------------------------------+------------------------------------------------------------------------------------------------------+------+-----------------+
 | CowtanWay                    | tasa (Amon)                                                                                          |   2  | Python          |
 +------------------------------+------------------------------------------------------------------------------------------------------+------+-----------------+
@@ -281,7 +281,7 @@ A list of the datasets for which a CMORizers is available is provided in the fol
 +------------------------------+------------------------------------------------------------------------------------------------------+------+-----------------+
 | ESACCI-AEROSOL               | abs550aer, od550aer, od550aerStderr, od550lt1aer, od870aer, od870aerStderr (aero)                    |   2  | NCL             |
 +------------------------------+------------------------------------------------------------------------------------------------------+------+-----------------+
-| ESACCI-CLOUD                 | clivi, clt, cltStderr, lwp, rlut, rlutcs, rsut, rsutcs, rsdt, rlus, rsus, rsuscs (Amon)              |   2  | NCL             |
+| ESACCI-CLOUD                 | clivi, clt, cltStderr, clwvi, lwp, rlut, rlutcs, rsut, rsutcs, rsdt, rlus, rsus, rsuscs (Amon)       |   2  | NCL             |
 +------------------------------+------------------------------------------------------------------------------------------------------+------+-----------------+
 | ESACCI-FIRE                  | burntArea (Lmon)                                                                                     |   2  | NCL             |
 +------------------------------+------------------------------------------------------------------------------------------------------+------+-----------------+

--- a/esmvaltool/cmorizers/data/formatters/datasets/clara_avhrr.ncl
+++ b/esmvaltool/cmorizers/data/formatters/datasets/clara_avhrr.ncl
@@ -34,6 +34,7 @@
 ;    7) Untar all .tar files into a single directory.
 ;
 ; Modification history
+;    20230818-lauer_axel: added output of clwvi (in addition to iwp, lwp)
 ;    20210506-lauer_axel: output of lwp instead of clwvi
 ;    20210323-lauer_axel: written.
 ;
@@ -57,30 +58,31 @@ begin
   YEAR2 = 2018
 
   ; Selected variable (standard name)
-  VAR = (/"clt", "clivi", "lwp"/)
+  VAR = (/"clt", "clivi", "lwp", "clwvi"/)
 
   ; Name in the raw data
-  NAME = (/"cfc", "iwp_allsky", "lwp_allsky"/)
+  NAME = (/"cfc", "iwp_allsky", "lwp_allsky", "iwp_allsky"/)
 
   ; Filename base
-  FNBASE = (/"CFCmm", "IWPmm", "LWPmm"/)
+  FNBASE = (/"CFCmm", "IWPmm", "LWPmm", "IWPmm"/)
 
   ; Conversion factor
   ; Remark: total cloud cover (CFC) is reported as "1" but is actually "%"
   ; IWP and LWP use scale_factor to convert to kg/m2
-  ; CONV = (/1., 1., 1./)
+  ; CONV = (/1., 1., 1., 1./)
 
   ; MIP
-  MIP = (/"Amon", "Amon", "Amon"/)
+  MIP = (/"Amon", "Amon", "Amon", "Amon"/)
 
   ; Frequency
-  FREQ = (/"mon", "mon", "mon"/)
+  FREQ = (/"mon", "mon", "mon", "mon"/)
 
   ; CMOR table
   CMOR_TABLE = getenv("cmor_tables") + \
     (/"/cmip5/Tables/CMIP5_Amon", \
       "/cmip5/Tables/CMIP5_Amon", \
-      "/custom/CMOR_lwp.dat"/)
+      "/custom/CMOR_lwp.dat",    \
+      "/cmip5/Tables/CMIP5_Amon"/)
 
   ; Type
   TYPE = "sat"
@@ -159,17 +161,56 @@ begin
           output&lat = f->lat
           output!2 = "lon"
           output&lon = f->lon
+          fillval = xx@_FillValue
         end if
         output(ind(toint(yy * 100 + mm).eq.date), :, :) = (/xx/)
 
         delete(fname)
         delete(f)
+        delete(xx)
 
+        ; *** calculate clwvi (lwp + iwp) ***
+
+        if (VAR(vv) .eq. "clwvi") then
+          fname = systemfunc("ls " + input_dir_path + "LWPmm" + \
+                             syear + smonth + "01*.nc")
+
+          ; No files found
+          if (ismissing(fname)) then
+            log_info("Warning: input data incomplete for variable " + \
+                     VAR(vv) + " (" + syear + smonth + ")")
+            continue
+          end if
+
+          ; Extract data
+          f = addfile(fname, "r")
+          val = f->lwp_allsky
+          if (isatt(val, "scale_factor")) then
+            scalefac = tofloat(val@scale_factor)
+          else
+            scalefac = 1.0
+          end if
+          if (isatt(val, "add_offset")) then
+            offset = tofloat(val@add_offset)
+          else
+            offset = 0.0
+          end if
+          xx = tofloat(val) * scalefac + offset
+          delete(val)
+
+          idx = ind(toint(yy * 100 + mm).eq.date)
+          output(idx, :, :) = output(idx, :, :) + (/xx(0, :, :)/)
+
+          delete(idx)
+          delete(xx)
+          delete(fname)
+          delete(f)
+        end if  ; if VAR(vv) .eq. "clwvi"
       end do
     end do
 
     ; Set fill value
-    output = where(output.eq.xx@_FillValue, output@_FillValue, output)
+    output = where(output.eq.fillval, output@_FillValue, output)
 
     ; Format coordinates
     output!0 = "time"

--- a/esmvaltool/cmorizers/data/formatters/datasets/cloudsat_l2.ncl
+++ b/esmvaltool/cmorizers/data/formatters/datasets/cloudsat_l2.ncl
@@ -58,6 +58,7 @@
 ;                  --end=2015 CLOUDSAT-L2
 ;
 ; Modification history
+;    20230904-lauer_axel: added output of clwvi (iwp + lwp)
 ;    20220809-lauer_axel: adapted CMORizer to new format introduced in
 ;                         ESMValTool v2.5.0 and added info message
 ;    20210924-lauer_axel: added processing of lwp and iwp
@@ -100,12 +101,13 @@ begin
   end if
 
   ; output variable (standard name)
-  outvar = (/"clw", "lwp", "clivi"/)
+  outvar = (/"clw", "lwp", "clivi", "clwvi"/)
 
   ; input variables
   var = (/"LO_RO_liquid_water_content_2B_CWC_RO", \
           "LO_RO_liquid_water_path_2B_CWC_RO",    \
-          "IO_RO_ice_water_path_2B_CWC_RO"/)
+          "IO_RO_ice_water_path_2B_CWC_RO",       \
+          "dummy"/)
 
   var_flag = "Precip_flag_2C_PRECIP_COLUMN"
 
@@ -120,6 +122,7 @@ begin
   CMOR_TABLE = getenv("cmor_tables") + \
     (/"/cmip5/Tables/CMIP5_" + mip, \
       "/custom/CMOR_lwp.dat", \
+      "/cmip5/Tables/CMIP5_" + mip, \
       "/cmip5/Tables/CMIP5_" + mip/)
 
   ; Type
@@ -168,26 +171,26 @@ begin
   grid = new((/nt, nz, ny, nx/), float)
   gridpts = new((/nt, nz, ny, nx/), integer)
 
-  grid2d = new((/nt, 2, ny, nx/), float)
-  gridpts2d = new((/nt, 2, ny, nx/), integer)
+  grid2d = new((/nt, 3, ny, nx/), float)
+  gridpts2d = new((/nt, 3, ny, nx/), integer)
 
   ; "grid-box average" (all points)
   grid_avg = new((/nt, nz, ny, nx/), float)
   gridpts_avg = new((/nt, nz, ny, nx/), integer)
-  grid2d_avg = new((/nt, 2, ny, nx/), float)
-  gridpts2d_avg = new((/nt, 2, ny, nx/), integer)
+  grid2d_avg = new((/nt, 3, ny, nx/), float)
+  gridpts2d_avg = new((/nt, 3, ny, nx/), integer)
 
   ; "in-cloud" (no precipitation)
   grid_noprecip = new((/nt, nz, ny, nx/), float)
   gridpts_noprecip = new((/nt, nz, ny, nx/), integer)
-  grid2d_noprecip = new((/nt, 2, ny, nx/), float)
-  gridpts2d_noprecip = new((/nt, 2, ny, nx/), integer)
+  grid2d_noprecip = new((/nt, 3, ny, nx/), float)
+  gridpts2d_noprecip = new((/nt, 3, ny, nx/), integer)
 
   ; "grid-box average" (no precipitation)
   grid_avg_noprecip = new((/nt, nz, ny, nx/), float)
   gridpts_avg_noprecip = new((/nt, nz, ny, nx/), integer)
-  grid2d_avg_noprecip = new((/nt, 2, ny, nx/), float)
-  gridpts2d_avg_noprecip = new((/nt, 2, ny, nx/), integer)
+  grid2d_avg_noprecip = new((/nt, 3, ny, nx/), float)
+  gridpts2d_avg_noprecip = new((/nt, 3, ny, nx/), integer)
 
   ; boundaries of vertical (height) bins
 
@@ -491,21 +494,27 @@ begin
         delete(lon_ext)
         delete(hgt1d)
 
-        ; ===================================
-        ; 2-dim cloud liquid / ice water path
-        ; ===================================
+        ; ============================================================
+        ; 2-dim cloud liquid / ice water path / total cloud water path
+        ; ============================================================
 
-        do ivar = 1, 2
+        do ivar = 1, 3
           if (outvar(ivar) .eq. "lwp") then
             x = l1d
             ilev = 0
           else if (outvar(ivar) .eq. "clivi") then
             x = i1d
             ilev = 1
+          else if (outvar(ivar) .eq. "clwvi") then
+            ; clwvi is calculated from the *output* fields of lwp and iwp
+            ; to make sure it is the sum of the two (masking, etc.)
+            ; --> nothing to do here
+            continue
           else
             log_info("Warning: output variable unknown: " + outvar(ivar) + \
                      ", skipping variable " + outvar(ivar) + ".")
             continue
+          end if
           end if
           end if
 
@@ -746,11 +755,23 @@ begin
 
     ; save results to files
 
-    do ivar = 1, 2
+    do ivar = 1, 3
       if (outvar(ivar) .eq. "lwp") then
         ilev = 0
       else if (outvar(ivar) .eq. "clivi") then
         ilev = 1
+      else if (outvar(ivar) .eq. "clwvi") then
+        ; calculate clwvi (lwp+iwp) as sum of output fields for lwp and iwp
+        ilev = 2
+        grid2d(:, ilev, :, :) = grid2d(:, 0, :, :) \
+                                + grid2d(:, 1, :, :)
+        grid2d_avg(:, ilev, :, :) = grid2d_avg(:, 0, :, :) \
+                                    + grid2d_avg(:, 1, :, :)
+        grid2d_noprecip(:, ilev, :, :) = grid2d_noprecip(:, 0, :, :) \
+                                         + grid2d_noprecip(:, 1, :, :)
+        grid2d_avg_noprecip(:, ilev, :, :) = grid2d_avg_noprecip(:, 0, :, :) \
+                                             + grid2d_avg_noprecip(:, 1, :, :)
+      end if
       end if
       end if
 
@@ -842,7 +863,7 @@ begin
     write_nc(fout, outvar(ivar), output, bounds, gAtt)
     delete(output)
     delete(gAtt)
-    end do  ; loop over implemented 2-dim variables (lwp, iwp)
+    end do  ; loop over implemented 2-dim variables (lwp, iwp, lwp+iwp)
   end do  ; loop over years
 
 end

--- a/esmvaltool/cmorizers/data/formatters/datasets/cloudsat_l2.ncl
+++ b/esmvaltool/cmorizers/data/formatters/datasets/cloudsat_l2.ncl
@@ -764,13 +764,13 @@ begin
         ; calculate clwvi (lwp+iwp) as sum of output fields for lwp and iwp
         ilev = 2
         grid2d(:, ilev, :, :) = grid2d(:, 0, :, :) \
-                                + grid2d(:, 1, :, :)
+          + grid2d(:, 1, :, :)
         grid2d_avg(:, ilev, :, :) = grid2d_avg(:, 0, :, :) \
-                                    + grid2d_avg(:, 1, :, :)
+          + grid2d_avg(:, 1, :, :)
         grid2d_noprecip(:, ilev, :, :) = grid2d_noprecip(:, 0, :, :) \
-                                         + grid2d_noprecip(:, 1, :, :)
+          + grid2d_noprecip(:, 1, :, :)
         grid2d_avg_noprecip(:, ilev, :, :) = grid2d_avg_noprecip(:, 0, :, :) \
-                                             + grid2d_avg_noprecip(:, 1, :, :)
+          + grid2d_avg_noprecip(:, 1, :, :)
       end if
       end if
       end if

--- a/esmvaltool/cmorizers/data/formatters/datasets/esacci_cloud.ncl
+++ b/esmvaltool/cmorizers/data/formatters/datasets/esacci_cloud.ncl
@@ -22,7 +22,7 @@
 ;        --reject="index.html*"
 ;        https://public.satproj.klima.dwd.de/data/ESA_Cloud_CCI/
 ;          CLD_PRODUCTS/v3.0/L3C/AVHRR-PM/
-
+;
 ;    All files are expected in a single directory (no subdirectories
 ;    with years).
 ;
@@ -67,7 +67,7 @@ begin
 
   ; Conversion factor
   CONV = (/100., 1., 0.001, 0.001, 0.001, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, \
-           1.0, 1.0/)
+          1.0, 1.0/)
 
   ; MIP
   MIP = (/"Amon", "Amon", "Amon", "Amon", "Amon", "Amon", "Amon", "Amon", \

--- a/esmvaltool/cmorizers/data/formatters/datasets/esacci_cloud.ncl
+++ b/esmvaltool/cmorizers/data/formatters/datasets/esacci_cloud.ncl
@@ -27,6 +27,7 @@
 ;    with years).
 ;
 ; Modification history
+;    20230818-lauer_axel: added output of clwvi (in addition to iwp, lwp)
 ;    20210428-lauer_axel: AVHRR-AM and AVHRR-PM data are now averaged during
 ;                         the overlapping time; TOA radiative fluxes are now
 ;                         also processed
@@ -56,24 +57,25 @@ begin
   YEAR2 = get_year(end_year, 2016)
 
   ; Selected variable (standard name)
-  VAR = (/"clt", "cltStderr", "clivi", "lwp", "rlut", "rlutcs", \
+  VAR = (/"clt", "cltStderr", "clivi", "lwp", "clwvi", "rlut", "rlutcs", \
           "rsut", "rsutcs", "rsdt", "rlus", "rsus", "rsuscs"/)
 
   ; Name in the raw data
-  NAME = (/"cfc", "cfc_unc", "iwp_allsky", "lwp_allsky", "toa_lwup", \
-           "toa_lwup_clr", "toa_swup", "toa_swup_clr", "toa_swdn", \
-           "boa_lwup", "boa_swup", "boa_swup_clr"/)
+  NAME = (/"cfc", "cfc_unc", "iwp_allsky", "lwp_allsky", "iwp_allsky", \
+           "toa_lwup", "toa_lwup_clr", "toa_swup", "toa_swup_clr", \
+           "toa_swdn", "boa_lwup", "boa_swup", "boa_swup_clr"/)
 
   ; Conversion factor
-  CONV = (/100., 1., 0.001, 0.001, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0/)
+  CONV = (/100., 1., 0.001, 0.001, 0.001, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, \
+           1.0, 1.0/)
 
   ; MIP
   MIP = (/"Amon", "Amon", "Amon", "Amon", "Amon", "Amon", "Amon", "Amon", \
-          "Amon", "Amon", "Amon", "Amon"/)
+          "Amon", "Amon", "Amon", "Amon", "Amon"/)
 
   ; Frequency
   FREQ = (/"mon", "mon", "mon", "mon", "mon", "mon", "mon", "mon", "mon", \
-           "mon", "mon", "mon"/)
+           "mon", "mon", "mon", "mon"/)
 
   ; CMOR table
   CMOR_TABLE = getenv("cmor_tables") + \
@@ -81,6 +83,7 @@ begin
       "/custom/CMOR_cltStderr.dat", \
       "/cmip5/Tables/CMIP5_Amon", \
       "/custom/CMOR_lwp.dat", \
+      "/cmip5/Tables/CMIP5_Amon", \
       "/cmip5/Tables/CMIP5_Amon", \
       "/cmip5/Tables/CMIP5_Amon", \
       "/cmip5/Tables/CMIP5_Amon", \
@@ -151,6 +154,13 @@ begin
           ; Convert units
           xx_all(i, :, :, :) = xx * CONV(vv)
 
+          ; *** calculate clwvi (lwp + iwp) ***
+          if (VAR(vv) .eq. "clwvi") then
+            xx2 = f->lwp_allsky * 0.001
+            xx_all(i, :, :, :) = xx_all(i, :, :, :) + xx2
+            delete(xx2)
+          end if
+
           if (firstime) then
             lat = f->lat
             lon = f->lon
@@ -161,6 +171,7 @@ begin
 
         delete(fname)
         delete(xx)
+
         xx = dim_avg_n(xx_all, 0)  ; ignore missing values
         delete(xx_all)
 

--- a/esmvaltool/recipes/examples/recipe_check_obs.yml
+++ b/esmvaltool/recipes/examples/recipe_check_obs.yml
@@ -167,6 +167,7 @@ diagnostics:
       clivi:
       clt:
       cltStderr:
+      clwvi:
       lwp:
       rlut:
       rlutcs:
@@ -1065,6 +1066,8 @@ diagnostics:
         mip: Amon
       clivi:
         mip: Amon
+      clwvi:
+        mip: Amon
       lwp:
         mip: Amon
     additional_datasets:
@@ -1078,6 +1081,7 @@ diagnostics:
     variables:
       clivi:
       clw:
+      clwvi:
       lwp:
     additional_datasets:
       - {dataset: CLOUDSAT-L2, project: OBS, tier: 3, type: sat,


### PR DESCRIPTION
## Description

This PR adds the variable `clwvi` (= lwp + iwp) to the output of the CMORizer scripts for the datasets CLARA-AVHRR, CLOUDSAT-L2 and ESACCI-CLOUD.

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated data reformatting script](https://docs.esmvaltool.org/en/latest/develop/dataset.html)

- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/dataset.html#dataset-documentation) is available
- [x] [🛠][1] The dataset has been [added to the CMOR check recipe](https://docs.esmvaltool.org/en/latest/community/dataset.html#testing)
- [x] [🛠][1] The dataset has been added to the shared [data pools](https://docs.esmvaltool.org/en/latest/community/dataset.html#cmorized-data) of DKRZ and Jasmin by the @ESMValGroup/OBS-maintainers team
- [x] [🧪][2] Numbers and units of the data look [physically meaningful](https://docs.esmvaltool.org/en/latest/community/dataset.html#scientific-sanity-check)