### PR TITLE
Fix `_fix_lons` function in `recipe_flato13ipcc_figure_914.yml` due to `numpy` error

### DIFF
--- a/esmvaltool/diag_scripts/ipcc_ar5/ch09_fig09_14.py
+++ b/esmvaltool/diag_scripts/ipcc_ar5/ch09_fig09_14.py
@@ -78,7 +78,7 @@ DEGREE_SYMBOL = "\u00b0"
 
 def _fix_lons(lons):
     """Fix the given longitudes into the range ``[-180, 180]``."""
-    lons = np.array(lons, copy=False, ndmin=1)
+    lons = np.atleast_1d(lons)
     fixed_lons = ((lons + 180) % 360) - 180
     # Make the positive 180s positive again.
     fixed_lons[(fixed_lons == -180) & (lons > 0)] *= -1


### PR DESCRIPTION
## Description

As identified during the recipe testing for the 2.13.x release #4157 , a change in `numpy` version lead to the following error in `esmvaltool/diag_scripts/ipcc_ar5/ch09_fig09_14.py`:
```
  File "/home/b/b381312/projects/ESMValTool/esmvaltool/diag_scripts/ipcc_ar5/ch09_fig09_14.py", line 81, in _fix_lons
    lons = np.array(lons, copy=False, ndmin=1)
ValueError: Unable to avoid copy while creating an array as requested.
If using `np.array(obj, copy=False)` replace it with `np.asarray(obj)` to allow a copy when needed (no behavior change in NumPy 1.x).
For more details, see https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword.
```
Following the recommendation from `numpy` the code was adapted, but also in a way to keep the effect of `ndim=1` in the original code. The modified code line looks now like this:
`lons = np.atleast_1d(lons)`

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [ ] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [ ] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [ ] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [ ] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [ ] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [ ] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [ ] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [ ] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added

***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
