### PR TITLE
Update time ranges in REF 'cloud radiative effect' recipe

### DIFF
--- a/esmvaltool/recipes/ref/recipe_ref_cre.yml
+++ b/esmvaltool/recipes/ref/recipe_ref_cre.yml
@@ -16,7 +16,7 @@ datasets:
   - {project: CMIP6, dataset: MPI-ESM1-2-LR, exp: historical, ensemble: r1i1p1f1, grid: gn}
 
 timerange_for_models: &time_period
-  timerange: '2005/2014'  # can be specified, this is just an example
+  timerange: '1996/2014' #should end 2015 for CMIP7
 
 
 preprocessors:
@@ -56,7 +56,8 @@ diagnostics:
         preprocessor: full_climatology
         derive: true
     additional_datasets:
-      - {dataset: CERES-EBAF, project: OBS, type: sat, version: Ed4.2, tier: 2, reference_for_monitor_diags: true}
+      - {dataset: CERES-EBAF, project: OBS, type: sat, version: Ed4.2, tier: 2,
+         start_year: 2000, end_year: 2023, reference_for_monitor_diags: true}
     scripts:
       plot: &plot_multi_dataset_default
         script: monitor/multi_datasets.py
@@ -82,9 +83,12 @@ diagnostics:
         preprocessor: zonal_mean
         derive: true
     additional_datasets:
-      - {dataset: CERES-EBAF, project: OBS, type: sat, version: Ed4.2, tier: 2, reference_for_monitor_diags: true}
-      - {dataset: ESACCI-CLOUD, project: OBS, type: sat, version: AVHRR-AMPM-fv3.0, tier: 2}
-      - {dataset: ISCCP-FH, project: OBS, type: sat, version: v0, tier: 2}
+      - {dataset: CERES-EBAF, project: OBS, type: sat, version: Ed4.2, tier: 2,
+         start_year: 2000, end_year: 2023, reference_for_monitor_diags: true}
+      - {dataset: ESACCI-CLOUD, project: OBS, type: sat, version: AVHRR-AMPM-fv3.0, tier: 2,
+         start_year: 1996, end_year: 2016}
+      - {dataset: ISCCP-FH, project: OBS, type: sat, version: v0, tier: 2,
+         start_year: 1996, end_year: 2016}
     scripts:
       plot:
         <<: *plot_multi_dataset_default


### PR DESCRIPTION

## Description

Time ranges need to be updated for use in REF.
Models: 1996-2015 (for CMIP6 we use 2014)
Obs: full available time range after 1996


## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [x] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [x] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [x] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [x] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added

