### PR TITLE
Fix `recipe_williams09climdyn_CREM.yml` by replacing `np.NAN` with `np.nan`

### DIFF
--- a/esmvaltool/diag_scripts/crem/ww09_esmvaltool.py
+++ b/esmvaltool/diag_scripts/crem/ww09_esmvaltool.py
@@ -603,15 +603,15 @@ def crem_calc(pointers):
 
         mask = pctisccp_data.copy()
         if region == "tropics":
-            mask[:, (lats2 < -20) | (lats2 > 20), :] = np.NAN
+            mask[:, (lats2 < -20) | (lats2 > 20), :] = np.nan
         elif region == "extra-tropics":
-            mask[:, (lats2 >= -20) & (lats2 <= 20), :] = np.NAN
-            mask[(snc_data >= 0.1) | (sic_data >= 0.1)] = np.NAN
+            mask[:, (lats2 >= -20) & (lats2 <= 20), :] = np.nan
+            mask[(snc_data >= 0.1) | (sic_data >= 0.1)] = np.nan
         elif region == "snow-ice":
-            mask[:, (lats2 >= -20) & (lats2 <= 20), :] = np.NAN
-            mask[(snc_data < 0.1) & (sic_data < 0.1)] = np.NAN
+            mask[:, (lats2 >= -20) & (lats2 <= 20), :] = np.nan
+            mask[(snc_data < 0.1) & (sic_data < 0.1)] = np.nan
 
-        mask[cltisccp_data == 0.0] = np.NAN
+        mask[cltisccp_data == 0.0] = np.nan
 
         points = np.isfinite(mask)
         npoints = len(mask[points])  # Number of valid data points in region


### PR DESCRIPTION
## Description

As noted during the testing of recipes for the v2.13.0 release, the recipe `recipe_williams09climdyn_CREM.yml` fails due to `np.NAN` being present in the diagnostic script `esmvaltool/diag_scripts/crem/ww09_esmvaltool.py`.
This PR solves this issue by replacing the `np.NAN` instances with `np.nan`.

See recipe testing for the release here https://github.com/ESMValGroup/ESMValTool/issues/4157