### PR TITLE
Fix coords in ESACCI-CLOUD cmorizer

### DIFF
--- a/esmvaltool/cmorizers/data/formatters/datasets/esacci_cloud.py
+++ b/esmvaltool/cmorizers/data/formatters/datasets/esacci_cloud.py
@@ -176,6 +176,8 @@ def _concatenate_and_save_monthly_cubes(
 
     if attach == "-AMPM":
         cube = monthly_statistics(cube)
+        cube.remove_coord("month_number")
+        cube.remove_coord("year")
 
     # Regrid the cube to the target grid (e.g., 0.5x0.5)
     cube = regrid(cube, target_grid="0.5x0.5", scheme="area_weighted")


### PR DESCRIPTION


## Description

This PR fixes the ESACCI-Cloud cmorizer by removing the auxiliary coords "month_number" and "year".

- Closes #issue_number
- Link to documentation:

* * *

## Before you get started



## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful



### [New or updated data reformatting script](https://docs.esmvaltool.org/en/latest/develop/dataset.html)

- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/dataset.html#dataset-documentation) is available
- [x] [🛠][1] The dataset has been [added to the CMOR check recipe](https://docs.esmvaltool.org/en/latest/community/dataset.html#testing)
- [ ] [🛠][1] The dataset has been added to the shared [data pools](https://docs.esmvaltool.org/en/latest/community/dataset.html#cmorized-data) of DKRZ and Jasmin by the @ESMValGroup/OBS-maintainers team
- [x] [🧪][2] Numbers and units of the data look [physically meaningful](https://docs.esmvaltool.org/en/latest/community/dataset.html#scientific-sanity-check)


