### PR TITLE
Update environment: pin `iris>=3.11`, unpin `cartopy` and allow for `numpy >=2`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - update_environment_Nov24
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - update_environment_Nov24
   schedule:
     - cron: '0 0 * * *'
 

--- a/environment.yml
+++ b/environment.yml
@@ -10,20 +10,20 @@ channels:
 
 dependencies:
   - aiohttp
-  - cartopy <0.24  # https://github.com/ESMValGroup/ESMValTool/issues/3767
+  - cartopy
   - cdo >=2.3.0
   - cdsapi
   - cf-units
   - cfgrib
   - cftime
   - cmocean
-  - curl <8.10
+  - curl <8.10  # https://github.com/ESMValGroup/ESMValTool/issues/3758
   - cython
   - dask !=2024.8.0  # https://github.com/dask/dask/issues/11296
   - distributed
   - ecmwf-api-client
   - eofs
-  - esmpy  # <8.6 safe https://github.com/SciTools/iris-esmf-regrid/issues/415
+  - esmpy
   - esmvalcore 2.11.*
   - fiona
   - fire
@@ -41,7 +41,7 @@ dependencies:
   - nc-time-axis
   - netCDF4
   - numba
-  - numpy !=1.24.3,<2.0  # severe masking bug
+  - numpy !=1.24.3
   - openpyxl
   - packaging
   - pandas==2.1.4  # unpin when ESMValCore released with https://github.com/ESMValGroup/ESMValCore/pull/2529

--- a/environment.yml
+++ b/environment.yml
@@ -41,7 +41,7 @@ dependencies:
   - nc-time-axis
   - netCDF4
   - numba
-  - numpy !=1.24.3
+  - numpy !=1.24.3  # severe masking bug
   - openpyxl
   - packaging
   - pandas==2.1.4  # unpin when ESMValCore released with https://github.com/ESMValGroup/ESMValCore/pull/2529

--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
   - fsspec
   - gdal >=3.9.0
   - importlib_metadata <8  # https://github.com/ESMValGroup/ESMValTool/issues/3699 only for Python 3.10/11 and esmpy<8.6
-  - iris >=3.6.1
+  - iris >=3.11
   - iris-esmf-regrid >=0.10.0  # github.com/SciTools-incubator/iris-esmf-regrid/pull/342
   - jinja2
   - joblib

--- a/environment_osx.yml
+++ b/environment_osx.yml
@@ -22,7 +22,7 @@ dependencies:
   - distributed
   - ecmwf-api-client
   - eofs
-  - esmpy  # <8.6 safe https://github.com/SciTools/iris-esmf-regrid/issues/415
+  - esmpy
   - esmvalcore 2.11.*
   - fiona
   - fire

--- a/environment_osx.yml
+++ b/environment_osx.yml
@@ -29,7 +29,7 @@ dependencies:
   - fsspec
   - gdal >=3.9.0
   - importlib_metadata <8  # https://github.com/ESMValGroup/ESMValTool/issues/3699 only for Python 3.10/11 and esmpy<8.6
-  - iris >=3.6.1
+  - iris >=3.11
   - iris-esmf-regrid >=0.10.0  # github.com/SciTools-incubator/iris-esmf-regrid/pull/342
   - jinja2
   - joblib

--- a/environment_osx.yml
+++ b/environment_osx.yml
@@ -10,7 +10,7 @@ channels:
 
 dependencies:
   - aiohttp
-  - cartopy <0.24  # https://github.com/ESMValGroup/ESMValTool/issues/3767
+  - cartopy
   - cdo >=2.3.0
   - cdsapi
   - cf-units
@@ -40,7 +40,7 @@ dependencies:
   - nc-time-axis
   - netCDF4
   - numba
-  - numpy !=1.24.3,<2.0  # severe masking bug
+  - numpy !=1.24.3  # severe masking bug
   - openpyxl
   - packaging
   - pandas==2.1.4  # unpin when ESMValCore released with https://github.com/ESMValGroup/ESMValCore/pull/2529

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ REQUIREMENTS = {
         'scikit-image',
         'scikit-learn>=1.4.0',  # github.com/ESMValGroup/ESMValTool/issues/3504
         'scipy',
-        'scitools-iris>=3.6.1',
+        'scitools-iris>=3.11',
         'seaborn',
         'seawater',
         'shapely>=2',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ REQUIREMENTS = {
     # Use with pip install . to install from source
     'install': [
         'aiohttp',
-        'cartopy<0.24',  # github.com/ESMValGroup/ESMValTool/issues/3767
+        'cartopy',
         'cdo',
         'cdsapi',
         'cf-units',


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

- We are now using `iris=3.11` which is what we need to be able to unpin `cartopy`, see @schlunma 's comment https://github.com/ESMValGroup/ESMValTool/issues/3769#issuecomment-2456938359
- to not risk getting `cartopy==0.24` with an older iris eg `iris==3.10`, and hence get the bug we pinned cartopy for in the first place, we should pin `iris>=3.11`
- `iris==3.11` works well with `numpy>=2` so we remove the upper pin in our own environment; note, however, that numpy2 is not yet available to us, due to `ncl` (that holds `esmpy` from going past 8.6, and makes us keep that silly `importlib_metadata<8` pin, see https://github.com/ESMValGroup/ESMValTool/issues/3699)

Closes #3769 
Contributes to https://github.com/ESMValGroup/ESMValTool/issues/3812

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful
