### PR TITLE
Extend broken recipe policy

### DIFF
--- a/doc/sphinx/source/community/broken_recipe_policy.rst
+++ b/doc/sphinx/source/community/broken_recipe_policy.rst
@@ -16,7 +16,7 @@ For this, the affected recipe will be added to the :ref:`list of broken recipes 
 number of the last known release in which the recipe was still working.
 If a recipe continues to be broken for three releases of the ESMValTool (about one year) and no recipe maintainer could be found
 during this time, or the affected recipe and diagnostics will be retired. This means the recipe and diagnostic code are
-moved from the folders ``esmvaltool/recipe`` and ``esmvaltool/diag_scripts`` to ``archive/legacy_recipes`` and ``archive/legacy_diag_scripts`` by the release manager. In case of recipes considered
+moved from the folders ``esmvaltool/recipes`` and ``esmvaltool/diag_scripts`` to ``archive/legacy_recipes`` and ``archive/legacy_diag_scripts`` by the release manager. In case of recipes considered
 outdated by the :ref:`Maintaining a recipe<recipe-maintainer>`, a pull request can be opened to move recipe and diagnostic code to the ``archive`` folders at any time.
 
 In both cases, the scientific documentation of the recipe (and diagnostics) will be kept in the user and developer guide with an

--- a/doc/sphinx/source/community/broken_recipe_policy.rst
+++ b/doc/sphinx/source/community/broken_recipe_policy.rst
@@ -6,7 +6,7 @@ Broken /outdated recipe policy
 Recipes might stop working for different reasons. Among those are, for instance, withdrawal of datasets
 used by the recipe (i.e. the recipe contains data that are no longer publicly available), backward incompatible development
 of the ESMValTool including new features or retiring old ones as well as
-changes to Python or used dependencies such as library functions. Recipes might also be considered outdated by the :ref:`Maintaining a recipe<recipe-maintainer>`.
+changes to Python or used dependencies such as library functions. Recipes might also be considered outdated by the :ref:`recipe maintainer<recipe-maintainer>`.
 
 In case a recipe stopped working, the :ref:`Maintaining a recipe<recipe-maintainer>` is contacted by the technical lead development team (`@ESMValGroup/technical-lead-development-team`_) to find
 a solution, fixing the affected recipe and checking the scientific output after applying the fix. If no recipe maintainer is

--- a/doc/sphinx/source/community/broken_recipe_policy.rst
+++ b/doc/sphinx/source/community/broken_recipe_policy.rst
@@ -17,7 +17,7 @@ number of the last known release in which the recipe was still working.
 If a recipe continues to be broken for three releases of the ESMValTool (about one year) and no recipe maintainer could be found
 during this time, or the affected recipe and diagnostics will be retired. This means the recipe and diagnostic code are
 moved from the folders ``esmvaltool/recipes`` and ``esmvaltool/diag_scripts`` to ``archive/legacy_recipes`` and ``archive/legacy_diag_scripts`` by the release manager. In case of recipes considered
-outdated by the :ref:`Maintaining a recipe<recipe-maintainer>`, a pull request can be opened to move recipe and diagnostic code to the ``archive`` folders at any time.
+outdated by the :ref:`recipe maintainer<recipe-maintainer>`, a pull request can be opened to move recipe and diagnostic code to the ``archive`` folders at any time.
 
 In both cases, the scientific documentation of the recipe (and diagnostics) will be kept in the user and developer guide with an
 additional note and link to the last release in which the recipe was still fully functional and a reference to the ``archive`` folder.

--- a/doc/sphinx/source/community/broken_recipe_policy.rst
+++ b/doc/sphinx/source/community/broken_recipe_policy.rst
@@ -1,22 +1,29 @@
 .. _broken-recipe-policy:
 
-Broken recipe policy
-====================
+Broken /outdated recipe policy
+==============================
 
 Recipes might stop working for different reasons. Among those are, for instance, withdrawal of datasets
 used by the recipe (i.e. the recipe contains data that are no longer publicly available), backward incompatible development
 of the ESMValTool including new features or retiring old ones as well as
-changes to Python or used dependencies such as library functions.
-In such cases, the :ref:`Maintaining a recipe<recipe-maintainer>` is contacted by the technical lead development team (`@ESMValGroup/technical-lead-development-team`_) to find
+changes to Python or used dependencies such as library functions. Recipes might also be considered outdated by the :ref:`Maintaining a recipe<recipe-maintainer>`.
+
+In case a recipe stopped working, the :ref:`Maintaining a recipe<recipe-maintainer>` is contacted by the technical lead development team (`@ESMValGroup/technical-lead-development-team`_) to find
 a solution, fixing the affected recipe and checking the scientific output after applying the fix. If no recipe maintainer is
 available, such recipes will be flagged by the release manager during the
 :ref:`Release schedule and procedure<preparation-new-release>` as "broken".
 For this, the affected recipe will be added to the :ref:`list of broken recipes <broken-recipe-list>`, together with the version
 number of the last known release in which the recipe was still working.
 If a recipe continues to be broken for three releases of the ESMValTool (about one year) and no recipe maintainer could be found
-during this time, the affected recipe and diagnostics will be retired. This means the recipe and diagnostic code are
-removed from the ESMValTool main branch by the release manager and thus will not be included in future releases.
-Only the scientific documentation of the recipe (and diagnostics) will be kept in the user and developer guide with an
-additional note and link to the last release in which the recipe was still fully functional.
+during this time, or the affected recipe and diagnostics will be retired. This means the recipe and diagnostic code are
+moved from the folders ``esmvaltool/recipe`` and ``esmvaltool/diag_scripts`` to ``archive/legacy_recipes`` and ``archive/legacy_diag_scripts`` by the release manager. In case of recipes considered
+outdated by the :ref:`Maintaining a recipe<recipe-maintainer>`, a pull request can be opened to move recipe and diagnostic code to the ``archive`` folders at any time.
+
+In both cases, the scientific documentation of the recipe (and diagnostics) will be kept in the user and developer guide with an
+additional note and link to the last release in which the recipe was still fully functional and a reference to the ``archive`` folder.
+The documentation of the retired recipe in the user and developer guide is moved into the category "legacy recipes" to distinguish
+between currently available and functional recipes and such legacy recipes.
+
+Special care needs to be taken when retiring diagnostic scripts to avoid unintentionally affecting other recipes or diagnostics. 
 
 .. _`@ESMValGroup/technical-lead-development-team`: https://github.com/orgs/ESMValGroup/teams/technical-lead-development-team

--- a/doc/sphinx/source/community/broken_recipe_policy.rst
+++ b/doc/sphinx/source/community/broken_recipe_policy.rst
@@ -1,6 +1,6 @@
 .. _broken-recipe-policy:
 
-Broken /outdated recipe policy
+Broken/outdated recipe policy
 ==============================
 
 Recipes might stop working for different reasons. Among those are, for instance, withdrawal of datasets

--- a/doc/sphinx/source/community/broken_recipe_policy.rst
+++ b/doc/sphinx/source/community/broken_recipe_policy.rst
@@ -8,7 +8,7 @@ used by the recipe (i.e. the recipe contains data that are no longer publicly av
 of the ESMValTool including new features or retiring old ones as well as
 changes to Python or used dependencies such as library functions. Recipes might also be considered outdated by the :ref:`recipe maintainer<recipe-maintainer>`.
 
-In case a recipe stopped working, the :ref:`Maintaining a recipe<recipe-maintainer>` is contacted by the technical lead development team (`@ESMValGroup/technical-lead-development-team`_) to find
+In case a recipe stopped working, the :ref:`recipe maintainer<recipe-maintainer>` is contacted by the technical lead development team (`@ESMValGroup/technical-lead-development-team`_) to find
 a solution, fixing the affected recipe and checking the scientific output after applying the fix. If no recipe maintainer is
 available, such recipes will be flagged by the release manager during the
 :ref:`Release schedule and procedure<preparation-new-release>` as "broken".


### PR DESCRIPTION
## Description

This PR extends the broken recipe policy to include retiring outdated recipes by the recipe maintainer and to allow for moving broken/outdated recipes and diagnostics to be newly created folders ``archive/recipes`` and ``archive/diag_scripts``.

See discussion https://github.com/ESMValGroup/ESMValTool/discussions/3912

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful