### PR TITLE
Support `CenteredNorm` in diagnostic monitor/multidatasets.py

### DIFF
--- a/esmvaltool/diag_scripts/monitor/multi_datasets.py
+++ b/esmvaltool/diag_scripts/monitor/multi_datasets.py
@@ -312,7 +312,7 @@ plot_kwargs: dict, optional
     will be derived from the corresponding dataset, e.g., ``{project}``,
     ``{short_name}``, ``{exp}``. Examples: ``default: {levels: 2}, CMIP6:
     {vmin: 200, vmax: 250}``. In addition to the normalization_ options
-    supported by the plot function, the option ``norm=centered``. In this case,
+    supported by the plot function, the option ``norm: centered``. In this case,
     the keywords ``vcenter`` and ``halfrange`` should be used instead of
     ``vmin`` or ``vmax`` (see :class:`~matplotlib.colors.CenteredNorm`).
 plot_kwargs_bias: dict, optional

--- a/esmvaltool/diag_scripts/monitor/multi_datasets.py
+++ b/esmvaltool/diag_scripts/monitor/multi_datasets.py
@@ -225,13 +225,16 @@ plot_kwargs: dict, optional
     ``plot_func``. String arguments can include facets in curly brackets which
     will be derived from the corresponding dataset, e.g., ``{project}``,
     ``{short_name}``, ``{exp}``. Examples: ``default: {levels: 2}, CMIP6:
-    {vmin: 200, vmax: 250}``.
+    {vmin: 200, vmax: 250}``. In addition to the normalization_ options
+    supported by the plot function, the option ``norm=centered``. In this case,
+    the keywords ``vcenter`` and ``halfrange`` should be used instead of
+    ``vmin`` or ``vmax`` (see :class:`~matplotlib.colors.CenteredNorm`).
 plot_kwargs_bias: dict, optional
     Optional keyword arguments for the plot function defined by ``plot_func``
     for plotting biases. These keyword arguments update (and potentially
     overwrite) the ``plot_kwargs`` for the bias plot. This option has no effect
     if no reference dataset is given. See option ``plot_kwargs`` for more
-    details. By default, uses ``cmap: bwr``.
+    details. By default, uses ``cmap: bwr`` and ``norm=centered``.
 projection: str, optional (default: 'Robinson')
     Projection used for the map plot. Needs to be a valid projection class of
     :mod:`cartopy.crs`. Keyword arguments can be specified using the option
@@ -248,10 +251,9 @@ pyplot_kwargs: dict, optional
     ``{project}``, ``{short_name}``, ``{exp}``.  Examples: ``title: 'Awesome
     Plot of {long_name}'``, ``xlabel: '{short_name}'``, ``xlim: [0, 5]``.
 rasterize: bool, optional (default: True)
-    If ``True``, use `rasterization
-    <https://matplotlib.org/stable/gallery/misc/rasterization_demo.html>`_ for
-    map plots to produce smaller files. This is only relevant for vector
-    graphics (e.g., ``output_file_type=pdf,svg,ps``).
+    If ``True``, use rasterization_ for map plots to produce smaller files.
+    This is only relevant for vector graphics (e.g.,
+    ``output_file_type=pdf,svg,ps``).
 show_stats: bool, optional (default: True)
     Show basic statistics on the plots.
 x_pos_stats_avg: float, optional (default: 0.0)
@@ -309,13 +311,16 @@ plot_kwargs: dict, optional
     ``plot_func``. String arguments can include facets in curly brackets which
     will be derived from the corresponding dataset, e.g., ``{project}``,
     ``{short_name}``, ``{exp}``. Examples: ``default: {levels: 2}, CMIP6:
-    {vmin: 200, vmax: 250}``.
+    {vmin: 200, vmax: 250}``. In addition to the normalization_ options
+    supported by the plot function, the option ``norm=centered``. In this case,
+    the keywords ``vcenter`` and ``halfrange`` should be used instead of
+    ``vmin`` or ``vmax`` (see :class:`~matplotlib.colors.CenteredNorm`).
 plot_kwargs_bias: dict, optional
     Optional keyword arguments for the plot function defined by ``plot_func``
     for plotting biases. These keyword arguments update (and potentially
     overwrite) the ``plot_kwargs`` for the bias plot. This option has no effect
     if no reference dataset is given. See option ``plot_kwargs`` for more
-    details. By default, uses ``cmap: bwr``.
+    details. By default, uses ``cmap: bwr`` and ``norm=centered``.
 pyplot_kwargs: dict, optional
     Optional calls to functions of :mod:`matplotlib.pyplot`. Dictionary keys
     are functions of :mod:`matplotlib.pyplot`. Dictionary values are used as
@@ -324,10 +329,9 @@ pyplot_kwargs: dict, optional
     ``{project}``, ``{short_name}``, ``{exp}``.  Examples: ``title: 'Awesome
     Plot of {long_name}'``, ``xlabel: '{short_name}'``, ``xlim: [0, 5]``.
 rasterize: bool, optional (default: True)
-    If ``True``, use `rasterization
-    <https://matplotlib.org/stable/gallery/misc/rasterization_demo.html>`_ for
-    profile plots to produce smaller files. This is only relevant for vector
-    graphics (e.g., ``output_file_type=pdf,svg,ps``).
+    If ``True``, use rasterization_ for profile plots to produce smaller files.
+    This is only relevant for vector graphics (e.g.,
+    ``output_file_type=pdf,svg,ps``).
 show_stats: bool, optional (default: True)
     Show basic statistics on the plots.
 show_y_minor_ticklabels: bool, optional (default: False)
@@ -456,13 +460,16 @@ plot_kwargs: dict, optional
     ``plot_func``. String arguments can include facets in curly brackets which
     will be derived from the corresponding dataset, e.g., ``{project}``,
     ``{short_name}``, ``{exp}``. Examples: ``default: {levels: 2}, CMIP6:
-    {vmin: 200, vmax: 250}``.
+    {vmin: 200, vmax: 250}``. In addition to the normalization_ options
+    supported by the plot function, the option ``norm=centered``. In this case,
+    the keywords ``vcenter`` and ``halfrange`` should be used instead of
+    ``vmin`` or ``vmax`` (see :class:`~matplotlib.colors.CenteredNorm`).
 plot_kwargs_bias: dict, optional
     Optional keyword arguments for the plot function defined by ``plot_func``
     for plotting biases. These keyword arguments update (and potentially
     overwrite) the ``plot_kwargs`` for the bias plot. This option has no effect
     if no reference dataset is given. See option ``plot_kwargs`` for more
-    details. By default, uses ``cmap: bwr``.
+    details. By default, uses ``cmap: bwr`` and ``norm=centered``.
 pyplot_kwargs: dict, optional
     Optional calls to functions of :mod:`matplotlib.pyplot`. Dictionary keys
     are functions of :mod:`matplotlib.pyplot`. Dictionary values are used as
@@ -471,10 +478,9 @@ pyplot_kwargs: dict, optional
     ``{project}``, ``{short_name}``, ``{exp}``.  Examples: ``title: 'Awesome
     Plot of {long_name}'``, ``xlabel: '{short_name}'``, ``xlim: [0, 5]``.
 rasterize: bool, optional (default: True)
-    If ``True``, use `rasterization
-    <https://matplotlib.org/stable/gallery/misc/rasterization_demo.html>`_ for
-    profile plots to produce smaller files. This is only relevant for vector
-    graphics (e.g., ``output_file_type=pdf,svg,ps``).
+    If ``True``, use rasterization_ for profile plots to produce smaller files.
+    This is only relevant for vector graphics (e.g.,
+    ``output_file_type=pdf,svg,ps``).
 show_stats: bool, optional (default: True)
     Show basic statistics on the plots.
 show_y_minor_ticklabels: bool, optional (default: False)
@@ -536,13 +542,16 @@ plot_kwargs: dict, optional
     ``plot_func``. String arguments can include facets in curly brackets which
     will be derived from the corresponding dataset, e.g., ``{project}``,
     ``{short_name}``, ``{exp}``. Examples: ``default: {levels: 2}, CMIP6:
-    {vmin: 200, vmax: 250}``.
+    {vmin: 200, vmax: 250}``. In addition to the normalization_ options
+    supported by the plot function, the option ``norm=centered``. In this case,
+    the keywords ``vcenter`` and ``halfrange`` should be used instead of
+    ``vmin`` or ``vmax`` (see :class:`~matplotlib.colors.CenteredNorm`).
 plot_kwargs_bias: dict, optional
     Optional keyword arguments for the plot function defined by ``plot_func``
     for plotting biases. These keyword arguments update (and potentially
     overwrite) the ``plot_kwargs`` for the bias plot. This option has no effect
     if no reference dataset is given. See option ``plot_kwargs`` for more
-    details. By default, uses ``cmap: bwr``.
+    details. By default, uses ``cmap: bwr`` and ``norm=centered``.
 pyplot_kwargs: dict, optional
     Optional calls to functions of :mod:`matplotlib.pyplot`. Dictionary keys
     are functions of :mod:`matplotlib.pyplot`. Dictionary values are used as
@@ -550,11 +559,10 @@ pyplot_kwargs: dict, optional
     curly brackets which will be derived from the corresponding dataset, e.g.,
     ``{project}``, ``{short_name}``, ``{exp}``.  Examples: ``title: 'Awesome
     Plot of {long_name}'``, ``xlabel: '{short_name}'``, ``xlim: [0, 5]``.
-rasterize: bool, optional (default: False)
-    If ``True``, use `rasterization
-    <https://matplotlib.org/stable/gallery/misc/rasterization_demo.html>`_ for
-    profile plots to produce smaller files. This is only relevant for vector
-    graphics (e.g., ``output_file_type=pdf,svg,ps``).
+rasterize: bool, optional (default: True)
+    If ``True``, use rasterization_ for profile plots to produce smaller files.
+    This is only relevant for vector graphics (e.g.,
+    ``output_file_type=pdf,svg,ps``).
 show_y_minor_ticks: bool, optional (default: True)
     Show minor ticks for time on the Y axis.
 show_x_minor_ticks: bool, optional (default: True)
@@ -570,8 +578,14 @@ time_format: str, optional (default: None)
    anchors to share the configuration of common arguments with other monitor
    diagnostic script.
 
+.. _rasterization: https://matplotlib.org/stable/gallery/misc/
+   rasterization_demo.html
+.. _normalization: https://matplotlib.org/stable/users/explain/colors/
+   colormapnorms.html
+
 """
 import logging
+import warnings
 from copy import deepcopy
 from pathlib import Path
 from pprint import pformat
@@ -586,6 +600,7 @@ import seaborn as sns
 from iris.analysis.cartography import area_weights
 from iris.coord_categorisation import add_year
 from iris.coords import AuxCoord
+from matplotlib.colors import CenteredNorm
 from matplotlib.gridspec import GridSpec
 from matplotlib.ticker import (
     AutoMinorLocator,
@@ -703,6 +718,9 @@ class MultiDatasets(MonitorBase):
                 self.plots[plot_type]['plot_kwargs_bias'].setdefault(
                     'cmap', 'bwr'
                 )
+                self.plots[plot_type]['plot_kwargs_bias'].setdefault(
+                    'norm', 'centered'
+                )
                 if 'projection' not in self.plots[plot_type]:
                     self.plots[plot_type].setdefault('projection', 'Robinson')
                     self.plots[plot_type].setdefault(
@@ -733,6 +751,9 @@ class MultiDatasets(MonitorBase):
                 self.plots[plot_type].setdefault('plot_kwargs_bias', {})
                 self.plots[plot_type]['plot_kwargs_bias'].setdefault(
                     'cmap', 'bwr'
+                )
+                self.plots[plot_type]['plot_kwargs_bias'].setdefault(
+                    'norm', 'centered'
                 )
                 self.plots[plot_type].setdefault('pyplot_kwargs', {})
                 self.plots[plot_type].setdefault('rasterize', True)
@@ -776,6 +797,9 @@ class MultiDatasets(MonitorBase):
                 self.plots[plot_type].setdefault('plot_kwargs_bias', {})
                 self.plots[plot_type]['plot_kwargs_bias'].setdefault(
                     'cmap', 'bwr')
+                self.plots[plot_type]['plot_kwargs_bias'].setdefault(
+                    'norm', 'centered'
+                )
                 self.plots[plot_type].setdefault('pyplot_kwargs', {})
                 self.plots[plot_type].setdefault('rasterize', True)
                 self.plots[plot_type].setdefault('show_stats', True)
@@ -802,8 +826,11 @@ class MultiDatasets(MonitorBase):
                 self.plots[plot_type]['plot_kwargs_bias'].setdefault(
                     'cmap', 'bwr'
                 )
+                self.plots[plot_type]['plot_kwargs_bias'].setdefault(
+                    'norm', 'centered'
+                )
                 self.plots[plot_type].setdefault('pyplot_kwargs', {})
-                self.plots[plot_type].setdefault('rasterize', False)
+                self.plots[plot_type].setdefault('rasterize', True)
                 self.plots[plot_type].setdefault(
                     'show_y_minor_ticks', True
                 )
@@ -1042,6 +1069,14 @@ class MultiDatasets(MonitorBase):
         if plot_type in ('timeseries', 'annual_cycle', '1d_profile',
                          'variable_vs_lat'):
             plot_kwargs.setdefault('label', label)
+
+        # Handle norm='centered' correctly
+        if plot_kwargs.get('norm') == 'centered':
+            norm = CenteredNorm(
+                vcenter=plot_kwargs.pop('vcenter', 0.0),
+                halfrange=plot_kwargs.pop('halfrange', None),
+            )
+            plot_kwargs['norm'] = norm
 
         return deepcopy(plot_kwargs)
 
@@ -2485,7 +2520,14 @@ class MultiDatasets(MonitorBase):
 def main():
     """Run diagnostic."""
     with run_diagnostic() as config:
-        MultiDatasets(config).compute()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore',
+                message="Using DEFAULT_SPHERICAL_EARTH_RADIUS",
+                category=UserWarning,
+                module='iris',
+            )
+            MultiDatasets(config).compute()
 
 
 if __name__ == '__main__':

--- a/esmvaltool/diag_scripts/monitor/multi_datasets.py
+++ b/esmvaltool/diag_scripts/monitor/multi_datasets.py
@@ -562,7 +562,7 @@ pyplot_kwargs: dict, optional
 rasterize: bool, optional (default: True)
     If ``True``, use rasterization_ for profile plots to produce smaller files.
     This is only relevant for vector graphics (e.g.,
-    ``output_file_type=pdf,svg,ps``).
+    ``output_file_type: pdf,svg,ps``).
 show_y_minor_ticks: bool, optional (default: True)
     Show minor ticks for time on the Y axis.
 show_x_minor_ticks: bool, optional (default: True)

--- a/esmvaltool/diag_scripts/monitor/multi_datasets.py
+++ b/esmvaltool/diag_scripts/monitor/multi_datasets.py
@@ -551,7 +551,7 @@ plot_kwargs_bias: dict, optional
     for plotting biases. These keyword arguments update (and potentially
     overwrite) the ``plot_kwargs`` for the bias plot. This option has no effect
     if no reference dataset is given. See option ``plot_kwargs`` for more
-    details. By default, uses ``cmap: bwr`` and ``norm=centered``.
+    details. By default, uses ``cmap: bwr`` and ``norm: centered``.
 pyplot_kwargs: dict, optional
     Optional calls to functions of :mod:`matplotlib.pyplot`. Dictionary keys
     are functions of :mod:`matplotlib.pyplot`. Dictionary values are used as

--- a/esmvaltool/diag_scripts/monitor/multi_datasets.py
+++ b/esmvaltool/diag_scripts/monitor/multi_datasets.py
@@ -1070,7 +1070,6 @@ class MultiDatasets(MonitorBase):
                          'variable_vs_lat'):
             plot_kwargs.setdefault('label', label)
 
-        # Handle norm='centered' correctly
         if plot_kwargs.get('norm') == 'centered':
             norm = CenteredNorm(
                 vcenter=plot_kwargs.pop('vcenter', 0.0),

--- a/esmvaltool/diag_scripts/monitor/multi_datasets.py
+++ b/esmvaltool/diag_scripts/monitor/multi_datasets.py
@@ -469,7 +469,7 @@ plot_kwargs_bias: dict, optional
     for plotting biases. These keyword arguments update (and potentially
     overwrite) the ``plot_kwargs`` for the bias plot. This option has no effect
     if no reference dataset is given. See option ``plot_kwargs`` for more
-    details. By default, uses ``cmap: bwr`` and ``norm=centered``.
+    details. By default, uses ``cmap: bwr`` and ``norm: centered``.
 pyplot_kwargs: dict, optional
     Optional calls to functions of :mod:`matplotlib.pyplot`. Dictionary keys
     are functions of :mod:`matplotlib.pyplot`. Dictionary values are used as

--- a/esmvaltool/diag_scripts/monitor/multi_datasets.py
+++ b/esmvaltool/diag_scripts/monitor/multi_datasets.py
@@ -331,7 +331,7 @@ pyplot_kwargs: dict, optional
 rasterize: bool, optional (default: True)
     If ``True``, use rasterization_ for profile plots to produce smaller files.
     This is only relevant for vector graphics (e.g.,
-    ``output_file_type=pdf,svg,ps``).
+    ``output_file_type: pdf,svg,ps``).
 show_stats: bool, optional (default: True)
     Show basic statistics on the plots.
 show_y_minor_ticklabels: bool, optional (default: False)

--- a/esmvaltool/diag_scripts/monitor/multi_datasets.py
+++ b/esmvaltool/diag_scripts/monitor/multi_datasets.py
@@ -480,7 +480,7 @@ pyplot_kwargs: dict, optional
 rasterize: bool, optional (default: True)
     If ``True``, use rasterization_ for profile plots to produce smaller files.
     This is only relevant for vector graphics (e.g.,
-    ``output_file_type=pdf,svg,ps``).
+    ``output_file_type: pdf,svg,ps``).
 show_stats: bool, optional (default: True)
     Show basic statistics on the plots.
 show_y_minor_ticklabels: bool, optional (default: False)

--- a/esmvaltool/diag_scripts/monitor/multi_datasets.py
+++ b/esmvaltool/diag_scripts/monitor/multi_datasets.py
@@ -320,7 +320,7 @@ plot_kwargs_bias: dict, optional
     for plotting biases. These keyword arguments update (and potentially
     overwrite) the ``plot_kwargs`` for the bias plot. This option has no effect
     if no reference dataset is given. See option ``plot_kwargs`` for more
-    details. By default, uses ``cmap: bwr`` and ``norm=centered``.
+    details. By default, uses ``cmap: bwr`` and ``norm: centered``.
 pyplot_kwargs: dict, optional
     Optional calls to functions of :mod:`matplotlib.pyplot`. Dictionary keys
     are functions of :mod:`matplotlib.pyplot`. Dictionary values are used as

--- a/esmvaltool/diag_scripts/monitor/multi_datasets.py
+++ b/esmvaltool/diag_scripts/monitor/multi_datasets.py
@@ -253,7 +253,7 @@ pyplot_kwargs: dict, optional
 rasterize: bool, optional (default: True)
     If ``True``, use rasterization_ for map plots to produce smaller files.
     This is only relevant for vector graphics (e.g.,
-    ``output_file_type=pdf,svg,ps``).
+    ``output_file_type: pdf,svg,ps``).
 show_stats: bool, optional (default: True)
     Show basic statistics on the plots.
 x_pos_stats_avg: float, optional (default: 0.0)

--- a/esmvaltool/diag_scripts/monitor/multi_datasets.py
+++ b/esmvaltool/diag_scripts/monitor/multi_datasets.py
@@ -234,7 +234,7 @@ plot_kwargs_bias: dict, optional
     for plotting biases. These keyword arguments update (and potentially
     overwrite) the ``plot_kwargs`` for the bias plot. This option has no effect
     if no reference dataset is given. See option ``plot_kwargs`` for more
-    details. By default, uses ``cmap: bwr`` and ``norm=centered``.
+    details. By default, uses ``cmap: bwr`` and ``norm: centered``.
 projection: str, optional (default: 'Robinson')
     Projection used for the map plot. Needs to be a valid projection class of
     :mod:`cartopy.crs`. Keyword arguments can be specified using the option

--- a/esmvaltool/diag_scripts/monitor/multi_datasets.py
+++ b/esmvaltool/diag_scripts/monitor/multi_datasets.py
@@ -226,9 +226,10 @@ plot_kwargs: dict, optional
     will be derived from the corresponding dataset, e.g., ``{project}``,
     ``{short_name}``, ``{exp}``. Examples: ``default: {levels: 2}, CMIP6:
     {vmin: 200, vmax: 250}``. In addition to the normalization_ options
-    supported by the plot function, the option ``norm: centered``. In this case,
-    the keywords ``vcenter`` and ``halfrange`` should be used instead of
-    ``vmin`` or ``vmax`` (see :class:`~matplotlib.colors.CenteredNorm`).
+    supported by the plot function, the option ``norm: centered`` can be
+    specified. In this case, the keywords ``vcenter`` and ``halfrange`` should
+    be used instead of ``vmin`` or ``vmax`` (see
+    :class:`~matplotlib.colors.CenteredNorm`).
 plot_kwargs_bias: dict, optional
     Optional keyword arguments for the plot function defined by ``plot_func``
     for plotting biases. These keyword arguments update (and potentially
@@ -252,8 +253,8 @@ pyplot_kwargs: dict, optional
     Plot of {long_name}'``, ``xlabel: '{short_name}'``, ``xlim: [0, 5]``.
 rasterize: bool, optional (default: True)
     If ``True``, use rasterization_ for map plots to produce smaller files.
-    This is only relevant for vector graphics (e.g.,
-    ``output_file_type: pdf,svg,ps``).
+    This is only relevant for vector graphics (e.g., ``output_file_type:
+    pdf,svg,ps``).
 show_stats: bool, optional (default: True)
     Show basic statistics on the plots.
 x_pos_stats_avg: float, optional (default: 0.0)
@@ -312,9 +313,10 @@ plot_kwargs: dict, optional
     will be derived from the corresponding dataset, e.g., ``{project}``,
     ``{short_name}``, ``{exp}``. Examples: ``default: {levels: 2}, CMIP6:
     {vmin: 200, vmax: 250}``. In addition to the normalization_ options
-    supported by the plot function, the option ``norm: centered``. In this case,
-    the keywords ``vcenter`` and ``halfrange`` should be used instead of
-    ``vmin`` or ``vmax`` (see :class:`~matplotlib.colors.CenteredNorm`).
+    supported by the plot function, the option ``norm: centered`` can be
+    specified. In this case, the keywords ``vcenter`` and ``halfrange`` should
+    be used instead of ``vmin`` or ``vmax`` (see
+    :class:`~matplotlib.colors.CenteredNorm`).
 plot_kwargs_bias: dict, optional
     Optional keyword arguments for the plot function defined by ``plot_func``
     for plotting biases. These keyword arguments update (and potentially
@@ -330,8 +332,8 @@ pyplot_kwargs: dict, optional
     Plot of {long_name}'``, ``xlabel: '{short_name}'``, ``xlim: [0, 5]``.
 rasterize: bool, optional (default: True)
     If ``True``, use rasterization_ for profile plots to produce smaller files.
-    This is only relevant for vector graphics (e.g.,
-    ``output_file_type: pdf,svg,ps``).
+    This is only relevant for vector graphics (e.g., ``output_file_type:
+    pdf,svg,ps``).
 show_stats: bool, optional (default: True)
     Show basic statistics on the plots.
 show_y_minor_ticklabels: bool, optional (default: False)
@@ -461,9 +463,10 @@ plot_kwargs: dict, optional
     will be derived from the corresponding dataset, e.g., ``{project}``,
     ``{short_name}``, ``{exp}``. Examples: ``default: {levels: 2}, CMIP6:
     {vmin: 200, vmax: 250}``. In addition to the normalization_ options
-    supported by the plot function, the option ``norm: centered``. In this case,
-    the keywords ``vcenter`` and ``halfrange`` should be used instead of
-    ``vmin`` or ``vmax`` (see :class:`~matplotlib.colors.CenteredNorm`).
+    supported by the plot function, the option ``norm: centered`` can be
+    specified. In this case, the keywords ``vcenter`` and ``halfrange`` should
+    be used instead of ``vmin`` or ``vmax`` (see
+    :class:`~matplotlib.colors.CenteredNorm`).
 plot_kwargs_bias: dict, optional
     Optional keyword arguments for the plot function defined by ``plot_func``
     for plotting biases. These keyword arguments update (and potentially
@@ -479,8 +482,8 @@ pyplot_kwargs: dict, optional
     Plot of {long_name}'``, ``xlabel: '{short_name}'``, ``xlim: [0, 5]``.
 rasterize: bool, optional (default: True)
     If ``True``, use rasterization_ for profile plots to produce smaller files.
-    This is only relevant for vector graphics (e.g.,
-    ``output_file_type: pdf,svg,ps``).
+    This is only relevant for vector graphics (e.g., ``output_file_type:
+    pdf,svg,ps``).
 show_stats: bool, optional (default: True)
     Show basic statistics on the plots.
 show_y_minor_ticklabels: bool, optional (default: False)
@@ -543,9 +546,10 @@ plot_kwargs: dict, optional
     will be derived from the corresponding dataset, e.g., ``{project}``,
     ``{short_name}``, ``{exp}``. Examples: ``default: {levels: 2}, CMIP6:
     {vmin: 200, vmax: 250}``. In addition to the normalization_ options
-    supported by the plot function, the option ``norm: centered``. In this case,
-    the keywords ``vcenter`` and ``halfrange`` should be used instead of
-    ``vmin`` or ``vmax`` (see :class:`~matplotlib.colors.CenteredNorm`).
+    supported by the plot function, the option ``norm: centered`` can be
+    specified. In this case, the keywords ``vcenter`` and ``halfrange`` should
+    be used instead of ``vmin`` or ``vmax`` (see
+    :class:`~matplotlib.colors.CenteredNorm`).
 plot_kwargs_bias: dict, optional
     Optional keyword arguments for the plot function defined by ``plot_func``
     for plotting biases. These keyword arguments update (and potentially
@@ -561,8 +565,8 @@ pyplot_kwargs: dict, optional
     Plot of {long_name}'``, ``xlabel: '{short_name}'``, ``xlim: [0, 5]``.
 rasterize: bool, optional (default: True)
     If ``True``, use rasterization_ for profile plots to produce smaller files.
-    This is only relevant for vector graphics (e.g.,
-    ``output_file_type: pdf,svg,ps``).
+    This is only relevant for vector graphics (e.g., ``output_file_type:
+    pdf,svg,ps``).
 show_y_minor_ticks: bool, optional (default: True)
     Show minor ticks for time on the Y axis.
 show_x_minor_ticks: bool, optional (default: True)

--- a/esmvaltool/diag_scripts/monitor/multi_datasets.py
+++ b/esmvaltool/diag_scripts/monitor/multi_datasets.py
@@ -461,7 +461,7 @@ plot_kwargs: dict, optional
     will be derived from the corresponding dataset, e.g., ``{project}``,
     ``{short_name}``, ``{exp}``. Examples: ``default: {levels: 2}, CMIP6:
     {vmin: 200, vmax: 250}``. In addition to the normalization_ options
-    supported by the plot function, the option ``norm=centered``. In this case,
+    supported by the plot function, the option ``norm: centered``. In this case,
     the keywords ``vcenter`` and ``halfrange`` should be used instead of
     ``vmin`` or ``vmax`` (see :class:`~matplotlib.colors.CenteredNorm`).
 plot_kwargs_bias: dict, optional

--- a/esmvaltool/diag_scripts/monitor/multi_datasets.py
+++ b/esmvaltool/diag_scripts/monitor/multi_datasets.py
@@ -543,7 +543,7 @@ plot_kwargs: dict, optional
     will be derived from the corresponding dataset, e.g., ``{project}``,
     ``{short_name}``, ``{exp}``. Examples: ``default: {levels: 2}, CMIP6:
     {vmin: 200, vmax: 250}``. In addition to the normalization_ options
-    supported by the plot function, the option ``norm=centered``. In this case,
+    supported by the plot function, the option ``norm: centered``. In this case,
     the keywords ``vcenter`` and ``halfrange`` should be used instead of
     ``vmin`` or ``vmax`` (see :class:`~matplotlib.colors.CenteredNorm`).
 plot_kwargs_bias: dict, optional

--- a/esmvaltool/diag_scripts/monitor/multi_datasets.py
+++ b/esmvaltool/diag_scripts/monitor/multi_datasets.py
@@ -226,7 +226,7 @@ plot_kwargs: dict, optional
     will be derived from the corresponding dataset, e.g., ``{project}``,
     ``{short_name}``, ``{exp}``. Examples: ``default: {levels: 2}, CMIP6:
     {vmin: 200, vmax: 250}``. In addition to the normalization_ options
-    supported by the plot function, the option ``norm=centered``. In this case,
+    supported by the plot function, the option ``norm: centered``. In this case,
     the keywords ``vcenter`` and ``halfrange`` should be used instead of
     ``vmin`` or ``vmax`` (see :class:`~matplotlib.colors.CenteredNorm`).
 plot_kwargs_bias: dict, optional


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

Especially when plotting biases, it is very useful to use a [`CenteredNorm`](https://matplotlib.org/stable/api/_as_gen/matplotlib.colors.CenteredNorm.html#matplotlib.colors.CenteredNorm) for the colorbar. This ensures that the '0' is at the center of the colorbar (usually white when using a proper [=diverging] colormap). This PR allows the usage of `norm='centered'` in recipes and sets this as default for bias plots for the diagnostic `monitor/multidatasets.py`.

Example with new default (white = 0).

![centered](https://github.com/ESMValGroup/ESMValTool/assets/32543114/260e2700-8213-4837-8203-756f7756a11a)

Example with old default (white = 15 --> misleading):

![linear](https://github.com/ESMValGroup/ESMValTool/assets/32543114/25095987-1722-4b97-80a5-6d7a2a01b0f7)

In addition, this PR cleans three other very small issues of this diagnostic:
- Simplify doc by using a reference to the rasterization webpage.
- Using the default `rasterize=True` consistently for ALL plot types.
- Ignore iris warnings about using `DEFAULT_EARTH_RADIUS` to get cleaner output.

Link to documentation: https://esmvaltool--3415.org.readthedocs.build/en/3415/api/esmvaltool.diag_scripts.monitor/multi_datasets.html#api-esmvaltool-diag-scripts-monitor-multi-datasets

* * *

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [x] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [x] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [x] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [x] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added

***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
