### PR TITLE
Revert "(Re-)raise exception when imagehash not available"

### DIFF
--- a/esmvaltool/utils/testing/regression/compare.py
+++ b/esmvaltool/utils/testing/regression/compare.py
@@ -18,9 +18,8 @@ from PIL import Image
 
 try:
     import imagehash
-except ImportError as exc:
+except ImportError:
     print("Please `pip install imagehash`")
-    raise exc
 
 IGNORE_FILES: tuple[str, ...] = (
     '*_citation.bibtex',

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,6 @@
 addopts =
     --doctest-modules
     --ignore=doc/sphinx/source/conf.py
-    --ignore=esmvaltool/utils/testing/regression/compare.py
-    --ignore=tests/unit/utils/test_compare.py
     --cov=esmvaltool
     --cov-report=xml:test-reports/coverage.xml
     --cov-report=html:test-reports/coverage_html


### PR DESCRIPTION
Reverts ESMValGroup/ESMValTool#3435

Tests are failing. 