### PR TITLE
Fix issue to private func deprecation in iris=3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - fix_issues_iris311
   schedule:
     - cron: '0 0 * * *'
 

--- a/esmvaltool/diag_scripts/shared/_supermeans.py
+++ b/esmvaltool/diag_scripts/shared/_supermeans.py
@@ -13,7 +13,6 @@ import os.path
 import cf_units
 import iris
 import iris.coord_categorisation
-from iris.coord_categorisation import _pt_date
 import numpy as np
 
 
@@ -204,6 +203,28 @@ def add_start_hour(cube, coord, name='diurnal_sampling_hour'):
     bounds exist.
     """
     _add_categorised_coord(cube, name, coord, start_hour_from_bounds)
+
+
+# lifted from iris==3.10 last iris to have it in iris.coord_categorisation
+# Private "helper" function
+def _pt_date(coord, time):
+    """Return the datetime of a time-coordinate point.
+
+    Parameters
+    ----------
+    coord : Coord
+        Coordinate (must be Time-type).
+    time : float
+        Value of a coordinate point.
+
+    Returns
+    -------
+    cftime.datetime
+
+    """
+    # NOTE: All of the currently defined categorisation functions are
+    # calendar operations on Time coordinates.
+    return coord.units.num2date(time, only_use_cftime_datetimes=True)
 
 
 def start_hour_from_bounds(coord, _, bounds):


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

Closes #3795 

Bottom line: a shared utility in `shared` was using an import of a private function from `iris.coord_categorisation` - a bad thing to have left unnoticed until said private function was retired or changed its name in iris=3.11 - on its own, it's a decent little function, so I plucked it out of iris=3.10, and moved it in our code. Hey presto! No needs for tests since we don't test that utility (sigh!).

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [ ] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful
