### PR TITLE
Fix sklearn tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - fix_recipe_filler_bkwds_incompatibility
+      - fix_sklearn_tests
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
       - fix_recipe_filler_bkwds_incompatibility
-      - fix_sklearn_tests
   schedule:
     - cron: '0 0 * * *'
 

--- a/esmvaltool/diag_scripts/mlr/custom_sklearn.py
+++ b/esmvaltool/diag_scripts/mlr/custom_sklearn.py
@@ -670,9 +670,18 @@ class AdvancedPipeline(Pipeline):
 
     def fit_transformers_only(self, x_data, y_data, **fit_kwargs):
         """Fit only ``transform`` steps of Pipeline."""
-        fit_params = _get_fit_parameters(fit_kwargs, self.steps,
-                                         self.__class__)
-        return self._fit(x_data, y_data, **fit_params)
+        # Temporarily set the final estimator to 'passthrough' to avoid fitting
+        # it
+        final_step = self.steps[-1]
+        self.steps[-1] = (final_step[0], 'passthrough')
+
+        # This will now fit all transformers, but not the final estimator
+        self.fit(x_data, y_data, **fit_kwargs)
+
+        # Re-assign the original (non-fitted) final estimator
+        self.steps[-1] = final_step
+
+        return self
 
     def transform_only(self, x_data):
         """Only perform ``transform`` steps of Pipeline."""

--- a/tests/integration/diag_scripts/mlr/test_custom_sklearn_classes.py
+++ b/tests/integration/diag_scripts/mlr/test_custom_sklearn_classes.py
@@ -455,8 +455,11 @@ class TestAdvancedRFE():
         np.testing.assert_array_equal(rfe.support_, [False, False, True])
         est = rfe.estimator_
         assert isinstance(est, AdvancedPipeline)
-        assert est.steps[0][1].transformers_ == [
-            ('passthrough', 'passthrough', [0])]
+        assert len(est.steps[0][1].transformers_) == 1
+        transformer = est.steps[0][1].transformers_[0]
+        assert transformer[0] == 'passthrough'
+        assert isinstance(transformer[1], FunctionTransformer)
+        assert transformer[2] == [0]
         np.testing.assert_allclose(est.steps[1][1].coef_, [1.0])
         np.testing.assert_allclose(est.steps[1][1].intercept_, 0.0, atol=1e-10)
         pred = rfe.predict(self.X_PRED)
@@ -473,8 +476,11 @@ class TestAdvancedRFE():
         np.testing.assert_array_equal(rfe.support_, [True, False, False])
         est = rfe.estimator_
         assert isinstance(est, AdvancedPipeline)
-        assert est.steps[0][1].transformers_ == [
-            ('passthrough', 'passthrough', [0])]
+        assert len(est.steps[0][1].transformers_) == 1
+        transformer = est.steps[0][1].transformers_[0]
+        assert transformer[0] == 'passthrough'
+        assert isinstance(transformer[1], FunctionTransformer)
+        assert transformer[2] == [0]
         np.testing.assert_allclose(est.steps[1][1].coef_, [0.5])
         np.testing.assert_allclose(est.steps[1][1].intercept_, 0.0, atol=1e-10)
         pred = rfe.predict(self.X_PRED)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

Due to a recent update of scikit-learn, [some of our tests fail](https://github.com/ESMValGroup/ESMValTool/actions/runs/7604964418/job/20708571287).

This PR fixes that by
- adapting the our code to the changes of their public API
- not using private API anymore to avoid errors like this in the future

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
- Closes #3504 

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [ ] [🛠][1] ~[Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully~ see https://github.com/ESMValGroup/ESMValTool/pull/3506#issuecomment-1905992518
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [ ] [🛠][1] ~All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful~ see https://github.com/ESMValGroup/ESMValTool/pull/3506#issuecomment-1905992518

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [x] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [x] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [x] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [x] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added

***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
