### PR TITLE
setup-miniconda default mamba needs updated: pin mamba to latest in two Github Actions to observe if any fails

### DIFF
--- a/.github/workflows/install-from-conda.yml
+++ b/.github/workflows/install-from-conda.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - pin-mamba-ga
   schedule:
     - cron: '0 4 * * *'
 
@@ -28,6 +29,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           miniforge-version: "latest"
           use-mamba: true
+          mamba-version: "2.0.5"
       - run: mkdir -p conda_install_linux_artifacts_python_${{ matrix.python-version }}
       - name: Record versions
         run: |

--- a/.github/workflows/test-development.yml
+++ b/.github/workflows/test-development.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - main
+      - pin-mamba-ga
   schedule:
     - cron: '0 0 * * *'
 
@@ -39,6 +40,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           miniforge-version: "latest"
           use-mamba: true
+          mamba-version: "2.0.5"
       - run: mkdir -p develop_test_linux_artifacts_python_${{ matrix.python-version }}
       - name: Record versions
         run: |


### PR DESCRIPTION
This is test PR to observe the behaviour of pinning mamba to latest, during setup-miniconda step - we have seen quite frequent random (mostly HTTP-related but not only) issues with the base env solving, it is possible these are due to a fairly old mamba being used (1.5), see [example](https://github.com/ESMValGroup/ESMValTool/actions/runs/12990988279/job/36227450397)

After quite a few test runs, 100% pass rate - so I opened an issue about updating the default mamba at upstream https://github.com/conda-incubator/setup-miniconda/issues/392