### PR TITLE
Add fallbacks for CMIP7 tasmax handling in `ref/recipe_ref_fire.yml`

### DIFF
--- a/esmvaltool/diag_scripts/fire/diagnostic_run_confire.py
+++ b/esmvaltool/diag_scripts/fire/diagnostic_run_confire.py
@@ -458,9 +458,11 @@ def _read_variable_from_netcdf(
             callback=_sort_time,
         )
     else:
+        # Fallback for CMIP7 data for tasmax
+        var = "tas" if "tasmax/tas_tmaxavg" in filename[0] else filename[1]
         dataset = iris.load_raw(
             Path(directory) / filename[0],
-            filename[1],
+            var,
             callback=_sort_time,
         )
     dataset = dataset[0]

--- a/esmvaltool/diag_scripts/fire/fire_diagnostic.py
+++ b/esmvaltool/diag_scripts/fire/fire_diagnostic.py
@@ -341,7 +341,15 @@ def main(cfg: dict) -> None:
         vars_file = {}
         for i, attributes in enumerate(group):
             logger.info("Variable %s", attributes["short_name"])
-            vars_file[attributes["short_name"]] = attributes
+            # Fallback for CMIP7 data for tasmax
+            short_name_key = (
+                "tasmax"
+                if attributes.get("branding_suffix")
+                and attributes["short_name"] == "tas"
+                and "tmax" in attributes["branding_suffix"]
+                else attributes["short_name"]
+            )
+            vars_file[short_name_key] = attributes
             # Save model information for output plot name
             if i == 0:
                 plot_file_info = "_".join(


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

    While the checklist is intended to be filled in by the technical and scientific
    reviewers, it is the responsibility of the author of the pull request to make
    sure all items on it are properly implemented.
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull request makes
    ESMValTool better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/en/latest/community/

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
- Closes #4343
- Link to documentation:

The issue is solved by adding two fallbacks for CMIP7 data handling of tasmax as described in #4343:

- in `fire/fire_diagnostic.py` L344, in order to pick up the `tasmax` key for the `vars_file` dictionary, a test on the attributes using the branding_suffix is added
```
# Fallback for CMIP7 data for tasmax
short_name_key = (
    "tasmax"
    if attributes.get("branding_suffix")
    and attributes["short_name"] == "tas"
    and "tmax" in attributes["branding_suffix"]
    else attributes["short_name"]
)
vars_file[short_name_key] = attributes
```
- in `fire/diagnostic_run_confire.py` L461, in order to properly extract the `tasmax` variable from the cube, the variable name needs to be adapted to `tas` 
```
# Fallback for CMIP7 data for tasmax
var = "tas" if "tasmax/tas_tmaxavg" in filename[0] else filename[1]
dataset = iris.load_raw(
    Path(directory) / filename[0],
    var,
    callback=_sort_time,
)
```

* * *

## Before you get started

<!--
    Please discuss your idea with the development team before getting started,
    to avoid disappointment or unnecessary work later. The way to do this is
    to open a new issue on GitHub.
-->

- [x] [☝ Create an issue](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#contributing-code-and-documentation) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [x] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [x] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [x] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [x] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [x] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [x] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [x] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added

***

To help with the number of pull requests:

-  🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository

<!--
If you need help with any of the items on the checklists above, please do not hesitate to ask by commenting in the issue or pull request.
-->
