### PR TITLE
Pin pys2index >=0.1.5 in osx environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - pin_pys2index_osx
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - pin_pys2index_osx
   schedule:
     - cron: '0 0 * * *'
 

--- a/environment_osx.yml
+++ b/environment_osx.yml
@@ -52,7 +52,7 @@ dependencies:
   - psy-reg >=1.5.0
   - psy-simple >=1.5.0
   - pyproj >=2.1
-  - pys2index  # only from conda-forge
+  - pys2index >=0.1.5  # only from conda-forge
   - python >=3.10,<3.13
   - python-cdo
   - python-dateutil

--- a/environment_osx.yml
+++ b/environment_osx.yml
@@ -52,7 +52,7 @@ dependencies:
   - psy-reg >=1.5.0
   - psy-simple >=1.5.0
   - pyproj >=2.1
-  - pys2index >=0.1.5  # only from conda-forge
+  - pys2index >=0.1.5  # only from conda-forge; https://github.com/ESMValGroup/ESMValTool/pull/3792
   - python >=3.10,<3.13
   - python-cdo
   - python-dateutil


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

[Github Actions tests for OSX](https://github.com/ESMValGroup/ESMValTool/actions/runs/11545395202) are failing; this is coming from `pys2index`, and I noticed the environment installs an old version (0.1.4), so I am pinning it in an attempt to avert the fails; I suspect this will not fix the problem, since what the actual problem is I believe it to be the start of the incompatibility saga of M1 ARM processors vs generic intel-compiled code, but fingers crossed a simple pin will fix the barf :beer: 

EDIT: the pin worked! https://github.com/ESMValGroup/ESMValTool/actions/runs/11553713844/job/32155462033?pr=3792

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->


## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

