### PR TITLE
Pin pytest <8.0.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -69,7 +69,7 @@ dependencies:
   - zarr
   # Python packages needed for testing
   - flake8
-  - pytest >=3.9,!=6.0.0rc1,!=6.0.0
+  - pytest >=3.9,!=6.0.0rc1,!=6.0.0, <8.0.0  # github.com/conda-forge/pytest-feedstock/issues/170 and github.com/ESMValGroup/ESMValTool/issues/3513
   - pytest-cov
   - pytest-env
   - pytest-html !=2.1.0

--- a/environment_osx.yml
+++ b/environment_osx.yml
@@ -69,7 +69,7 @@ dependencies:
   - zarr
   # Python packages needed for testing
   - flake8
-  - pytest >=3.9,!=6.0.0rc1,!=6.0.0
+  - pytest >=3.9,!=6.0.0rc1,!=6.0.0, <8.0.0  # github.com/conda-forge/pytest-feedstock/issues/170 and github.com/ESMValGroup/ESMValTool/issues/3513
   - pytest-cov
   - pytest-env
   - pytest-html !=2.1.0

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ REQUIREMENTS = {
     # Execute `pip install .[test]` once and the use `pytest` to run tests
     'test': [
         'flake8',
-        'pytest>=3.9,!=6.0.0rc1,!=6.0.0',
+        'pytest>=3.9,!=6.0.0rc1,!=6.0.0, <8.0.0',  # see environment.yml
         'pytest-cov>=2.10.1',
         'pytest-env',
         'pytest-html!=2.1.0',


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

new pytest=8.0.0 pulls in a very old `pytest-metadata` (2.0.0) while conflicting with the newer version (3.0.0, that holds the env vars that pytest is looking for), see https://github.com/conda-forge/pytest-feedstock/issues/170 for more details; I'll try help at the pytest feedstock, but in the meantime, we should pin pytest to less than 8.0.0 (also a good idea for now, since the new version seems to be rather buggy) - reason for this is `pytest-metadat` has a hard pin on pytest<8 see https://github.com/conda-forge/pytest-metadata-feedstock/blob/main/recipe/meta.yaml

- Closes #3513 

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful
