### PR TITLE
Remove `end_year` facet for NOAA-GML datasets in `recipe_check_obs.yml`

### DIFF
--- a/esmvaltool/recipes/examples/recipe_check_obs.yml
+++ b/esmvaltool/recipes/examples/recipe_check_obs.yml
@@ -847,7 +847,7 @@ diagnostics:
       ch4s:
     additional_datasets:
       - {dataset: NOAA-GML-SURFACE-FLASK-CH4, project: OBS6, mip: Amon, type: atmos, version: 1, tier: 2,
-         start_year: 1983, end_year: 2023}
+         start_year: 1983}
     scripts: null
 
   NOAA-GML-SURFACE-FLASK-CO2:
@@ -856,7 +856,7 @@ diagnostics:
       co2s:
     additional_datasets:
       - {dataset: NOAA-GML-SURFACE-FLASK-CO2, project: OBS6, mip: Amon, type: atmos, version: 1, tier: 2,
-         start_year: 1968, end_year: 2023}
+         start_year: 1968}
     scripts: null
 
   NOAA-MBL-CH4:


### PR DESCRIPTION
## Description

Removing the `end_year` facet for the NOAA-GML datasets in `recipe_check_obs.yml` to avoid a version problem when searching for the dataset files. This is also updated directly for the N2O dataset in the corresponding PR #4059.

- Closes #4155