### PR TITLE
[Julia][Temporary] Skip all instances of `esmvaltool install Julia` in CI testing (Circle and Github Actions)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ commands:
             mamba env create >> /logs/conda.txt 2>&1
             conda activate esmvaltool
             pip install << parameters.flags >> ".[<<parameters.extra>>]"> /logs/install.txt 2>&1
-            esmvaltool install Julia > /logs/install_julia.txt 2>&1
+            # esmvaltool install Julia > /logs/install_julia.txt 2>&1
             if [[ "<<parameters.flags>>" != *'--editable'* ]]
             then
               rm -r esmvaltool
@@ -134,7 +134,7 @@ jobs:
             conda activate esmvaltool
             mkdir /logs
             pip install .[test] > /logs/install.txt 2>&1
-            esmvaltool install Julia > /logs/install_julia.txt 2>&1
+            # esmvaltool install Julia > /logs/install_julia.txt 2>&1
       - run:
           name: Check Python code style and mistakes
           command: |
@@ -204,7 +204,7 @@ jobs:
             mamba env create >> /logs/conda.txt 2>&1
             conda activate esmvaltool
             pip install --editable .[develop]
-            esmvaltool install Julia > /logs/install_julia.txt 2>&1
+            # esmvaltool install Julia > /logs/install_julia.txt 2>&1
             git clone https://github.com/ESMValGroup/ESMValCore $HOME/ESMValCore
             pip install --editable $HOME/ESMValCore[develop]
       - log_versions
@@ -271,7 +271,7 @@ jobs:
             # Activate the environment
             set +x; conda activate esmvaltool; set -x
             # install the Julia dependencies
-            esmvaltool install Julia > /logs/install_Julia.txt 2>&1
+            # esmvaltool install Julia > /logs/install_Julia.txt 2>&1
             # Log versions
             mamba env export > /logs/environment.yml
             # Test installation

--- a/.github/workflows/run-tests-monitor.yml
+++ b/.github/workflows/run-tests-monitor.yml
@@ -48,8 +48,8 @@ jobs:
         run: pip install pytest-monitor
       - name: Install ESMValTool
         run: pip install -e .[develop] 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/install.txt
-      - name: Install Julia dependencies
-        run: esmvaltool install Julia
+      # - name: Install Julia dependencies
+      #   run: esmvaltool install Julia
       - name: Run tests
         run: >
           pytest -n 2 -m "not installation" --db ../.pymon 2>&1

--- a/.github/workflows/test-development.yml
+++ b/.github/workflows/test-development.yml
@@ -47,8 +47,8 @@ jobs:
           python -V 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/python_version.txt
       - name: Install ESMValTool
         run: pip install -e .[develop] 2>&1 | tee develop_test_linux_artifacts_python_${{ matrix.python-version }}/install.txt
-      - name: Install Julia dependencies
-        run: esmvaltool install Julia
+      # - name: Install Julia dependencies
+      #   run: esmvaltool install Julia
       - name: Install development version of ESMValCore
         run: |
           cd ..

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,8 +45,8 @@ jobs:
         run: conda list
       - name: Install ESMValTool
         run: pip install -e .[develop] 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/install.txt
-      - name: Install Julia dependencies
-        run: esmvaltool install Julia
+      # - name: Install Julia dependencies
+      #   run: esmvaltool install Julia
       - name: Export Python minor version
         run: echo "pver1=$(python -V)" >> $GITHUB_ENV
       - name: Exit if Python minor version changed

--- a/doc/sphinx/source/quickstart/installation.rst
+++ b/doc/sphinx/source/quickstart/installation.rst
@@ -172,7 +172,7 @@ Installation of subpackages
 ---------------------------
 
 The diagnostics bundled in ESMValTool are scripts in four different programming
-languages: Python, NCL, R, and Julia.
+languages: Python, NCL, R, and Julia (currently at risk!).
 
 There are three language specific packages available:
 
@@ -208,6 +208,9 @@ one or more of the packages for other languages.
 
 Installation of Julia dependencies
 ----------------------------------
+
+.. note:: 
+    This is currently at risk!
 
 If you want to use the ESMValTool Julia functionality, you will also need to
 install Julia. If you are just getting started, we suggest that you

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,7 @@ RUN mamba update -y conda mamba pip && mamba env create --name esmvaltool --file
 SHELL ["conda", "run", "--name", "esmvaltool", "/bin/bash", "-c"]
 
 COPY . .
-RUN pip install --no-cache . && esmvaltool install Julia
+# RUN pip install --no-cache . && esmvaltool install Julia
+RUN pip install --no-cache .
 
 ENTRYPOINT ["conda", "run", "--name", "esmvaltool", "esmvaltool"]

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -11,4 +11,5 @@ RUN mamba update -y conda mamba pip && mamba env create --name esmvaltool --file
 SHELL ["conda", "run", "--name", "esmvaltool", "/bin/bash", "-c"]
 
 COPY . .
-RUN pip install --no-cache .[test] && esmvaltool install Julia && pip uninstall esmvaltool -y
+# RUN pip install --no-cache .[test] && esmvaltool install Julia && pip uninstall esmvaltool -y
+RUN pip install --no-cache .[test] && pip uninstall esmvaltool -y

--- a/docker/Dockerfile.exp
+++ b/docker/Dockerfile.exp
@@ -12,7 +12,8 @@ RUN    mamba update -y conda mamba pip \
 SHELL ["conda", "run", "--name", "esmvaltool", "/bin/bash", "-c"]
 
 COPY . .
-RUN pip install --no-cache git+https://github.com/ESMValGroup/ESMValCore.git#egg=ESMValCore . \
-    && esmvaltool install Julia
+# RUN pip install --no-cache git+https://github.com/ESMValGroup/ESMValCore.git#egg=ESMValCore . \
+#     && esmvaltool install Julia
+RUN pip install --no-cache git+https://github.com/ESMValGroup/ESMValCore.git#egg=ESMValCore .
 
 ENTRYPOINT ["conda", "run", "--name", "esmvaltool", "esmvaltool"]

--- a/tests/integration/test_diagnostic_run.py
+++ b/tests/integration/test_diagnostic_run.py
@@ -65,8 +65,7 @@ SCRIPTS = [
                  # marks=pytest.mark.skipif(
                  #     sys.platform == 'darwin',
                  #     reason="ESMValTool Julia not supported on OSX"))
-                 marks=pytest.mark.skip(
-                     reason="Julia is currently broken.")
+                 marks=pytest.mark.skip(reason="Julia is currently broken."))
 ]
 
 

--- a/tests/integration/test_diagnostic_run.py
+++ b/tests/integration/test_diagnostic_run.py
@@ -62,9 +62,11 @@ SCRIPTS = [
                      sys.platform == 'darwin',
                      reason="ESMValTool R not supported on OSX")),
     pytest.param('diagnostic.jl',
-                 marks=pytest.mark.skipif(
-                     sys.platform == 'darwin',
-                     reason="ESMValTool Julia not supported on OSX"))
+                 # marks=pytest.mark.skipif(
+                 #     sys.platform == 'darwin',
+                 #     reason="ESMValTool Julia not supported on OSX"))
+                 marks=pytest.mark.skip(
+                     reason="Julia is currently broken.")
 ]
 
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

Workaround for #3746 

**Current information**

`libcurl >8.10` breaks Julia installations - see https://github.com/ESMValGroup/ESMValTool/pull/3755

This PR is an alternative to pinning `curl` in our environment (the only purpose for that pin would be to fix Julia's issues for us, the pin may result in environment conflicts in the future).

**Obsolete information**

Currently Julia package installs are broken on at least two fronts, see comments in #3746 and my unsuccessful attempts at averting issues in #3747 - these are recent issues and they don't stem from a new version of Julia; if at all, it's actually rather hard to update it, due to env insolvency (latest Julia=1.10.4 can not be installed in our env). We can't have our tests constantly broken, so the peasant solution here is anything but elegant, but it is practical :beer: 
I have also been pestering the NetCDF jll folk at https://github.com/JuliaGeo/NetCDF.jl/issues/195

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful
