### PR TITLE
More flexible file loading in `monitor/multi_datasets.py`

### DIFF
--- a/esmvaltool/diag_scripts/monitor/multi_datasets.py
+++ b/esmvaltool/diag_scripts/monitor/multi_datasets.py
@@ -612,6 +612,7 @@ import seaborn as sns
 from iris.analysis.cartography import area_weights
 from iris.coord_categorisation import add_year
 from iris.coords import AuxCoord
+from iris.exceptions import ConstraintMismatchError
 from matplotlib.colors import CenteredNorm
 from matplotlib.gridspec import GridSpec
 from matplotlib.ticker import (
@@ -1107,7 +1108,22 @@ class MultiDatasets(MonitorBase):
         for dataset in input_data:
             filename = dataset['filename']
             logger.info("Loading %s", filename)
-            cube = iris.load_cube(filename)
+            cubes = iris.load(filename)
+            if len(cubes) == 1:
+                cube = cubes[0]
+            else:
+                var_name = dataset['short_name']
+                try:
+                    cube = cubes.extract_cube(iris.NameConstraint(
+                        var_name=var_name
+                    ))
+                except ConstraintMismatchError:
+                    var_names = [c.var_name for c in cubes]
+                    raise IOError(
+                        f"Cannot load data: multiple variables ({var_names}) "
+                        f"are available in file {filename}, but not the "
+                        f"requested '{var_name}'"
+                    )
 
             # Fix time coordinate if present
             if cube.coords('time', dim_coords=True):

--- a/esmvaltool/diag_scripts/monitor/multi_datasets.py
+++ b/esmvaltool/diag_scripts/monitor/multi_datasets.py
@@ -1117,13 +1117,13 @@ class MultiDatasets(MonitorBase):
                     cube = cubes.extract_cube(iris.NameConstraint(
                         var_name=var_name
                     ))
-                except ConstraintMismatchError:
+                except ConstraintMismatchError as exc:
                     var_names = [c.var_name for c in cubes]
-                    raise IOError(
+                    raise ValueError(
                         f"Cannot load data: multiple variables ({var_names}) "
                         f"are available in file {filename}, but not the "
                         f"requested '{var_name}'"
-                    )
+                    ) from exc
 
             # Fix time coordinate if present
             if cube.coords('time', dim_coords=True):


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

Some files written by the preprocessor can have multiple variables (e.g., ones that contain a [`AuxFactory`](https://scitools-iris.readthedocs.io/en/stable/generated/api/iris.aux_factory.html#module-iris.aux_factory); this is desired by iris and not a bug). Currently, these files cannot be loaded in `monitor/multi_datasets.py` since it uses `iris.load_cube()`. This PR aligns this diagnostic with [`monitor.py`](https://github.com/ESMValGroup/ESMValTool/blob/351c4d3f75fbdc0d59d4b1442d1a84108e5082bd/esmvaltool/diag_scripts/monitor/monitor.py#L154-L163) and allows multi-variable input.


* * *

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [x] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [x] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [x] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [x] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added


***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
