### PR TITLE
Update the name of the `remapscon2` operator in R recipes

### DIFF
--- a/esmvaltool/diag_scripts/hyint/hyint_etccdi_preproc.R
+++ b/esmvaltool/diag_scripts/hyint/hyint_etccdi_preproc.R
@@ -29,7 +29,7 @@ hyint_etccdi_preproc <-
       sfile_tmp0 <- cdo("delvar", args = "time_bnds", input = sfile)
       gridf <- tempfile()
       cdo("griddes", input = hyint_file, stdout = gridf)
-      sfile_tmp1 <- cdo("remapscon2",
+      sfile_tmp1 <- cdo("remapcon",
         args = gridf,
         input = sfile_tmp0
       )

--- a/esmvaltool/diag_scripts/hyint/hyint_functions.R
+++ b/esmvaltool/diag_scripts/hyint/hyint_functions.R
@@ -626,7 +626,7 @@ create_landseamask <-
 
     ## Regridding the topographic map to chosen grid
     cdo(
-      "remapscon2",
+      "remapcon",
       args = paste0("'", regrid, "'"),
       input = ftopo,
       output = regridded_topo
@@ -827,7 +827,7 @@ ncdf_opener_universal <- # nolint
              rotate = "full",
              interp2grid = F,
              grid = "r144x73",
-             remap_method = "remapscon2",
+             remap_method = "remapcon",
              exportlonlat = TRUE,
              verbose = F) {
     # load package
@@ -1090,7 +1090,7 @@ ncdf_opener <- function(namefile,
                         rotate = "full",
                         interp2grid = F,
                         grid = "r144x73",
-                        remap_method = "remapscon2",
+                        remap_method = "remapcon",
                         exportlonlat = T) {
   field <-
     ncdf_opener_universal(
@@ -1123,7 +1123,7 @@ ncdf_opener_time <- # nolint
              rotate = "full",
              interp2grid = F,
              grid = "r144x73",
-             remap_method = "remapscon2") {
+             remap_method = "remapcon") {
     # function to open netcdf files. It uses ncdf4 library
     # time selection of month and years needed automatically rotate matrix
     # to place greenwich at the center (flag "rotate")

--- a/esmvaltool/diag_scripts/hyint/hyint_preproc.R
+++ b/esmvaltool/diag_scripts/hyint/hyint_preproc.R
@@ -22,7 +22,7 @@ hyint_preproc <- function(work_dir,
     } else {
       gridf <- rgrid
     }
-    tempf <- cdo("remapscon2", args = gridf, input = climofile)
+    tempf <- cdo("remapcon", args = gridf, input = climofile)
     unlink(gridf)
   } else {
     tempf <- cdo("addc", args = "0", input = climofile)

--- a/esmvaltool/diag_scripts/miles/basis_functions.R
+++ b/esmvaltool/diag_scripts/miles/basis_functions.R
@@ -336,7 +336,7 @@ ncdf_opener_universal <- # nolint
              interp2grid = FALSE,
              fillmiss = FALSE,
              grid = "r144x73",
-             remap_method = "remapscon2",
+             remap_method = "remapcon",
              exportlonlat = TRUE,
              verbose = TRUE) {
     # load package
@@ -645,7 +645,7 @@ ncdf_opener <- function(namefile,
                         interp2grid = FALSE,
                         fillmiss = FALSE,
                         grid = "r144x73",
-                        remap_method = "remapscon2",
+                        remap_method = "remapcon",
                         exportlonlat = TRUE,
                         verbose = FALSE) {
   field <- ncdf_opener_universal(

--- a/esmvaltool/diag_scripts/quantilebias/quantilebias_functions.R
+++ b/esmvaltool/diag_scripts/quantilebias/quantilebias_functions.R
@@ -62,7 +62,7 @@ ncdf_opener_universal <- # nolint
            rotate = "full",
            interp2grid = F,
            grid = "r144x73",
-           remap_method = "remapscon2",
+           remap_method = "remapcon",
            exportlonlat = TRUE,
            verbose = F) {
     # load package
@@ -326,7 +326,7 @@ ncdf_opener <- function(namefile,
                         rotate = "full",
                         interp2grid = F,
                         grid = "r144x73",
-                        remap_method = "remapscon2",
+                        remap_method = "remapcon",
                         exportlonlat = T) {
   field <-
     ncdf_opener_universal(


### PR DESCRIPTION
## Description

Since version 2.3.0 of CDO, the operator `remapscon2` has been removed (see release [notes](https://code.mpimet.mpg.de/news/533)). It is now recommended to use `remapcon` instead (e.g. https://code.mpimet.mpg.de/boards/2/topics/16404).

This affected the runs of two recipes during testing ahead of the 2.13.0 release https://github.com/ESMValGroup/ESMValTool/issues/4157:
- `hyint/recipe_hyint.yml`
- `hyint/recipe_hyint_extreme_events.yml`

Potentially, this could also impact the following recipes where `remapcon2` is also used:
- `recipe_miles_block.yml` (failed due to timeout)
- `recipe_miles_eof.yml` (failed due to timeout)
- `recipe_miles_regimes.yml` (failed due to timeout)
- `recipe_quantilebias.yml `(run w/o error?)

This PR updates the relevant locations to use the operator `remapcon`.

- Closes #4163 
- Link to documentation:

* * *

## Before you get started

- [ ] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [ ] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [ ] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [ ] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [ ] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [ ] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [ ] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [ ] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added