### PR TITLE
Fix caption and time range for REF diagnostic "Cloud scatterplots"

### DIFF
--- a/esmvaltool/diag_scripts/seaborn_jointplot_histogram.py
+++ b/esmvaltool/diag_scripts/seaborn_jointplot_histogram.py
@@ -256,7 +256,7 @@ def main(cfg: dict[str, Any]) -> None:
 
     # Save results
     basename = cfg["plot_filename"]
-    caption = f"Scatterplot {cfg['x']} vs {cfg['y']} ({cfg['suptitle']})"
+    caption = f"Scatterplot of {cube_x.long_name} ({cfg['x']}) vs {cube_y.long_name} ({cfg['y']}) ({cfg['suptitle']})"
     provenance = get_provenance_record(caption, [filename_x, filename_y])
     save_figure(basename, provenance, cfg, dpi=cfg.get("dpi", 300))
     cube_hist, cube_hist_x, cube_hist_y = data_to_cubes(data, cfg)

--- a/esmvaltool/recipes/ref/recipe_ref_scatterplot.yml
+++ b/esmvaltool/recipes/ref/recipe_ref_scatterplot.yml
@@ -12,7 +12,7 @@ documentation:
     - bock_lisa
 
 timerange_for_data: &time_period
-  timerange: '2007/2011'  # can be specified, this is just an example
+  timerange: '1996/2014'  # should end 2015 for CMIP7
 regridding: &regridding
   regrid:
     target_grid: 1x1


### PR DESCRIPTION


## Description

Time ranges need to be updated for use in REF.
Models: 1996-2015 (for CMIP6 we use 2014)
Obs: full available time range after 1996


* * *

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [ ] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [ ] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [ ] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [ ] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [ ] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [ ] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [ ] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added
