### PR TITLE
Fix CDS downloader scripts

### DIFF
--- a/esmvaltool/cmorizers/data/downloaders/cds.py
+++ b/esmvaltool/cmorizers/data/downloaders/cds.py
@@ -32,6 +32,7 @@ class CDSDownloader(BaseDownloader):
         Some products have a subfix appended to their name for certain
         variables. This parameter is to specify it, by default ''
     """
+
     def __init__(self,
                  product_name,
                  config,
@@ -39,10 +40,11 @@ class CDSDownloader(BaseDownloader):
                  dataset,
                  dataset_info,
                  overwrite,
-                 extra_name=''):
+                 extra_name='',
+                 cds_url='https://cds.climate.copernicus.eu/api'):
         super().__init__(config, dataset, dataset_info, overwrite)
         try:
-            self._client = cdsapi.Client()
+            self._client = cdsapi.Client(url=cds_url)
         except Exception as ex:
             if str(ex).endswith(".cdsapirc"):
                 logger.error(

--- a/esmvaltool/cmorizers/data/downloaders/datasets/cds_xch4.py
+++ b/esmvaltool/cmorizers/data/downloaders/datasets/cds_xch4.py
@@ -26,16 +26,15 @@ def download_dataset(config, dataset, dataset_info, start_date, end_date,
     downloader = CDSDownloader(
         product_name='satellite-methane',
         request_dictionary={
-            'format': 'tgz',
             'processing_level': 'level_3',
             'variable': 'xch4',
             'sensor_and_algorithm': 'merged_obs4mips',
-            'version': '4.1',
+            'version': '4_5',
         },
         config=config,
         dataset=dataset,
         dataset_info=dataset_info,
         overwrite=overwrite,
     )
-    downloader.download_request("CDS-XCH4.tar")
+    downloader.download_request("CDS-XCH4.zip")
     unpack_files_in_folder(downloader.local_folder)

--- a/esmvaltool/cmorizers/data/formatters/datasets/cds_xch4.ncl
+++ b/esmvaltool/cmorizers/data/formatters/datasets/cds_xch4.ncl
@@ -38,7 +38,7 @@ begin
 
   ; Period
   YEAR1 = 2003
-  YEAR2 = 2018
+  YEAR2 = 2022
 
   ; Selected variable (standard name)
   VAR = (/"xch4"/)
@@ -62,8 +62,8 @@ begin
   VERSION = "L3"
 
   ; Global attributes
-  SOURCE = "https://cds.climate.copernicus.eu/cdsapp#!/dataset/" + \
-    "satellite-methane?tab=form"
+  SOURCE = "https://cds.climate.copernicus.eu/datasets/" + \
+    "satellite-methane?tab=download"
   REF = "Buchwitz et al., Adv. Astronaut. Sci. Technol., " + \
     "doi:10.1007/s42423-018-0004-6, 2018."
   COMMENT = ""
@@ -79,8 +79,8 @@ begin
 
     ; Read variables
 
-    fname = input_dir_path + "200301_201812-C3S-L3_GHG-GHG_PRODUCTS-" + \
-      "MERGED-MERGED-OBS4MIPS-MERGED-v4.1.nc"
+    fname = input_dir_path + "200301_202212-C3S-L3_XCH4-GHG_PRODUCTS-" + \
+      "MERGED-MERGED-OBS4MIPS-MERGED-v4.5.nc"
     setfileoption("nc", "MissingToFillValue", False)
     f = addfile(fname, "r")
     output = f->xch4

--- a/esmvaltool/cmorizers/data/utilities.py
+++ b/esmvaltool/cmorizers/data/utilities.py
@@ -31,7 +31,6 @@ def add_height2m(cube: Cube) -> None:
     ----------
     cube: iris.cube.Cube
         Cube which will get the 2m-height coordinate in-place.
-
     """
     add_scalar_height_coord(cube, height=2.)
 
@@ -43,7 +42,6 @@ def add_height10m(cube: Cube) -> None:
     ----------
     cube: iris.cube.Cube
         Cube which will get the 10m-height coordinate in-place.
-
     """
     add_scalar_height_coord(cube, height=10.)
 
@@ -57,7 +55,6 @@ def add_scalar_depth_coord(cube: Cube, depth: float = 0.0) -> None:
         Cube which will get the depth coordinate in-place.
     depth: float, optional (default: 0.0)
         Value for the depth in meters.
-
     """
     logger.debug("Adding depth coordinate (%sm)", depth)
     depth_coord = iris.coords.AuxCoord(depth,
@@ -82,7 +79,6 @@ def add_scalar_height_coord(cube: Cube, height: float = 2.0) -> None:
         Cube which will get the height coordinate in-place.
     height: float, optional (default: 2.0)
         Value for the height in meters.
-
     """
     logger.debug("Adding height coordinate (%sm)", height)
     height_coord = iris.coords.AuxCoord(height,
@@ -336,19 +332,15 @@ def save_variable(cube, var, outdir, attrs, **kwargs):
     except iris.exceptions.CoordinateNotFoundError:
         time_suffix = None
     else:
-        if (
-                len(time.points) == 1 and
-                "mon" not in cube.attributes.get('mip')
-        ) or cube.attributes.get("frequency") == "yr":
+        if (len(time.points) == 1 and "mon" not in cube.attributes.get('mip')
+            ) or cube.attributes.get("frequency") == "yr":
             year = str(time.cell(0).point.year)
             time_suffix = '-'.join([year + '01', year + '12'])
         else:
             date1 = (
-                f"{time.cell(0).point.year:d}{time.cell(0).point.month:02d}"
-            )
+                f"{time.cell(0).point.year:d}{time.cell(0).point.month:02d}")
             date2 = (
-                f"{time.cell(-1).point.year:d}{time.cell(-1).point.month:02d}"
-            )
+                f"{time.cell(-1).point.year:d}{time.cell(-1).point.month:02d}")
             time_suffix = '-'.join([date1, date2])
 
     name_elements = [
@@ -387,12 +379,12 @@ def extract_doi_value(tags):
                     reference_doi.append(f'doi:{doi}')
             else:
                 reference_doi.append('doi not found')
-                logger.warning(
-                    'The reference file %s does not have a doi.', bibtex_file)
+                logger.warning('The reference file %s does not have a doi.',
+                               bibtex_file)
         else:
             reference_doi.append('doi not found')
-            logger.warning(
-                'The reference file %s does not exist.', bibtex_file)
+            logger.warning('The reference file %s does not exist.',
+                           bibtex_file)
     return ', '.join(reference_doi)
 
 
@@ -567,7 +559,7 @@ def unpack_files_in_folder(folder):
                 continue
             if filename.startswith('.'):
                 continue
-            if not filename.endswith(('.gz', '.tgz', '.tar')):
+            if not filename.endswith(('.gz', '.tgz', '.tar', '.zip')):
                 continue
             logger.info('Unpacking %s', filename)
             shutil.unpack_archive(full_path, folder)


### PR DESCRIPTION
## Description

Following the solution found in #3899, this PR fixes the CDS downloader to accept a URL, so both CDS and ADS data can be downloaded using it. Additionally, the affected CDS cmorizers are adapted - and if need be updated if their current versions are no longer available.

Affected downloaders:
- [ ]  CDS-SATELLITE-ALBEDO
- [ ]  CDS-SATELLITE-FAPAR
- [ ]  CDS-SATELLITE-SOIL-MOISTURE: v201912.0.0 that was last used is [deprecated](https://cds.climate.copernicus.eu/datasets/satellite-soil-moisture?tab=download), updating to newest version v202312
- [ ] CDS-UERRA: Dataset is no longer supported by data providers [see here](https://cds.climate.copernicus.eu/datasets/reanalysis-uerra-europe-soil-levels?tab=overview), but still downloadable. Format GRIB with only experimental netcdf4, still testing if the .nc files are fine
- [ ]  CDS-XCH4: updated to v 4.5 as v4.1 is no longer accessible. Changed formatter accordingly.
- [ ] CDS-XCO2: doesn't have a downloader currently but should be comparable to XCH4, might add if enough time. Otherwise will leave for a time I change the cmorizer to be python instead of current ncl ;)

- Closes #3750 
- Link to documentation:

* * *

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [ ] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [ ] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [ ] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [ ] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [ ] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [ ] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [ ] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added

### [New or updated data reformatting script](https://docs.esmvaltool.org/en/latest/develop/dataset.html)

- [ ] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/dataset.html#dataset-documentation) is available
- [ ] [🛠][1] The dataset has been [added to the CMOR check recipe](https://docs.esmvaltool.org/en/latest/community/dataset.html#testing)
- [ ] [🛠][1] The dataset has been added to the shared [data pools](https://docs.esmvaltool.org/en/latest/community/dataset.html#cmorized-data) of DKRZ and Jasmin by the @ESMValGroup/OBS-maintainers team
- [ ] [🧪][2] Numbers and units of the data look [physically meaningful](https://docs.esmvaltool.org/en/latest/community/dataset.html#scientific-sanity-check)

***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
