### PR TITLE
Recipe test workflow support recipes in subdirectories

### DIFF
--- a/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/app/compare/bin/compare_task_runner.sh
+++ b/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/app/compare/bin/compare_task_runner.sh
@@ -3,8 +3,8 @@
 BASH_XTRACEFD=1
 set -eux
 
-FOLDER_NAME="${OUTPUT_DIR}/recipe_${KGO_METRIC}*"
-KGO="${KGO_ROOT_PATH}/recipe_${KGO_METRIC}*"
+FOLDER_NAME="${OUTPUT_DIR}/${KGO_METRIC}*"
+KGO="${KGO_ROOT_PATH}/${KGO_METRIC}*"
 
 # Create a variable that defines the path to the compare script.
 COMPARE_SCRIPT="${ESMVALTOOL_DIR}/esmvaltool/utils/testing/regression/compare.py"

--- a/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/app/compare/bin/compare_task_runner.sh
+++ b/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/app/compare/bin/compare_task_runner.sh
@@ -3,8 +3,8 @@
 BASH_XTRACEFD=1
 set -eux
 
-FOLDER_NAME="${OUTPUT_DIR}/${KGO_METRIC}*"
-KGO="${KGO_ROOT_PATH}/${KGO_METRIC}*"
+FOLDER_NAME="${OUTPUT_DIR}/${RECIPE_NAME}*"
+KGO="${KGO_ROOT_PATH}/${RECIPE_NAME}*"
 
 # Create a variable that defines the path to the compare script.
 COMPARE_SCRIPT="${ESMVALTOOL_DIR}/esmvaltool/utils/testing/regression/compare.py"

--- a/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/app/compare/rose-app.conf
+++ b/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/app/compare/rose-app.conf
@@ -2,5 +2,4 @@
 default=rtw-env compare_task_runner.sh
 
 [env]
-KGO_METRIC=${KGO_METRIC}
 KGO_ROOT_PATH=${KGO_ROOT_PATH}

--- a/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/app/process/rose-app.conf
+++ b/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/app/process/rose-app.conf
@@ -1,6 +1,5 @@
 [command]
-default=rtw-env esmvaltool run ${RECIPE_NAME} --config_file=${USER_CONFIG_PATH}
+default=rtw-env esmvaltool run ${RECIPE_PATH} --config_file=${USER_CONFIG_PATH}
 
 [env]
-RECIPE_NAME=${RECIPE_NAME}
 USER_CONFIG_PATH=${USER_CONFIG_PATH}

--- a/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/flow.cylc
+++ b/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/flow.cylc
@@ -87,7 +87,10 @@
             RECIPE_PATH = "${CYLC_TASK_PARAM_medium//--//}.yml"
 
     # Bash variable manipulation `##*--` below strips leading path from recipe
-    # parameter to obtain recipe name (=recipe basename minus yml extension).
+    # parameter to obtain RECIPE_NAME.
+    # RECIPE_NAME is the recipe file basename without yml extension, as used by 
+    # ESMValTool for naming output directories. E.g. for the recipe
+    # examples/recipe_python.yml, RECIPE_NAME=recipe_python
     [[compare<fast>]]
         inherit = None, COMPUTE
         [[[environment]]]

--- a/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/flow.cylc
+++ b/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/flow.cylc
@@ -5,10 +5,12 @@
 [task parameters]
     # `fast` recipes are those taking less than 10 mins.
     # Other recipes should be included in `medium`.
-    fast = radiation_budget, albedolandcover, heatwaves_coldwaves, \
-           autoassess_landsurface_soilmoisture
-    medium = ensclus  # Should be in fast: is in medium temporarily to
-                      # avoid empty variable.
+    fast = recipe_radiation_budget, \
+           recipe_albedolandcover, \
+           recipe_heatwaves_coldwaves, \
+           recipe_autoassess_landsurface_soilmoisture
+    medium = recipe_ensclus  # Should be in fast: is in medium temporarily to
+                             # avoid empty variable.
 
 [scheduling]
     initial cycle point = now
@@ -71,13 +73,13 @@
         inherit = None, COMPUTE
         [[[environment]]]
             ROSE_TASK_APP = process
-            RECIPE_NAME = "recipe_${CYLC_TASK_PARAM_fast}.yml"
+            RECIPE_NAME = "${CYLC_TASK_PARAM_fast}.yml"
 
     [[process<medium>]]
         inherit = None, COMPUTE
         [[[environment]]]
             ROSE_TASK_APP = process
-            RECIPE_NAME = "recipe_${CYLC_TASK_PARAM_medium}.yml"
+            RECIPE_NAME = "${CYLC_TASK_PARAM_medium}.yml"
 
     [[compare<fast>]]
         inherit = None, COMPUTE

--- a/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/flow.cylc
+++ b/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/flow.cylc
@@ -72,6 +72,8 @@
             ROOTPATH_OBS4MIPS = {{ ROOTPATH_OBS4MIPS }}
             ROOTPATH_RAWOBS = {{ ROOTPATH_RAWOBS }}
 
+    # Bash variable substitution below replaces `--` with `/` to obtain path to
+    # recipe.
     [[process<fast>]]
         inherit = None, COMPUTE
         [[[environment]]]
@@ -84,6 +86,8 @@
             ROSE_TASK_APP = process
             RECIPE_PATH = "${CYLC_TASK_PARAM_medium//--//}.yml"
 
+    # Bash variable manipulation `##*--` below strips leading path from recipe
+    # parameter to obtain recipe name (=recipe basename minus yml extension).
     [[compare<fast>]]
         inherit = None, COMPUTE
         [[[environment]]]

--- a/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/flow.cylc
+++ b/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/flow.cylc
@@ -88,14 +88,14 @@
         inherit = None, COMPUTE
         [[[environment]]]
             ROSE_TASK_APP = compare
-            KGO_METRIC = "${CYLC_TASK_PARAM_fast##*--}"
+            RECIPE_NAME = "${CYLC_TASK_PARAM_fast##*--}"
             KGO_ROOT_PATH = {{ KGO_ROOT_PATH }}
 
     [[compare<medium>]]
         inherit = None, COMPUTE
         [[[environment]]]
             ROSE_TASK_APP = compare
-            KGO_METRIC = "${CYLC_TASK_PARAM_medium##*--}"
+            RECIPE_NAME = "${CYLC_TASK_PARAM_medium##*--}"
             KGO_ROOT_PATH = {{ KGO_ROOT_PATH }}
 
 {% include 'site/' ~ SITE ~ '.cylc' %}

--- a/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/flow.cylc
+++ b/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/flow.cylc
@@ -5,10 +5,13 @@
 [task parameters]
     # `fast` recipes are those taking less than 10 mins.
     # Other recipes should be included in `medium`.
+    # Recipe paths are specified relative to esmvaltool/recipes. For recipes in
+    # subdirectories, `--` stands for `/` since the latter is an illegal char.
     fast = recipe_radiation_budget, \
            recipe_albedolandcover, \
            recipe_heatwaves_coldwaves, \
-           recipe_autoassess_landsurface_soilmoisture
+           recipe_autoassess_landsurface_soilmoisture, \
+           examples--recipe_python
     medium = recipe_ensclus  # Should be in fast: is in medium temporarily to
                              # avoid empty variable.
 
@@ -73,26 +76,26 @@
         inherit = None, COMPUTE
         [[[environment]]]
             ROSE_TASK_APP = process
-            RECIPE_NAME = "${CYLC_TASK_PARAM_fast}.yml"
+            RECIPE_NAME = "${CYLC_TASK_PARAM_fast//--//}.yml"
 
     [[process<medium>]]
         inherit = None, COMPUTE
         [[[environment]]]
             ROSE_TASK_APP = process
-            RECIPE_NAME = "${CYLC_TASK_PARAM_medium}.yml"
+            RECIPE_NAME = "${CYLC_TASK_PARAM_medium//--//}.yml"
 
     [[compare<fast>]]
         inherit = None, COMPUTE
         [[[environment]]]
             ROSE_TASK_APP = compare
-            KGO_METRIC = "${CYLC_TASK_PARAM_fast}"
+            KGO_METRIC = "${CYLC_TASK_PARAM_fast##*--}"
             KGO_ROOT_PATH = {{ KGO_ROOT_PATH }}
 
     [[compare<medium>]]
         inherit = None, COMPUTE
         [[[environment]]]
             ROSE_TASK_APP = compare
-            KGO_METRIC = "${CYLC_TASK_PARAM_medium}"
+            KGO_METRIC = "${CYLC_TASK_PARAM_medium##*--}"
             KGO_ROOT_PATH = {{ KGO_ROOT_PATH }}
 
 {% include 'site/' ~ SITE ~ '.cylc' %}

--- a/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/flow.cylc
+++ b/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/flow.cylc
@@ -76,13 +76,13 @@
         inherit = None, COMPUTE
         [[[environment]]]
             ROSE_TASK_APP = process
-            RECIPE_NAME = "${CYLC_TASK_PARAM_fast//--//}.yml"
+            RECIPE_PATH = "${CYLC_TASK_PARAM_fast//--//}.yml"
 
     [[process<medium>]]
         inherit = None, COMPUTE
         [[[environment]]]
             ROSE_TASK_APP = process
-            RECIPE_NAME = "${CYLC_TASK_PARAM_medium//--//}.yml"
+            RECIPE_PATH = "${CYLC_TASK_PARAM_medium//--//}.yml"
 
     [[compare<fast>]]
         inherit = None, COMPUTE

--- a/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/site/jasmin.cylc
+++ b/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/site/jasmin.cylc
@@ -33,13 +33,13 @@
     # memory should be specified, in case the default changes.
     # Variable (fast, medium) must be consistent with flow.cylc.
     # Comment indicates example recorded usage on JASMIN.
-    [[process<fast=autoassess_landsurface_soilmoisture>]]
+    [[process<fast=recipe_autoassess_landsurface_soilmoisture>]]
         # Actual: 1m35s, 2.1 GB on 2024-03-29.
         execution time limit = PT3M
         [[[directives]]]
             --mem = 3G
 
-    [[process<medium=ensclus>]]
+    [[process<medium=recipe_ensclus>]]
         # Actual: 4m23s, 1.5 GB on 2024-03-29.
         execution time limit = PT6M
         [[[directives]]]

--- a/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/site/metoffice.cylc
+++ b/esmvaltool/utils/recipe_test_workflow/recipe_test_workflow/site/metoffice.cylc
@@ -29,19 +29,19 @@
     # memory should be specified, in case the default changes.
     # Variable (fast, medium) must be consistent with flow.cylc.
     # Comment should indicate example recorded usage at Met Office.
-    [[process<fast=autoassess_landsurface_soilmoisture>]]
+    [[process<fast=recipe_autoassess_landsurface_soilmoisture>]]
         # Actual: 0m36s, 2.8 GB on 2024-03-29.
         execution time limit = PT2M
         [[[directives]]]
             --mem = 3G
 
-    [[process<fast=albedolandcover>]]
+    [[process<fast=recipe_albedolandcover>]]
         # Actual: 0m31s, 2.5 GB on 2024-04-08.
         execution time limit = PT2M
         [[[directives]]]
             --mem = 3G
             
-    [[process<medium=ensclus>]]
+    [[process<medium=recipe_ensclus>]]
         # Actual: 2m10s, 2.4 GB on 2024-03-29.
         execution time limit = PT4M
         [[[directives]]]


### PR DESCRIPTION
## Description

Enables recipe test workflow to run recipes in subdirectories of `esmvaltool/recipes`

- Closes #3566
- Link to documentation: 

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful
