### PR TITLE
Fix ocean/diagnostic_seaice type error

### DIFF
--- a/esmvaltool/diag_scripts/ocean/diagnostic_seaice.py
+++ b/esmvaltool/diag_scripts/ocean/diagnostic_seaice.py
@@ -424,7 +424,7 @@ def get_year(cube):
         The year as a string
 
     """
-    year = cube.coord("year").points
+    year = cube.coord("year").points[0]
     return str(int(year))
 
 


### PR DESCRIPTION
Fix error found in v2.15.0 recipe testing: https://github.com/ESMValGroup/ESMValTool/issues/4514#issuecomment-4954900045
in recipe_ocean_ice_extent.yml

```
Traceback (most recent call last):
  File "/home/189/fc6164/esmValTool/repos/ESMVal/ESMValTool/esmvaltool/diag_scripts/ocean/diagnostic_seaice.py", line 819, in <module>
    main(config)
  File "/home/189/fc6164/esmValTool/repos/ESMVal/ESMValTool/esmvaltool/diag_scripts/ocean/diagnostic_seaice.py", line 804, in main
    make_map_extent_plots(cfg, metadatas[filename], filename)
  File "/home/189/fc6164/esmValTool/repos/ESMVal/ESMValTool/esmvaltool/diag_scripts/ocean/diagnostic_seaice.py", line 667, in make_map_extent_plots
    label = get_year(cube)
            ^^^^^^^^^^^^^^
  File "/home/189/fc6164/esmValTool/repos/ESMVal/ESMValTool/esmvaltool/diag_scripts/ocean/diagnostic_seaice.py", line 428, in get_year
    return str(int(year))
               ^^^^^^^^^
TypeError: only 0-dimensional arrays can be converted to Python scalars
```