### PR TITLE
Run esmvalbot test PR twice a month

### DIFF
--- a/.github/workflows/cron_esmvalbot_test.yml
+++ b/.github/workflows/cron_esmvalbot_test.yml
@@ -4,9 +4,9 @@ on:
   # push:
   #   branches:
   #     - cron_esmvalbot_test
-  # scheduled once every 2 weeks
+  # scheduled twice a month
   schedule:
-    - cron: '0 4 */14 * *'
+    - cron: '0 4 */16 * *'
 
 # Required shell entrypoint to have properly configured bash shell
 defaults:


### PR DESCRIPTION
Update the schedule for the esmvalbot test reminder so it only runs twice a month, on the 1st and 17th (current schedule runs on the 1st, 15th, 29th, which causes two reminders shortly after each other).