### PR TITLE
Revert "Update RTW to use the `git` scheme"

### DIFF
--- a/esmvaltool/utils/recipe_test_workflow/app/get_esmval/bin/clone_latest_esmval.sh
+++ b/esmvaltool/utils/recipe_test_workflow/app/get_esmval/bin/clone_latest_esmval.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Send the output from 'set -x' to 'stdout' rather than 'stderr'.
+BASH_XTRACEFD=1
+set -eux
+
+# Remove the ESMValTool and ESMValCore directories, if they exist.
+if [[ -d ${ESMVALTOOL_DIR} ]]; then
+    rm -rf "${ESMVALTOOL_DIR}"
+fi
+
+if [[ -d ${ESMVALCORE_DIR} ]]; then
+    rm -rf "${ESMVALCORE_DIR}"
+fi
+
+# Checkout the specified branch for ESMValCore and ESMValTool. Use the
+# quiet ('-q') option to prevent the progress status from being reported
+# (which is done via done via 'stderr').
+git clone -q -b "${BRANCH}" "${ESMVALTOOL_URL}" "${ESMVALTOOL_DIR}"
+git clone -q -b "${BRANCH}" "${ESMVALCORE_URL}" "${ESMVALCORE_DIR}"

--- a/esmvaltool/utils/recipe_test_workflow/app/get_esmval/opt/rose-app-metoffice.conf
+++ b/esmvaltool/utils/recipe_test_workflow/app/get_esmval/opt/rose-app-metoffice.conf
@@ -1,12 +1,7 @@
-# The reason behind the benign 'default' command below is because
-# if the '[command]' section does not exist
-# a '[WARN] command not defined' message is written to the 'job.err' file.
-
 [command]
-default=echo "Cloning ESMValCore and ESMValTool into ${ESMVAL_DIR}"
+default=clone_latest_esmval.sh
 
-[file:${ESMVALCORE_DIR}]
-source=git:git@github.com:ESMValGroup/ESMValCore::./::main
-
-[file:${ESMVALTOOL_DIR}]
-source=git:git@github.com:ESMValGroup/ESMValTool::./::main
+[env]
+BRANCH=main
+ESMVALCORE_URL=git@github.com:ESMValGroup/ESMValCore.git
+ESMVALTOOL_URL=git@github.com:ESMValGroup/ESMValTool.git

--- a/esmvaltool/utils/recipe_test_workflow/flow.cylc
+++ b/esmvaltool/utils/recipe_test_workflow/flow.cylc
@@ -57,7 +57,6 @@
             USER_CONFIG_DIR = ${ROSE_DATAC}/config_dir
             USER_CONFIG_PATH = ${USER_CONFIG_DIR}/config-user.yml
             OUTPUT_DIR = ${ROSE_DATAC}
-            ESMVAL_DIR = ""
             ESMVALCORE_DIR = ""
             ESMVALTOOL_DIR = ""
             PYTHONPATH_PREPEND = ""

--- a/esmvaltool/utils/recipe_test_workflow/site/metoffice/runtime.cylc
+++ b/esmvaltool/utils/recipe_test_workflow/site/metoffice/runtime.cylc
@@ -2,9 +2,8 @@
 [runtime]
     [[root]]
         [[[environment]]]
-            ESMVAL_DIR = ${CYLC_WORKFLOW_RUN_DIR}/share/lib/python
-            ESMVALCORE_DIR = ${ESMVAL_DIR}/ESMValCore
-            ESMVALTOOL_DIR = ${ESMVAL_DIR}/ESMValTool
+            ESMVALCORE_DIR = ${CYLC_WORKFLOW_RUN_DIR}/share/lib/python/ESMValCore
+            ESMVALTOOL_DIR = ${CYLC_WORKFLOW_RUN_DIR}/share/lib/python/ESMValTool
             PYTHONPATH_PREPEND = ${ESMVALCORE_DIR}:${ESMVALTOOL_DIR}
 
     # COMPUTE provides defaults for computation-heavy tasks.


### PR DESCRIPTION
Reverts ESMValGroup/ESMValTool#4030 due to the fact that the `git` scheme doesn't check out hidden files, which are required to make progress on #4036.

I have reported this to the [MO Science Git Migration Project](https://github.com/MetOffice/Science-Git-Migration-Project/issues/46#issuecomment-2886922662).