### PR TITLE
Simplify configure task in recipe test workflow

### DIFF
--- a/esmvaltool/utils/recipe_test_workflow/doc/source/user_guide/workflow.rst
+++ b/esmvaltool/utils/recipe_test_workflow/doc/source/user_guide/workflow.rst
@@ -30,15 +30,14 @@ The |RTW| performs the following steps:
 
 ``configure``
   :Description:
-     Creates and modifies the |ESMValTool| user configuration file
+     Creates the |ESMValTool| user configuration file
   :Runs on:
      Localhost
   :Executes:
      The ``configure.py`` script from the |Rose| app
   :Details:
-     ``configure`` should run at the start of each cycle after ``clone_latest_esmval``
-     has completed; in the case where the next cycle doesn't happen for a week,
-     the clone could potentially be out of date by the time of the task trigger.
+     ``configure`` should run at the start of each cycle after 
+     ``install_env_file`` has completed.
 
 ``process``
   :Description:

--- a/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/app/configure/bin/configure.py
+++ b/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/app/configure/bin/configure.py
@@ -4,9 +4,6 @@ import os
 import pprint
 
 import yaml
-from esmvalcore.config._config_object import Config
-
-import esmvaltool
 
 
 def main():

--- a/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/app/configure/bin/configure.py
+++ b/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/app/configure/bin/configure.py
@@ -9,10 +9,9 @@ import yaml
 def main():
     """Write the required user configuration file for ESMValTool.
 
-    The default configuration values from the latest version of
-    ESMValTool are updated with the configuration values defined in the
-    environment for the ``configure`` task and the result is written to
-    the file defined by ``USER_CONFIG_PATH`` in the ``flow.cylc`` file.
+    The configuration values defined in the environment for the
+    ``configure`` task are written to the configuration file defined
+    by ``USER_CONFIG_PATH`` in the ``flow.cylc`` file.
     """
     # Get the configuration values defined in the environment for the
     # 'configure' task.

--- a/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/app/configure/bin/configure.py
+++ b/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/app/configure/bin/configure.py
@@ -17,16 +17,11 @@ def main():
     environment for the ``configure`` task and the result is written to
     the file defined by ``USER_CONFIG_PATH`` in the ``flow.cylc`` file.
     """
-    # Get the default configuration values from the latest version of
-    # ESMValTool.
-    config_values = get_latest_default_conf_vals()
-
     # Get the configuration values defined in the environment for the
     # 'configure' task.
-    config_values_from_task_env = get_config_values_from_task_env()
+    config_values = get_config_values_from_task_env()
 
-    # Update the default configuration values.
-    config_values.update(config_values_from_task_env)
+    # Update the configuration from OS environment.
     user_config_path = os.environ["USER_CONFIG_PATH"]
     config_values["config_file"] = user_config_path
 
@@ -36,30 +31,6 @@ def main():
           "values: ")
     pprint.PrettyPrinter().pprint(config_values)
     write_yaml(user_config_path, config_values)
-
-
-def get_latest_default_conf_vals():
-    """Return the default configuration values from the latest version of
-    ESMValTool."""
-    latest_esmvaltool_dir = os.environ["ESMVALTOOL_DIR"]
-    default_config_file = os.path.join(latest_esmvaltool_dir,
-                                       "config-user-example.yml")
-    # A dictionary is needed here to avoid the config object from
-    # converting paths to 'PosixPath' objects, which causes issues when
-    # writing the YAML file.
-    config_values = dict(Config._load_user_config(default_config_file))
-
-    # Update the type of the value of 'config_developer_file' from a
-    # 'PosixPath' object to a string, to avoid issues when writing the
-    # YAML file (all other paths will be overwritten).
-    config_developer_file = str(config_values["config_developer_file"])
-    config_values["config_developer_file"] = config_developer_file
-
-    print("Default configuration values from the latest version of ESMValTool "
-          f"{esmvaltool.__version__} (from '{default_config_file}'): ")
-    pprint.PrettyPrinter().pprint(config_values)
-
-    return config_values
 
 
 def get_config_values_from_task_env():

--- a/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/flow.cylc
+++ b/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/flow.cylc
@@ -12,10 +12,8 @@
    final cycle point = 10
     [[graph]]
         R1 = """install_env_file => configure & clone_latest_esmval
-                configure => process<fast> => compare<fast>
-                configure => process<medium> => compare<medium>
-                clone_latest_esmval => process<fast>
-                clone_latest_esmval => process<medium>"""
+                configure & clone_latest_esmval => process<medium> => compare<medium>
+                configure & clone_latest_esmval => process<fast> => compare<fast>"""
 
 [runtime]
     [[root]]

--- a/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/flow.cylc
+++ b/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/flow.cylc
@@ -11,8 +11,7 @@
    initial cycle point = 1
    final cycle point = 10
     [[graph]]
-        R1 = """install_env_file => configure
-                install_env_file => clone_latest_esmval
+        R1 = """install_env_file => configure & clone_latest_esmval
                 configure => process<fast> => compare<fast>
                 configure => process<medium> => compare<medium>
                 clone_latest_esmval => process<fast>

--- a/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/flow.cylc
+++ b/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/flow.cylc
@@ -11,9 +11,12 @@
    initial cycle point = 1
    final cycle point = 10
     [[graph]]
-        R1 = """install_env_file => clone_latest_esmval => configure
+        R1 = """install_env_file => configure
+                install_env_file => clone_latest_esmval
                 configure => process<fast> => compare<fast>
-                configure => process<medium> => compare<medium>"""
+                configure => process<medium> => compare<medium>
+                clone_latest_esmval => process<fast>
+                clone_latest_esmval => process<medium>"""
 
 [runtime]
     [[root]]


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description
At present, the configure task in RTW reads the example user config file from the repo and overwrites with any variables provided by the workflow config (mainly DRS). However, ESMValTool doesn't require a user config file to contain all the keys specified in the user file, and will provide defaults for any keys not in the file (indeed the example file doesn't include all possible config variables). It therefore will be simpler to write only the keys provided by the RTW.

Benefits:
- This simplifies the workflow by removing the need to obtain/read the example user config file, and 
- means that all the other keys default to values set by the code, rather than a mix of code and example file as at present


<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
- Closes #3398 
- Link to documentation: N/A

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [ ] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available (N/A)
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful (apart from docs test, due to #3395)


***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
