### PR TITLE
Change OBS6 to native6 for ERA5 in recipes

### DIFF
--- a/esmvaltool/recipes/bock20jgr/recipe_bock20jgr_fig_1-4.yml
+++ b/esmvaltool/recipes/bock20jgr/recipe_bock20jgr_fig_1-4.yml
@@ -355,7 +355,7 @@ diagnostics:
         end_year: 1999
         additional_datasets: *cmip3_tas
     additional_datasets:
-      - {dataset: ERA5, project: native6, mip: Amon, type: reanaly, version: v1,
+      - {dataset: ERA5, project: native6, frequency: mon, type: reanaly, version: v1,
          tier: 3}
     scripts:
       model_bias:

--- a/esmvaltool/recipes/bock20jgr/recipe_bock20jgr_fig_1-4.yml
+++ b/esmvaltool/recipes/bock20jgr/recipe_bock20jgr_fig_1-4.yml
@@ -313,7 +313,7 @@ diagnostics:
         end_year: 2014
         additional_datasets: *cmip6_tas
     additional_datasets:
-      - {dataset: ERA5, project: OBS6, type: reanaly, version: v1, tier: 3}
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
     scripts:
       model_bias: &model_bias_settings
         script: bock20jgr/model_bias.ncl
@@ -333,7 +333,7 @@ diagnostics:
         end_year: 2004
         additional_datasets: *cmip5_tas
     additional_datasets:
-      - {dataset: ERA5, project: OBS6, type: reanaly, version: v1, tier: 3}
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
     scripts:
       model_bias:
         <<: *model_bias_settings
@@ -355,7 +355,7 @@ diagnostics:
         end_year: 1999
         additional_datasets: *cmip3_tas
     additional_datasets:
-      - {dataset: ERA5, project: OBS6, mip: Amon, type: reanaly, version: v1,
+      - {dataset: ERA5, project: native6, mip: Amon, type: reanaly, version: v1,
          tier: 3}
     scripts:
       model_bias:
@@ -370,7 +370,7 @@ diagnostics:
         <<: *var_cmip6_bias
         additional_datasets: *cmip6_highresmip_low
     additional_datasets:
-      - {dataset: ERA5, project: OBS6, type: reanaly, version: v1, tier: 3}
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
     scripts:
       model_bias:
         <<: *model_bias_settings
@@ -384,7 +384,7 @@ diagnostics:
         <<: *var_cmip6_bias
         additional_datasets: *cmip6_highresmip_high
     additional_datasets:
-      - {dataset: ERA5, project: OBS6, type: reanaly, version: v1, tier: 3}
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1, tier: 3}
     scripts:
       model_bias:
         <<: *model_bias_settings

--- a/esmvaltool/recipes/recipe_eyring13jgr_12.yml
+++ b/esmvaltool/recipes/recipe_eyring13jgr_12.yml
@@ -127,7 +127,7 @@ diagnostics:
         start_year: 1995
         end_year: 2014
     additional_datasets:
-      - {dataset: ERA5, project: OBS6, type: reanaly, version: 1,
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1,
          start_year: 1995, end_year: 2014, tier: 3}
     scripts:
       clim: &clim_settings

--- a/esmvaltool/recipes/sanity_checks/recipe_create_ranges_obs.yml
+++ b/esmvaltool/recipes/sanity_checks/recipe_create_ranges_obs.yml
@@ -515,8 +515,8 @@ diagnostics:
     additional_datasets:
       - {dataset: ISCCP-FH, project: OBS, type: sat, version: v0, tier: 2,
         start_year: 1984, end_year: 2016}
-      - {dataset: ERA5, project: native6, type: reanaly, version: v1,
-        tier: 3}
+      - {dataset: ERA5, project: native6, type: reanaly, version: 'v1',
+        tier: 3, start_year: 1995, end_year: 2014}
       - {dataset: MERRA2, project: OBS6, type: reanaly, version: '5.12.4', tier: 3,
         start_year: 1980, end_year: 2021}
     scripts: null

--- a/esmvaltool/recipes/sanity_checks/recipe_create_ranges_obs.yml
+++ b/esmvaltool/recipes/sanity_checks/recipe_create_ranges_obs.yml
@@ -515,7 +515,7 @@ diagnostics:
     additional_datasets:
       - {dataset: ISCCP-FH, project: OBS, type: sat, version: v0, tier: 2,
         start_year: 1984, end_year: 2016}
-      - {dataset: ERA5, project: OBS6, type: reanaly, version: '1',
+      - {dataset: ERA5, project: native6, type: reanaly, version: v1,
         tier: 3}
       - {dataset: MERRA2, project: OBS6, type: reanaly, version: '5.12.4', tier: 3,
         start_year: 1980, end_year: 2021}


### PR DESCRIPTION
## Description

This PR replaces the use of class `OBS6` with class `native6` for monthly mean ERA5 data in the following recipes:

- bock20jgr/recipe_bock20jgr_fig_1-4.yml
- recipe_eyring13jgr_12.yml
- sanity_checks/recipe_create_ranges_obs.yml

This allows to remove monthly and hourly (unused) ERA5 data on Levante stored as `OBS6`. All data removed are available as `native6` on Levante. The aim is to free up some disk space by removing data that are redundant as they are currently stored twice (as `OBS6` and `native6`).

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [ ] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [ ] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [ ] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [ ] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [ ] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [ ] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [ ] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added