### PR TITLE
Add explanatory note in documentation advice on Codacy

### DIFF
--- a/doc/sphinx/source/community/code_documentation.rst
+++ b/doc/sphinx/source/community/code_documentation.rst
@@ -205,6 +205,8 @@ Formatting issues are considered trivial and need to be addressed by running
 ``pre-commit run -a``.
 Note that the automatic code quality checks by prospector are really helpful to
 improve the quality of your code, but they are not flawless.
+For example, writing a new cmorizer *requires* you to define a new function
+that takes more than 5 arguments, which Codacy considers a code style issue.
 If you suspect prospector or Codacy may be wrong, please ask the
 `@ESMValGroup/tech-reviewers`_ by commenting on your pull request.
 

--- a/doc/sphinx/source/community/code_documentation.rst
+++ b/doc/sphinx/source/community/code_documentation.rst
@@ -201,7 +201,7 @@ A pull request should preferably not introduce any new prospector issues.
 However, we understand that there is a limit to how much time can be spent on
 polishing code, so up to 10 new (non-trivial) issues is still an acceptable
 amount.
-Formatting issues are considered trivial and need to be addressed by running
+Formatting issues are considered trivial to resolve and need to be addressed by running
 ``pre-commit run -a``.
 Note that the automatic code quality checks by prospector are really helpful to
 improve the quality of your code, but they are not flawless.

--- a/doc/sphinx/source/develop/dataset.rst
+++ b/doc/sphinx/source/develop/dataset.rst
@@ -192,8 +192,11 @@ reformatted data set, ``cfg`` to the dataset-specific configuration file,
 dictionary), ``start_date`` to the start
 of the period to format, and ``end_date`` to the end of the period to format.
 If not needed, the last three arguments can be ignored using underscores.
-The return value of this function is ignored. All
-the work, i.e. loading of the raw files, processing them and saving the final
+The return value of this function is ignored.
+Note that this function will trigger a Codacy style issue because it has more
+than 5 arguments; you can ignore that issue in line with the :ref:`code_quality` guidance.
+
+All the work, i.e. loading of the raw files, processing them and saving the final
 output, has to be performed inside its body. To simplify this process, ESMValTool
 provides a set of predefined utilities.py_, which can be imported into your CMORizer
 by


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

Suggestion documentation tweak to ensure developers of cmorizers can expect Codacy issues.

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
- Closes #4016 
- Link to documentation: https://esmvaltool--4020.org.readthedocs.build/en/4020/, and more specifically
  - https://esmvaltool--4020.org.readthedocs.build/en/4020/community/code_documentation.html#python
  - https://esmvaltool--4020.org.readthedocs.build/en/4020/develop/dataset.html#cmorizer-script-written-in-python

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [ ] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [ ] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [ ] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [ ] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [ ] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [ ] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [ ] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [ ] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added

### [New or updated data reformatting script](https://docs.esmvaltool.org/en/latest/develop/dataset.html)

- [ ] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/dataset.html#dataset-documentation) is available
- [ ] [🛠][1] The dataset has been [added to the CMOR check recipe](https://docs.esmvaltool.org/en/latest/community/dataset.html#testing)
- [ ] [🛠][1] The dataset has been added to the shared [data pools](https://docs.esmvaltool.org/en/latest/community/dataset.html#cmorized-data) of DKRZ and Jasmin by the @ESMValGroup/OBS-maintainers team
- [ ] [🧪][2] Numbers and units of the data look [physically meaningful](https://docs.esmvaltool.org/en/latest/community/dataset.html#scientific-sanity-check)

***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
