### PR TITLE
revert from CERES-EBAF_Surface to original CERES-EBAF in recipe_autoassess_landsurface_surfrad.yml

### DIFF
--- a/esmvaltool/recipes/recipe_autoassess_landsurface_surfrad.yml
+++ b/esmvaltool/recipes/recipe_autoassess_landsurface_surfrad.yml
@@ -42,7 +42,7 @@ diagnostics:
         force_derivation: false
         mip: Amon
         additional_datasets:
-          - {dataset: CERES-EBAF_Surface, project: obs4MIPs, start_year: 2001, end_year: 2012, tier: 1}
+          - {dataset: CERES-EBAF, project: obs4MIPs, start_year: 2001, end_year: 2012, tier: 1}
       sftlf:
         mip: fx
       rlns: # Surf LW net all sky
@@ -50,7 +50,7 @@ diagnostics:
         force_derivation: false
         mip: Amon
         additional_datasets:
-          - {dataset: CERES-EBAF_Surface, project: obs4MIPs, start_year: 2001, end_year: 2012, tier: 1}
+          - {dataset: CERES-EBAF, project: obs4MIPs, start_year: 2001, end_year: 2012, tier: 1}
     scripts:
       autoassess_landsurf_surfrad: &autoassess_landsurf_surfrad_settings
         script: autoassess/autoassess_area_base.py
@@ -58,7 +58,7 @@ diagnostics:
         area: land_surface_surfrad
         control_model: MPI-ESM-LR
         exp_model: MPI-ESM-MR
-        obs_models: [CERES-EBAF_Surface]
+        obs_models: [CERES-EBAF]
         obs_type: obs4MIPs
         start: 1993/12/01
         end: 2002/12/01
@@ -70,7 +70,7 @@ diagnostics:
         <<: *autoassess_landsurf_surfrad_settings
         control_model: MPI-ESM-LR
         exp_model: MPI-ESM-MR
-        obs_models: [CERES-EBAF_Surface]
+        obs_models: [CERES-EBAF]
         script: autoassess/plot_autoassess_metrics.py
         ancestors: ['*/autoassess_landsurf_surfrad']
         title: "Plot Land-Surface Metrics Surfrad"


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

Spotted by @schlunma during 2.14 release at #4346 
If we really need to switch to CERES-EBAF_Surface as new dataset then we ought to recalibrate the metrics, so @alistairsellar and I should do that in a separate PR. For now, CERES-EBAF data is still available at https://asdc.larc.nasa.gov/project/CERES/CERES_EBAF_Edition4.1

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful