### PR TITLE
use conda exec instead of mamba for circleCI `build_documentation` test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,6 +290,7 @@ jobs:
 workflows:
   commit:
     jobs:
+      - build_documentation
       - run_tests
       - test_installation_from_source_test_mode
       - test_installation_from_source_develop_mode

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,9 +247,8 @@ jobs:
             mkdir /logs
             . /opt/conda/etc/profile.d/conda.sh
             # Install
-            mamba --version
-            mamba install -c conda-forge "mamba>=2.1"  # mamba<2 can't solve env, even simple
-            mamba env create -n esmvaltool -f environment_python.yml
+            conda update -y conda
+            conda env create -n esmvaltool -f environment_python.yml
             conda activate esmvaltool
             pip install .[doc]
             # Log versions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,6 +247,7 @@ jobs:
             mkdir /logs
             . /opt/conda/etc/profile.d/conda.sh
             # Install
+            mamba install -c conda-forge "mamba>=2"  # mamba<2 can't solve env, even simple
             mamba env create -n esmvaltool -f environment_python.yml
             conda activate esmvaltool
             pip install .[doc]
@@ -290,6 +291,7 @@ jobs:
 workflows:
   commit:
     jobs:
+      - build_documentation
       - run_tests
       - test_installation_from_source_test_mode
       - test_installation_from_source_develop_mode

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,6 @@ jobs:
 workflows:
   commit:
     jobs:
-      - build_documentation
       - run_tests
       - test_installation_from_source_test_mode
       - test_installation_from_source_develop_mode

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,6 @@ jobs:
 workflows:
   commit:
     jobs:
-      - build_documentation
       - run_tests
       - test_installation_from_source_test_mode
       - test_installation_from_source_develop_mode

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,7 +248,7 @@ jobs:
             . /opt/conda/etc/profile.d/conda.sh
             # Install
             mamba --version
-            mamba install -c conda-forge "mamba>=2"  # mamba<2 can't solve env, even simple
+            mamba install -c conda-forge "mamba>=2.1"  # mamba<2 can't solve env, even simple
             mamba env create -n esmvaltool -f environment_python.yml
             conda activate esmvaltool
             pip install .[doc]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,6 @@ jobs:
             mkdir /logs
             . /opt/conda/etc/profile.d/conda.sh
             # Install
-            conda update -y conda
             conda env create -n esmvaltool -f environment_python.yml
             conda activate esmvaltool
             pip install .[doc]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,6 +247,7 @@ jobs:
             mkdir /logs
             . /opt/conda/etc/profile.d/conda.sh
             # Install
+            mamba --version
             mamba install -c conda-forge "mamba>=2"  # mamba<2 can't solve env, even simple
             mamba env create -n esmvaltool -f environment_python.yml
             conda activate esmvaltool


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->


mamba gets stuck at `info     libmamba Loading site packages` - not sure why, but it is 100% reproducible, and with multiple versions of mamba2; conda, especially if updated to the latest version, goes through very fast and nicely; beats me why, since they both use the same `libmamba` backend

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- ~[ ] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do~

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful
