### PR TITLE
Pin mamba<2 for conda-lock: solution by Ben Mares @maresb

### DIFF
--- a/.github/workflows/create-condalock-file.yml
+++ b/.github/workflows/create-condalock-file.yml
@@ -10,6 +10,7 @@ on:
       - pin_conda-lock
   schedule:
     - cron: '0 4 */10 * *'
+workflow_dispatch:
 
 # Required shell entrypoint to have properly configured bash shell
 defaults:
@@ -30,7 +31,6 @@ jobs:
           activate-environment: esmvaltool-fromlock
           python-version: "3.12"
           miniforge-version: "latest"
-          miniforge-variant: Mambaforge
           use-mamba: true
       - name: Show conda config
         run: |
@@ -38,7 +38,7 @@ jobs:
           conda --version
           # setup-miniconda@v3 installs an old conda and mamba
           # forcing a modern mamba updates both mamba and conda
-          conda install -c conda-forge "mamba>=1.4.8"
+          conda install -c conda-forge "mamba>=1.4.8,<2"
           conda config --show-sources
           conda config --show
           conda --version

--- a/.github/workflows/create-condalock-file.yml
+++ b/.github/workflows/create-condalock-file.yml
@@ -4,9 +4,10 @@ on:
   # Trigger on push on main or other branch for testing
   # NOTE that push: main will create the file very often
   # and hence lots of automated PRs
-  # push:
-  #   branches:
+  push:
+    branches:
   #     - main
+      - pin_conda-lock
   schedule:
     - cron: '0 4 */10 * *'
 
@@ -47,7 +48,7 @@ jobs:
           which python
           python --version
       - name: Install conda-lock
-        run: mamba install -y -c conda-forge conda-lock
+        run: mamba install -y -c conda-forge "conda-lock<2.5.7"
       - name: Check version of conda-lock
         run: conda-lock --version
       - name: Create conda lock file for linux-64

--- a/.github/workflows/create-condalock-file.yml
+++ b/.github/workflows/create-condalock-file.yml
@@ -10,7 +10,6 @@ on:
       - pin_conda-lock
   schedule:
     - cron: '0 4 */10 * *'
-workflow_dispatch:
 
 # Required shell entrypoint to have properly configured bash shell
 defaults:

--- a/.github/workflows/create-condalock-file.yml
+++ b/.github/workflows/create-condalock-file.yml
@@ -48,7 +48,7 @@ jobs:
           which python
           python --version
       - name: Install conda-lock
-        run: mamba install -y -c conda-forge "conda-lock<2.5.7"
+        run: mamba install -y -c conda-forge conda-lock
       - name: Check version of conda-lock
         run: conda-lock --version
       - name: Create conda lock file for linux-64

--- a/.github/workflows/create-condalock-file.yml
+++ b/.github/workflows/create-condalock-file.yml
@@ -4,10 +4,9 @@ on:
   # Trigger on push on main or other branch for testing
   # NOTE that push: main will create the file very often
   # and hence lots of automated PRs
-  push:
-    branches:
+  # push:
+  #   branches:
   #     - main
-      - pin_conda-lock
   schedule:
     - cron: '0 4 */10 * *'
 
@@ -37,6 +36,7 @@ jobs:
           conda --version
           # setup-miniconda@v3 installs an old conda and mamba
           # forcing a modern mamba updates both mamba and conda
+          # pin <2 due to https://github.com/ESMValGroup/ESMValTool/pull/3771
           conda install -c conda-forge "mamba>=1.4.8,<2"
           conda config --show-sources
           conda config --show


### PR DESCRIPTION
Our conda lock file generation action is currently failing, the issue is obscure, but I did ask Ben at `conda-lock` if he's got any ideas, see https://github.com/conda/conda-lock/issues/732 - ~for now I am testing about, see if pinning mamba helps~, and as suggested by @maresb pinning mamba<2 is the correct approach, cheers, Ben! :beer: 

~Well, we'll test whenever core conda decides to work again, that is...~