### PR TITLE
Fix circle ci nightly test installation from source development mode (and test mode) that times out

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ commands:
             mkdir /logs
             mamba env create
             conda activate esmvaltool
-            conda env list >> /logs/conda.txt
+            conda list >> /logs/conda.txt
             pip install << parameters.flags >> ".[<<parameters.extra>>]"> /logs/install.txt 2>&1
             esmvaltool install Julia > /logs/install_julia.txt 2>&1
             if [[ "<<parameters.flags>>" != *'--editable'* ]]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,8 +202,9 @@ jobs:
             # https://docs.esmvaltool.org/en/latest/quickstart/installation.html#install-from-source
             . /opt/conda/etc/profile.d/conda.sh
             mkdir /logs
-            mamba env create >> /logs/conda.txt 2>&1
+            mamba env create
             conda activate esmvaltool
+            mamba list >> /logs/conda.txt 2>&1
             pip install --editable .[develop]
             esmvaltool install Julia > /logs/install_julia.txt 2>&1
             git clone https://github.com/ESMValGroup/ESMValCore $HOME/ESMValCore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,7 +204,7 @@ jobs:
             mkdir /logs
             mamba env create
             conda activate esmvaltool
-            mamba list >> /logs/conda.txt 2>&1
+            mamba list >> /logs/conda.txt
             pip install --editable .[develop]
             esmvaltool install Julia > /logs/install_julia.txt 2>&1
             git clone https://github.com/ESMValGroup/ESMValCore $HOME/ESMValCore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ commands:
             mkdir /logs
             mamba env create >> /logs/conda.txt 2>&1
             conda activate esmvaltool
-            pip install << parameters.flags >> ".[<<parameters.extra>>]"> /logs/install.txt 2>&1
+            pip install << parameters.flags >> ".[<<parameters.extra>>]"  #  > /logs/install.txt 2>&1
             conda list curl
             conda list julia
             esmvaltool install Julia # > /logs/install_julia.txt 2>&1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,11 +90,10 @@ commands:
             # Install
             . /opt/conda/etc/profile.d/conda.sh
             mkdir /logs
-            mamba env create  # >> /logs/conda.txt - 2>&1 this contains zero information, output flushed when env created
+            mamba env create
             conda activate esmvaltool
+            conda env list >> /logs/conda.txt
             pip install << parameters.flags >> ".[<<parameters.extra>>]"> /logs/install.txt 2>&1
-            conda list curl
-            conda list julia
             esmvaltool install Julia > /logs/install_julia.txt 2>&1
             if [[ "<<parameters.flags>>" != *'--editable'* ]]
             then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,12 +90,12 @@ commands:
             # Install
             . /opt/conda/etc/profile.d/conda.sh
             mkdir /logs
-            mamba env create >> /logs/conda.txt 2>&1
+            mamba env create  # >> /logs/conda.txt - 2>&1 this contains zero information, output flushed when env created
             conda activate esmvaltool
-            pip install << parameters.flags >> ".[<<parameters.extra>>]"  #  > /logs/install.txt 2>&1
+            pip install << parameters.flags >> ".[<<parameters.extra>>]"> /logs/install.txt 2>&1
             conda list curl
             conda list julia
-            esmvaltool install Julia # > /logs/install_julia.txt 2>&1
+            esmvaltool install Julia > /logs/install_julia.txt 2>&1
             if [[ "<<parameters.flags>>" != *'--editable'* ]]
             then
               rm -r esmvaltool

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,9 @@ commands:
             mamba env create >> /logs/conda.txt 2>&1
             conda activate esmvaltool
             pip install << parameters.flags >> ".[<<parameters.extra>>]"> /logs/install.txt 2>&1
-            esmvaltool install Julia > /logs/install_julia.txt 2>&1
+            conda list curl
+            conda list julia
+            esmvaltool install Julia # > /logs/install_julia.txt 2>&1
             if [[ "<<parameters.flags>>" != *'--editable'* ]]
             then
               rm -r esmvaltool

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - cfgrib
   - cftime
   - cmocean
-  - curl <8.10  # https://github.com/ESMValGroup/ESMValTool/issues/3758
+  - curl <8.10  # https://github.com/ESMValGroup/ESMValTool/issues/3758 - dummy change trigger test
   - cython
   - dask !=2024.8.0  # https://github.com/dask/dask/issues/11296
   - distributed


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
The problem here is that this block of testing from Circle configuration:


```
            # Install
            . /opt/conda/etc/profile.d/conda.sh
            mkdir /logs
            mamba env create >> /logs/conda.txt 2>&1
            conda activate esmvaltool
            pip install << parameters.flags >> ".[<<parameters.extra>>]"> /logs/install.txt 2>&1
            esmvaltool install Julia > /logs/install_julia.txt 2>&1
            if [[ "<<parameters.flags>>" != *'--editable'* ]]
            then
              rm -r esmvaltool
            fi
```

is taking about 10-11 minutes (botj conda env creation **and** Julia install are taking a long time) and that exceeds Circle's 10min limit with no output, since we are not piping much to stdout, but rather, we are piping to file.

Since fixing the environment with modern dependencies and other such things is beyond the scope of this PR, the fix here is to divert the conda env recording from `mamba create environment` to a dedicated `conda env list` piped to file. The way mamba is set these days is that it fails to record the deps in a nice list when it finishes the env creation anyway, so the file contains exactly poopall.

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [ ] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

