### PR TITLE
Fix dates for ESACCI-AEROSOL in recipe_check_obs.yml

### DIFF
--- a/esmvaltool/recipes/examples/recipe_check_obs.yml
+++ b/esmvaltool/recipes/examples/recipe_check_obs.yml
@@ -211,19 +211,19 @@ diagnostics:
         frequency: mon
         additional_datasets:
           - {dataset: ESACCI-AEROSOL, project: OBS, mip: aero, tier: 2,
-             type: sat, version: AATSR-SU-v4.3-MONTHLY, start_year: 1997, end_year: 2017}
+             type: sat, version: AATSR-SU-v4.3-MONTHLY, start_year: 1997, end_year: 2011}
       od550aer:
         <<: *var_aermon
         additional_datasets:
           - {dataset: ESACCI-AEROSOL, project: OBS, mip: aero, tier: 2,
-             type: sat, version: SLSTR-SU-v1.12-MONTHLY, start_year: 2011, end_year: 2023}
+             type: sat, version: SLSTR-SU-v1.12-MONTHLY, start_year: 2017, end_year: 2022}
       od550aerStderr:
         <<: *var_aermon
       od550lt1aer:
         <<: *var_aermon
         additional_datasets:
           - {dataset: ESACCI-AEROSOL, project: OBS, mip: aero, tier: 2,
-             type: sat, version: SLSTR-SU-v1.12-MONTHLY, start_year: 2011, end_year: 2023}
+             type: sat, version: SLSTR-SU-v1.12-MONTHLY, start_year: 2017, end_year: 2022}
       od870aer:
         <<: *var_aermon
       od870aerStderr:
@@ -233,13 +233,13 @@ diagnostics:
         frequency: day
         additional_datasets:
           - {dataset: ESACCI-AEROSOL, project: OBS, mip: aero, tier: 2,
-             type: sat, version: AATSR-SU-v4.3-DAILY, start_year: 1997, end_year: 2017}
+             type: sat, version: AATSR-SU-v4.3-DAILY, start_year: 1997, end_year: 2011}
       od550aer_day:
         <<: *var_aerday
         short_name: od550aer
         additional_datasets:
           - {dataset: ESACCI-AEROSOL, project: OBS, mip: aero, tier: 2,
-             type: sat, version: SLSTR-SU-v1.12-DAILY, start_year: 2011, end_year: 2023}
+             type: sat, version: SLSTR-SU-v1.12-DAILY, start_year: 2017, end_year: 2022}
       od550aerStderr_day:
         <<: *var_aerday
         short_name: od550aerStderr
@@ -248,7 +248,7 @@ diagnostics:
         short_name: od550lt1aer
         additional_datasets:
           - {dataset: ESACCI-AEROSOL, project: OBS, mip: aero, tier: 2,
-             type: sat, version: SLSTR-SU-v1.12-MONTHLY, start_year: 2011, end_year: 2023}
+             type: sat, version: SLSTR-SU-v1.12-MONTHLY, start_year: 2017, end_year: 2022}
       od870aer_day:
         <<: *var_aerday
         short_name: od870aer


### PR DESCRIPTION
## Description

Fix the dates for ESACCI-AEROSOL in recipe_check_obs.yml.

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🛠][1] This pull request has a [descriptive title](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-title)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#code-quality)
- [ ] [🛠][1] [Documentation](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#documentation) is available
- [ ] [🛠][1] [Tests](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#tests) run successfully
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#list-of-authors) is up to date
- [ ] [🛠][1] Any changed dependencies have been [added or removed correctly](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#dependencies)
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/en/latest/community/code_documentation.html#pull-request-checks) were successful

### [New or updated recipe/diagnostic](https://docs.esmvaltool.org/en/latest/community/diagnostic.html)

- [ ] [🧪][2] [Recipe runs successfully](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#testing-recipes)
- [ ] [🧪][2] [Recipe is well documented](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recipe-and-diagnostic-documentation)
- [ ] [🧪][2] [Figure(s) and data](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#diagnostic-output) look as expected from literature
- [ ] [🛠][1] [Provenance information](https://docs.esmvaltool.org/en/latest/community/diagnostic.html#recording-provenance) has been added