### PR TITLE
Faster OSI-450-nh and OSI-450-sh CMORizer and respect Dask settings

### DIFF
--- a/esmvaltool/cmorizers/data/cmorizer.py
+++ b/esmvaltool/cmorizers/data/cmorizer.py
@@ -18,6 +18,7 @@ import esmvalcore
 import yaml
 from esmvalcore._task import write_ncl_settings
 from esmvalcore.config import CFG
+from esmvalcore.config._dask import get_distributed_client
 from esmvalcore.config._logging import configure_logging
 
 from esmvaltool import ESMValToolDeprecationWarning
@@ -222,11 +223,12 @@ class _Formatter:
             )
         logger.info("Processing datasets %s", datasets)
 
-        # loop through tier/datasets to be cmorized
         failed_datasets = []
-        for dataset in datasets:
-            if not self.format_dataset(dataset, start, end, install):
-                failed_datasets.append(dataset)
+        with get_distributed_client():
+            # loop through tier/datasets to be cmorized
+            for dataset in datasets:
+                if not self.format_dataset(dataset, start, end, install):
+                    failed_datasets.append(dataset)
 
         if failed_datasets:
             raise RuntimeError(

--- a/esmvaltool/cmorizers/data/formatters/osi_common.py
+++ b/esmvaltool/cmorizers/data/formatters/osi_common.py
@@ -53,7 +53,7 @@ class OSICmorizer:
             file_pattern = (
                 f"{vals['raw']}_{self.hemisphere}_{vals['grid']}_*.nc"
             )
-            for year in os.listdir(self.in_dir):
+            for year in sorted(os.listdir(self.in_dir)):
                 try:
                     year = int(year)
                 except ValueError:
@@ -84,7 +84,9 @@ class OSICmorizer:
 
     def _extract_variable(self, var_infos, raw_info, year, mips):
         """Extract to all vars."""
-        cubes = iris.load(
+        # The cubes need to be concatenated, not merged, and trying to merge is
+        # very slow, therefore we use load_raw which does not try to merge.
+        cubes = iris.load_raw(
             raw_info["file"],
             iris.Constraint(
                 cube_func=lambda c: c.var_name == raw_info["name"]


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

- Make the OSI-450-nh and OSI-450-sh CMORizers faster by using `iris.load_raw` (which does not try to merge the input cubes) instead of `iris.load`.
- Add the option to use the distributed scheduler for better performance.

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [ ] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
