### PR TITLE
Fix `recipe_carvalhais14nat.yml` to avoid the usage of `vars()` inside a function

### DIFF
--- a/esmvaltool/diag_scripts/land_carbon_cycle/shared.py
+++ b/esmvaltool/diag_scripts/land_carbon_cycle/shared.py
@@ -21,8 +21,8 @@ def _apply_common_mask(*args):
     ------
         an array with size of nargs x common size of all input arrays
     """
-    arrays = np.stack([*args], axis=0)
-    odat = np.ma.masked_array(arrays, dtype=np.float64)
+    odat = np.stack(args, axis=0)
+    odat = np.ma.masked_array(odat, dtype=np.float64)
     odat = np.ma.masked_invalid(odat)
     mask = np.ma.getmaskarray(odat).any(axis=0, keepdims=True)
     odat = np.ma.masked_where(np.broadcast_to(mask, odat.shape), odat)

--- a/esmvaltool/diag_scripts/land_carbon_cycle/shared.py
+++ b/esmvaltool/diag_scripts/land_carbon_cycle/shared.py
@@ -22,14 +22,15 @@ def _apply_common_mask(*args):
         an array with size of nargs x common size of all input arrays
     """
     nargs = len(args)
+    dat_masks = [np.ones(np.shape(args[arg_])) for arg_ in range(nargs)]
+    dat_mask_invs = [None for arg_ in range(nargs)]
     for arg_ in range(nargs):
         _dat = args[arg_]
-        vars()["dat_mask" + str(arg_)] = np.ones(np.shape(_dat))
-        vars()["dat_mask_inv" + str(arg_)] = np.ma.masked_invalid(_dat).mask
-        vars()["dat_mask" + str(arg_)][vars()["dat_mask_inv" + str(arg_)]] = 0
-    dat_mask = vars()["dat_mask0"]
+        dat_mask_invs[arg_] = np.ma.masked_invalid(_dat).mask
+        dat_masks[arg_][dat_mask_invs[arg_]] = 0
+    dat_mask = dat_masks[0]
     for arg_ in range(nargs):
-        dat_mask = dat_mask * vars()["dat_mask" + str(arg_)]
+        dat_mask = dat_mask * dat_masks[arg_]
     mask_where = np.ma.getmask(np.ma.masked_less(dat_mask, 1.0))
     odat = []
     for arg_ in range(nargs):

--- a/esmvaltool/diag_scripts/land_carbon_cycle/shared.py
+++ b/esmvaltool/diag_scripts/land_carbon_cycle/shared.py
@@ -21,23 +21,11 @@ def _apply_common_mask(*args):
     ------
         an array with size of nargs x common size of all input arrays
     """
-    nargs = len(args)
-    dat_masks = [np.ones(np.shape(args[arg_])) for arg_ in range(nargs)]
-    dat_mask_invs = [None for arg_ in range(nargs)]
-    for arg_ in range(nargs):
-        _dat = args[arg_]
-        dat_mask_invs[arg_] = np.ma.masked_invalid(_dat).mask
-        dat_masks[arg_][dat_mask_invs[arg_]] = 0
-    dat_mask = dat_masks[0]
-    for arg_ in range(nargs):
-        dat_mask = dat_mask * dat_masks[arg_]
-    mask_where = np.ma.getmask(np.ma.masked_less(dat_mask, 1.0))
-    odat = []
-    for arg_ in range(nargs):
-        _dat = args[arg_].astype(np.float64)
-        _dat[mask_where] = np.nan
-        odat = np.append(odat, np.ma.masked_invalid(_dat))
-    odat = odat.reshape(nargs, _dat.shape[0], _dat.shape[1])
+    arrays = np.stack([*args], axis=0)
+    odat = np.ma.masked_array(arrays, dtype=np.float64)
+    odat = np.ma.masked_invalid(odat)
+    mask = np.ma.getmaskarray(odat).any(axis=0, keepdims=True)
+    odat = np.ma.masked_where(np.broadcast_to(mask, odat.shape), odat)
     return odat
 
 


### PR DESCRIPTION
## Description

During the recipe testing for the release process of 2.13.0 #4157, the recipe `recipe_carvalhais14nat.yml` failed due to a diagnostic error:
```
Traceback (most recent call last):
  File "/home/b/b381312/projects/ESMValTool/esmvaltool/diag_scripts/land_carbon_cycle/diag_zonal_correlation.py", line 491, in <module>
    main(config)
    ~~~~^^^^^^^^
  File "/home/b/b381312/projects/ESMValTool/esmvaltool/diag_scripts/land_carbon_cycle/diag_zonal_correlation.py", line 434, in main
    zon_corr = _calc_zonal_correlation(
        _tau_dat,
    ...<3 lines>...
        fig_config,
    )
  File "/home/b/b381312/projects/ESMValTool/esmvaltool/diag_scripts/land_carbon_cycle/diag_zonal_correlation.py", line 128, in _calc_zonal_correlation
    dat_tau, dat_pr, dat_tas = _apply_common_mask(dat_tau, dat_pr, dat_tas)
                               ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/b/b381312/projects/ESMValTool/esmvaltool/diag_scripts/land_carbon_cycle/shared.py", line 29, in _apply_common_mask
    vars()["dat_mask" + str(arg_)][vars()["dat_mask_inv" + str(arg_)]] = 0
    ~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'dat_mask0'
```
This error could be traced back to the usage of `vars()` inside the function, making the dynamically created variables not accessible inside the function when calling it. This is solved by replacing the called to `vars()` by simple lists.

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [ ] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [x] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [x] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [ ] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [x] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added

***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
